### PR TITLE
Wififix2

### DIFF
--- a/src/asmcnc/skavaUI/widget_network_setup.py
+++ b/src/asmcnc/skavaUI/widget_network_setup.py
@@ -93,9 +93,10 @@ class NetworkSetup(Widget):
         self.country = self.countryTextEntry.text 
 
         # pass credentials to wpa_supplicant file
-        self.wpanetpass = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant.conf 2>/dev/null'
-        self.wpanetpasswlan0 = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant-wlan0.conf 2>/dev/null'
-        print self.wpanetpass
+        self.wpanetpass = 'wpa_passphrase "' + self.netname + '" "' + self.password + '" 2>/dev/null | sudo tee /etc/wpa_supplicant/wpa_supplicant.conf'
+        self.wpanetpasswlan0 = 'wpa_passphrase "' + self.netname + '" "' + self.password + '" 2>/dev/null | sudo tee /etc/wpa_supplicant/wpa_supplicant-wlan0.conf'
+        
+        #if wpanetpass.startswith('network={'):       
 
         # put the credentials and the necessary appendages into the wpa file
         os.system(self.wpanetpass)
@@ -109,5 +110,7 @@ class NetworkSetup(Widget):
         os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
         
         os.system('sudo reboot')
+        
+    
 
         

--- a/src/asmcnc/skavaUI/widget_network_setup.py
+++ b/src/asmcnc/skavaUI/widget_network_setup.py
@@ -93,20 +93,20 @@ class NetworkSetup(Widget):
         self.country = self.countryTextEntry.text 
 
         # pass credentials to wpa_supplicant file
-        self.wpanetpass = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant.conf'
-        self.wpanetpasswlan0 = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant-wlan0.conf'
+        self.wpanetpass = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant.conf 2>/dev/null'
+        self.wpanetpasswlan0 = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant-wlan0.conf 2>/dev/null'
         print self.wpanetpass
 
         # put the credentials and the necessary appendages into the wpa file
         os.system(self.wpanetpass)
         os.system('echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
         os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
-        os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')       
+        os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
    
         os.system(self.wpanetpasswlan0)
         os.system('echo "ctrl_interface=run/wpa_supplicant" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
         os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
-        os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')     
+        os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
         
         os.system('sudo reboot')
 

--- a/src/asmcnc/skavaUI/widget_network_setup.py
+++ b/src/asmcnc/skavaUI/widget_network_setup.py
@@ -23,6 +23,7 @@ Builder.load_string("""
     passwordTextEntry:passwordTextEntry
     ipLabel:ipLabel
     netNameLabel:netNameLabel
+    countryTextEntry:countryTextEntry
 
     BoxLayout:
     
@@ -41,6 +42,12 @@ Builder.load_string("""
         Button:
             text: 'Refresh status...'
             on_release: root.detectIP()
+        TextInput:
+            id: countryTextEntry
+            size_hint_y: None
+            height: '32dp'
+            text: 'Country code...'
+            focus: False
         TextInput:
             id: networkTextEntry
             size_hint_y: None
@@ -83,15 +90,24 @@ class NetworkSetup(Widget):
         # get network name and password from text entered (widget)
         self.netname = self.networkTextEntry.text
         self.password = self.passwordTextEntry.text
+        self.country = self.countryTextEntry.text 
 
         # pass credentials to wpa_supplicant file
         self.wpanetpass = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant.conf'
+        self.wpanetpasswlan0 = 'wpa_passphrase ' + self.netname + ' ' + self.password + ' | sudo tee /etc/wpa_supplicant/wpa_supplicant-wlan0.conf'
         print self.wpanetpass
 
         # put the credentials and the necessary appendages into the wpa file
         os.system(self.wpanetpass)
         os.system('echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
-        os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
+        os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')
+        os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant.conf')       
+   
+        os.system(self.wpanetpasswlan0)
+        os.system('echo "ctrl_interface=run/wpa_supplicant" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
+        os.system('echo "update_config=1" | sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')
+        os.system('echo "country="' + self.country + '| sudo tee --append /etc/wpa_supplicant/wpa_supplicant-wlan0.conf')     
+        
         os.system('sudo reboot')
 
         


### PR DESCRIPTION
FIXES:
- added 2>/dev/null to stop standard errors writing to file
- added quotation marks around SSID and passphrase to stop wifi breaking if there were no spaces
- updates wpa_supplicant.conf AND wpa_supplicant_wlan0.conf files
- requires user to add country code as well as username and password

TO IMPROVE
- It would be nice if there was something to shout at the user if they enter absolute garbage. That's for another time though. 
- On this note: if user writes a password with <8 or >63 characters, and then tries to access wifi via raspi-config, they won't be able to get there. They could still connect via the easycut interface though bc it rewrites the garbage. 