### PR TITLE
Fire grbl a list of $ settings which define the standard hardware setup.

### DIFF
--- a/src/asmcnc/skavaUI/widget_developer_options.py
+++ b/src/asmcnc/skavaUI/widget_developer_options.py
@@ -64,6 +64,9 @@ Builder.load_string("""
         Button:
             text: 'Get SW update'
             on_release: root.get_sw_update()
+        Button:
+            text: 'Bake GRBL settings'
+            on_release: root.bake_grbl_settings()
         Label:
             test: 'Repository Branch'
             font_size: 18
@@ -134,3 +137,45 @@ class DevOptions(Widget):
     def get_sw_update(self):
         os.system("cd /home/pi/easycut-smartbench/ && git pull")
         self.reboot()
+
+    def bake_grbl_settings(self):
+        grbl_settings = [
+                    '$0=10',    #Step pulse, microseconds
+                    '$1=255',    #Step idle delay, milliseconds
+                    '$2=4',           #Step port invert, mask
+                    '$3=1',           #Direction port invert, mask
+                    '$4=0',           #Step enable invert, boolean
+                    '$5=1',           #Limit pins invert, boolean
+                    '$6=0',           #Probe pin invert, boolean
+                    '$10=3',          #Status report, mask <----------------------
+                    '$11=0.010',      #Junction deviation, mm
+                    '$12=0.002',      #Arc tolerance, mm
+                    '$13=0',          #Report inches, boolean
+                    '$20=1',          #Soft limits, boolean <-------------------
+                    '$21=1',          #Hard limits, boolean <------------------
+                    '$22=1',          #Homing cycle, boolean <------------------------
+                    '$23=3',          #Homing dir invert, mask
+                    '$24=600.0',     #Homing feed, mm/min
+                    '$25=3000.0',    #Homing seek, mm/min
+                    '$26=250',        #Homing debounce, milliseconds
+                    '$27=15.000',      #Homing pull-off, mm
+                    '$30=25000.0',      #Max spindle speed, RPM
+                    '$31=0.0',         #Min spindle speed, RPM
+                    '$32=0',           #Laser mode, boolean
+                    '$100=56.649',   #X steps/mm
+                    '$101=56.623',   #Y steps/mm
+                    '$102=1066.667',   #Z steps/mm
+                    '$110=15000.0',   #X Max rate, mm/min
+                    '$111=15000.0',   #Y Max rate, mm/min
+                    '$112=2000.0',   #Z Max rate, mm/min
+                    '$120=500.0',    #X Acceleration, mm/sec^2
+                    '$121=200.0',    #Y Acceleration, mm/sec^2
+                    '$122=200.0',    #Z Acceleration, mm/sec^2
+                    '$130=1237.0',   #X Max travel, mm TODO: Link to a settings object
+                    '$131=2470.0',   #Y Max travel, mm
+                    '$132=143.0',   #Z Max travel, mm
+                    '$$', # Echo grbl settings, which will be read by sw, and internal parameters sync'd
+                    '$#' # Echo grbl parameter info, which will be read by sw, and internal parameters sync'd
+            ]
+
+        self.m.s.start_sequential_stream(grbl_settings, reset_grbl_after_stream=True)   # Send any grbl specific parameters

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,7 @@ from asmcnc.skavaUI import screen_alarm
 from asmcnc.skavaUI import screen_error
 from asmcnc.skavaUI import screen_serial_failure
 
-Cmport = 'COM3'
+Cmport = 'COM6'
 
 class SkavaUI(App):
 


### PR DESCRIPTION
New button in dev screen to fire a bunch of settings to grbl. Whilst this is possible via typing it all into the gcode console, that process has destroyed many a soul. Why have cotton when we can have serial silk.