### PR TITLE
Magic square axis fix

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -99,39 +99,8 @@ class RouterMachine(object):
 
     def home_all(self):
 
-        self.set_state('Home') # (grbl not very good at setting the 'home' state)
-        self.is_machine_homed = True # status on powerup
-        if self.is_squaring_XY_needed_after_homing: self.set_XY_square()
-        else: 
-            self.s.write_command('$H') # HOME
+        self.sm.current = 'homing'
 
-
-    def set_XY_square(self):
-
-        # This function is designed to square the machine's X&Y axes
-        # It does this by killing the limit switches and driving the X frame into mechanical deadstops at the end of the Y axis.
-        # The steppers will stall out, but the X frame will square against the mechanical deadstops.
-        # Intended use is first home after power-up only, or the stalling noise will get annoying!
-
-        self.is_squaring_XY_needed_after_homing = False # clear flag, so this function doesn't run again 
-
-        # Because we're setting grbl configs (i.e.$x=n), we need to adopt the grbl config approach used in the serial module.
-        # So no direct writing to serial here, we're waiting for grbl responses before we send each line:
-
-        square_homing_sequence =  [
-                                  '$H',
-                                  '$20=0', # soft limits off
-                                  '$21=0', # hard limits off
-                                  'G91', # relative coords
-                                  'G1 Y-25 F500', # drive lower frame into legs, assumes it's starting from a 3mm pull off
-                                  'G1 Y25', # re-enter work area
-                                  'G90', # abs coords
-                                  'G4 P1', # delay
-                                  '$21=1', # soft limits on
-                                  '$20=1', # soft limits off
-                                  '$H' # home
-                                  ]
-        self.s.start_sequential_stream(square_homing_sequence)
 
 # STATUS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -181,6 +181,7 @@ class RouterMachine(object):
     # ... unless it is unlocked
     def soft_reset(self):
         if self.s.is_job_streaming == True: self.s.cancel_stream() # Cancel stream_file to stop it continuing to send stuff after reset
+        if self.s.is_sequential_streaming == True: self.s.cancel_sequential_stream() # Cancel sequential stream to stop it continuing to send stuff after reset
         self.s.write_realtime("\x18", altDisplayText = 'Soft reset') # Soft-reset. This forces the need to home when the controller starts up
     
     def jog_absolute_single_axis(self, axis, target, speed):

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -126,7 +126,7 @@ class RouterMachine(object):
                                   'G1 Y-25 F500', # drive lower frame into legs, assumes it's starting from a 3mm pull off
                                   'G1 Y25', # re-enter work area
                                   'G90', # abs coords
-                                  'G4 P1' # delay
+                                  'G4 P1', # delay
                                   '$21=1', # soft limits on
                                   '$20=1', # soft limits off
                                   '$H' # home

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -717,6 +717,7 @@ class SerialConnection(object):
         self._sequential_stream_buffer = list_to_stream
         self._reset_grbl_after_stream = reset_grbl_after_stream
         self._send_next_sequential_stream()
+        
                 
     def _send_next_sequential_stream(self):
         log("_send_next_sequential_stream")
@@ -727,9 +728,14 @@ class SerialConnection(object):
         else:
             self.is_sequential_streaming = False
             if self._reset_grbl_after_stream:
-                self.m.soft_reset() # Soft-reset. This forces the need to home when the controller starts up
+                self.m.soft_reset()
 
 
+    def cancel_sequential_stream(self, reset_grbl_after_cancel = False):
+        self.is_sequential_streaming = False
+        _sequential_stream_buffer = []
+        if reset_grbl_after_cancel:
+            self.m.soft_reset()
 
 
 ## WRITE-----------------------------------------------------------------------------

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -702,18 +702,17 @@ class SerialConnection(object):
 
 ## SEQUENTIAL STREAMING
 
+    # This stream_file method waits for an 'ok' before sending the next setting
+    # It does not stuff the grbl buffer
+    # It is for:
+      # Anything sending EEPROM settings (which require special attention, due to writing of values)
+      # Matching Error/Alarm messages to exact commands (not possible during buffer stuffing)
+    # WARNING: this function is not blocking, as such, the is_sequential_streaming flag should be checked before using.
+
     _sequential_stream_buffer = []
     _reset_grbl_after_stream = False
 
     def start_sequential_stream(self, list_to_stream, reset_grbl_after_stream=False):
-
-        # This stream_file method waits for an 'ok' before sending the next setting
-        # It does not stuff the grbl buffer
-        # It is for:
-          # EEPROM settings require special attention, due to writing of values
-          # Matching Error/Alarm messages to exact commands (not possible during buffer stuffing)
-        # WARNING: this function is not blocking, and as of yet there is no way to indicate it has finished
-        
         log("start_sequential_stream")
         self._sequential_stream_buffer = list_to_stream
         self._reset_grbl_after_stream = reset_grbl_after_stream
@@ -728,7 +727,7 @@ class SerialConnection(object):
         else:
             self.is_sequential_streaming = False
             if self._reset_grbl_after_stream:
-                self.write_direct("\x18", realtime = True, show_in_sys = True, show_in_console = False) # Soft-reset. This forces the need to home when the controller starts up
+                self.m.soft_reset() # Soft-reset. This forces the need to home when the controller starts up
 
 
 

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -206,7 +206,6 @@ class SerialConnection(object):
             
             realtime_counter = 0
             for realtime_command in self.write_realtime_buffer:
-                print "WRITE: ", realtime_command[0], realtime_command[1], " ... END WRITE"
                 self.write_direct(realtime_command[0], altDisplayText = realtime_command[1], realtime = True)
                 realtime_counter += 1
                 
@@ -727,8 +726,10 @@ class SerialConnection(object):
             del self._sequential_stream_buffer[0]
         else:
             self.is_sequential_streaming = False
+            log("sequential stream ended")
             if self._reset_grbl_after_stream:
                 self.m.soft_reset()
+                print "GRBL Reset after sequential stream ended"
 
 
     def cancel_sequential_stream(self, reset_grbl_after_cancel = False):
@@ -736,6 +737,7 @@ class SerialConnection(object):
         _sequential_stream_buffer = []
         if reset_grbl_after_cancel:
             self.m.soft_reset()
+            print "GRBL Reset after sequential stream cancelled"
 
 
 ## WRITE-----------------------------------------------------------------------------

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -163,19 +163,18 @@ class HomingScreen(Screen):
             # Success!
             self.m.is_machine_homed = True # status on powerup
             Clock.unschedule(self.poll_machine_status)
-            self.exit_homing()
-
+            self.sm.current = 'home'
 
     def cancel_homing(self):
 
-        print('Homing Cancelled')
+        print('Cancelling homing...')
         Clock.unschedule(self.poll_machine_status) # necessary so that when sequential stream is cancelled, clock doesn't think it was because of successful completion
         self.m.s.cancel_sequential_stream(reset_grbl_after_cancel = False)
-        self.exit_homing()
+
+        self.m.soft_reset()
+        # ... will trigger an alarm screen
 
 
-    def exit_homing(self):
 
-        self.sm.current = 'home'
 
         

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -81,46 +81,101 @@ Builder.load_string("""
 
 """)
 
+# Intent of class is to send homing commands
+# Commands are sent via sequential streaming, which is monitored to evaluate whether the op has completed or not
+
 class HomingScreen(Screen):
     
-    wait_for_homing_finished = None
-    poll_machine_status = None
+    
+    is_squaring_XY_needed_after_homing = True
 
+    
     def __init__(self, **kwargs):
+    
         super(HomingScreen, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
     
+    
     def on_enter(self):
-        # self.m.s.suppress_error_screens = True
         
-        if self.m.is_squaring_XY_needed_after_homing:
-            self.poll_machine_status = Clock.schedule_interval(self.check_machine_status, 2)           
-            self.m.home_all()
-        else:
-            self.m.home_all()
-            self.wait_for_homing_finished = Clock.schedule_interval(self.exit_sequence, 0.5)
-        
-    def check_machine_status(self, dt):
-        if self.m.homing_stage_counter == 2:
-                # Because there's a GRBL pause in the homing sequence, will take an extra 5 seconds for anything
-                # else to happen. Hence delay here too. 
-                Clock.unschedule(self.poll_machine_status)
-                self.wait_for_homing_finished = Clock.schedule_interval(self.exit_sequence, 0.5)
+        # Is this first time since power cycling?
+        if self.is_squaring_XY_needed_after_homing: 
+            self.home_with_squaring()
+        else: 
+            self.home_normally()
 
-    def exit_sequence(self, dt):
-        if not self.m.s.is_sequential_streaming and self.m.state().startswith('Idle'):
-            # self.m.s.suppress_error_screens = False
-            if self.wait_for_homing_finished != None: Clock.unschedule(self.wait_for_homing_finished)
-            self.m.homing_stage_counter = 0
-            self.sm.current = 'home'
-            
+        # Due to polling timings, and the fact grbl doesn't issues status during homing, EC may have missed the 'home' status, so we tell it.
+        self.m.set_state('Home') 
+
+        # monitor sequential stream status for completion
+        self.poll_machine_status = Clock.schedule_interval(self.check_for_completion, 1)           
+
+
+    def home_normally(self):
+        
+        normal_homing_sequence = ['$H']
+        self.s.start_sequential_stream(normal_homing_sequence)
+
+
+    def home_with_squaring(self):
+
+        self.is_squaring_XY_needed_after_homing = False # clear flag, so this function doesn't run again 
+
+        # This function is designed to square the machine's X&Y axes
+        # It does this by killing the limit switches and driving the X frame into mechanical deadstops at the end of the Y axis.
+        # The steppers will stall out, but the X frame will square against the mechanical deadstops.
+        # Intended use is first home after power-up only, or the stalling noise will get annoying!
+
+        # Because we're setting grbl configs in this function (i.e.$x=n), we need to adopt the grbl config approach used in the serial module.
+        # So no direct writing to serial here, we're waiting for grbl responses before we send each line:
+
+        square_homing_sequence =  [
+                                  '$H', # home
+                                  '$20=0', # soft limits off
+                                  '$21=0', # hard limits off
+                                  'G91', # relative coords
+                                  'G1 Y-25 F500', # drive lower frame into legs, assumes it's starting from a 3mm pull off
+                                  'G1 Y25', # re-enter work area
+                                  'G90', # abs coords
+                                  
+                                  # Coming up we have some $x=n commands, and the machine needs to be idle when sending these
+                                  # Since it will be moving due to previous G command, we need to wait until it has stopped
+                                  # The simplest way to do this is to send a G4 command (grbl pause)
+                                  # This is fairly unique since it gets a "blocking ok" respoinse from grbl
+                                  # ie. grbl only issues the 'ok' response AFTER the pause command has been completed
+                                  # (most other commands get the 'ok' response as soon as they are loaded into the line buffer, not on completion)
+                                  # Therefore we know the machine has stopped moving before the line after the pause is sent
+                                  
+                                  'G4 P0.5', # delay, which is needed solely for it's "blocking ok" response
+                                  '$21=1', # soft limits on
+                                  '$20=1', # soft limits off
+                                  '$H' # home - which also issues a "blocking ok" response
+                                  ]
+
+        self.s.start_sequential_stream(square_homing_sequence)
+
+        
+    def check_for_completion(self, dt):
+
+        if self.m.s.is_sequential_streaming == False:
+           
+            # Success!
+            self.m.is_machine_homed = True # status on powerup
+            Clock.unschedule(self.poll_machine_status)
+            self.exit_homing()
+
+
     def cancel_homing(self):
-        if self.poll_machine_status != None: Clock.unschedule(self.poll_machine_status)
-        if self.wait_for_homing_finished != None: Clock.unschedule(self.wait_for_homing_finished)
-        self.m.s.is_sequential_streaming = False
-        self.m.s.write_direct("\x18", realtime = True, show_in_sys = True, show_in_console = False) # Soft-reset. This forces the need to home when the controller starts up
+
         print('Homing Cancelled')
-        self.m.homing_stage_counter = 0
+        Clock.unschedule(self.poll_machine_status) # necessary so that when sequential stream is cancelled, clock doesn't think it was because of successful completion
+        self.m.s.cancel_sequential_stream(reset_grbl_after_cancel = False)
+        exit_homing()
+
+
+    def exit_homing(self):
+
         self.sm.current = 'home'
+
         

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -156,14 +156,13 @@ class HomingScreen(Screen):
         
     def check_for_successful_completion(self, dt):
 
-        # if alarm state happens to prevent homing from completing, stop the success checking
+        # if alarm state is triggered which prevents homing from completing, stop checking for success
         if self.m.state == 'Alarm':
             print "Poll for homing success unscheduled"
             Clock.unschedule(self.poll_for_success)
 
-        # if sequential_stream completes
+        # if sequential_stream completes successfully
         elif self.m.s.is_sequential_streaming == False:
-            # Success!
             print "Homing success!"
             self.is_squaring_XY_needed_after_homing = False # clear flag, so this function doesn't run again
 

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -158,6 +158,7 @@ class HomingScreen(Screen):
 
         # if alarm state happens to prevent homing from completing, stop the success checking
         if self.m.state == 'Alarm':
+            print "Poll for homing success unscheduled"
             Clock.unschedule(self.poll_for_success)
 
         # if sequential_stream completes

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -115,7 +115,7 @@ class HomingScreen(Screen):
     def home_normally(self):
         
         normal_homing_sequence = ['$H']
-        self.s.start_sequential_stream(normal_homing_sequence)
+        self.m.s.start_sequential_stream(normal_homing_sequence)
 
 
     def home_with_squaring(self):
@@ -153,7 +153,7 @@ class HomingScreen(Screen):
                                   '$H' # home - which also issues a "blocking ok" response
                                   ]
 
-        self.s.start_sequential_stream(square_homing_sequence)
+        self.m.s.start_sequential_stream(square_homing_sequence)
 
         
     def check_for_completion(self, dt):
@@ -171,7 +171,7 @@ class HomingScreen(Screen):
         print('Homing Cancelled')
         Clock.unschedule(self.poll_machine_status) # necessary so that when sequential stream is cancelled, clock doesn't think it was because of successful completion
         self.m.s.cancel_sequential_stream(reset_grbl_after_cancel = False)
-        exit_homing()
+        self.exit_homing()
 
 
     def exit_homing(self):

--- a/src/asmcnc/skavaUI/screen_safety_warning.py
+++ b/src/asmcnc/skavaUI/screen_safety_warning.py
@@ -175,7 +175,7 @@ Builder.load_string("""
                             size_hint_x: 0.2
                             keep_ratio: True
                             allow_stretch: True                           
-                            source: "./asmcnc/skavaUI/img/danger_clipart.png"
+                            source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                             halign: 'left'
                             size:self.texture_size
                         Label:

--- a/src/asmcnc/skavaUI/widget_developer_options.py
+++ b/src/asmcnc/skavaUI/widget_developer_options.py
@@ -118,8 +118,7 @@ class DevOptions(Widget):
         sys.exit()
 
     def square_axes(self):
-        self.m.is_squaring_XY_needed_after_homing = True
-#         self.sm.current = 'homing'
+#         self.sm.get_screen('homing').is_squaring_XY_needed_after_homing = True
         self.m.home_all()
 
     def return_to_lobby(self):

--- a/src/asmcnc/skavaUI/widget_developer_options.py
+++ b/src/asmcnc/skavaUI/widget_developer_options.py
@@ -119,7 +119,7 @@ class DevOptions(Widget):
 
     def square_axes(self):
         self.m.is_squaring_XY_needed_after_homing = True
-        self.sm.current = 'homing'
+#         self.sm.current = 'homing'
         self.m.home_all()
 
     def return_to_lobby(self):

--- a/src/asmcnc/skavaUI/widget_developer_options.py
+++ b/src/asmcnc/skavaUI/widget_developer_options.py
@@ -118,7 +118,7 @@ class DevOptions(Widget):
         sys.exit()
 
     def square_axes(self):
-#         self.sm.get_screen('homing').is_squaring_XY_needed_after_homing = True
+        self.sm.get_screen('homing').is_squaring_XY_needed_after_homing = True
         self.m.home_all()
 
     def return_to_lobby(self):

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -156,7 +156,6 @@ class QuickCommands(Widget):
 
             
     def home(self):
-#         self.sm.current = 'homing'
         self.m.home_all()
 
     def unlock(self):

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -141,7 +141,6 @@ Builder.load_string("""
     
 # Valid states types: Idle, Run, Hold, Jog, Alarm, Door, Check, Home, Sleep
 
-from kivy.animation import Animation
 
 
 class QuickCommands(Widget):
@@ -153,18 +152,12 @@ class QuickCommands(Widget):
         super(QuickCommands, self).__init__(**kwargs)
         self.m=kwargs['machine']
         self.sm=kwargs['screen_manager']
-        
-        anim = Animation(height=80, width=80, t='in_out_sine') + Animation(height=60, width=60, t='in_out_sine')
-
-#         anim = Animation(size=(30, 30),t='in_out_sine',center=self.parent.center) + Animation(size=(10, 10),t='in_out_sine',center=self.parent.center)
-        anim.repeat = True
-#        anim.start(self.home_button)
+      
 
             
     def home(self):
-        Animation.stop_all(self.home_button)
-        self.sm.current = 'homing'
-    
+#         self.sm.current = 'homing'
+        self.m.home_all()
 
     def unlock(self):
         self.m.unlock_after_alarm()


### PR DESCRIPTION
Changed how we handle the two different homing cases.

* Homing screen now checks serial_comm's `is_sequentially_streaming` flag to know whether it's still homing or not. 
* Squaring routing now uses the `G4 P<x>` grbl delay command to force a 'blocking ok' which guarantees that that machine is idle before issuing $ commands. This replaces a ton of fragile code which was checking for states etc.
* Serial_comms now has a function cancel sequential streaming as a precaution