### PR TITLE
File preview lag

### DIFF
--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -462,6 +462,7 @@ class CheckingScreen(Screen):
             if self.job_ok:
                 self.sm.get_screen('home').job_gcode = self.job_gcode
                 self.sm.get_screen('home').job_filename = self.checking_file_name
+                self.sm.get_screen('home').preview_job_file()
                 self.sm.current = 'home'
                 
             else: 
@@ -485,6 +486,7 @@ class CheckingScreen(Screen):
     def load_file_now(self):
         self.sm.get_screen('home').job_gcode = self.job_gcode
         self.sm.get_screen('home').job_filename = self.checking_file_name
+        self.sm.get_screen('home').preview_job_file()
         self.sm.current = 'home'       
     
     def on_leave(self, *args):

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -241,7 +241,7 @@ class CheckingScreen(Screen):
     def boundary_check(self):
         
         # get non modal g-code
-        self.gcode_preview_widget.get_non_modal_gcode(self.job_gcode)
+        self.gcode_preview_widget.get_non_modal_gcode(self.job_gcode, False)
         
         # update limits            
         self.job_box.range_x[0] = self.gcode_preview_widget.min_x

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -462,7 +462,6 @@ class CheckingScreen(Screen):
             if self.job_ok:
                 self.sm.get_screen('home').job_gcode = self.job_gcode
                 self.sm.get_screen('home').job_filename = self.checking_file_name
-                self.sm.get_screen('home').preview_job_file()
                 self.sm.current = 'home'
                 
             else: 
@@ -486,7 +485,6 @@ class CheckingScreen(Screen):
     def load_file_now(self):
         self.sm.get_screen('home').job_gcode = self.job_gcode
         self.sm.get_screen('home').job_filename = self.checking_file_name
-        self.sm.get_screen('home').preview_job_file()
         self.sm.current = 'home'       
     
     def on_leave(self, *args):

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -219,7 +219,6 @@ class LoadingScreen(Screen):
 
         self.job_gcode = preloaded_job_gcode
         self.sm.get_screen('home').job_gcode = self.job_gcode
-#        self.sm.get_screen('home').preview_job_file()
         self.job_loading_loaded = '[b]Job Loaded[/b]'
         self.check_button.disabled = False
         self.home_button.disabled = False

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -171,6 +171,7 @@ class LoadingScreen(Screen):
     def quit_to_home(self):
         self.sm.get_screen('home').job_gcode = self.job_gcode
         self.sm.get_screen('home').job_filename = self.loading_file_name
+        self.sm.get_screen('home').preview_job_file()
         self.sm.current = 'home'
         
     def return_to_filechooser(self):

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -219,7 +219,7 @@ class LoadingScreen(Screen):
 
         self.job_gcode = preloaded_job_gcode
         self.sm.get_screen('home').job_gcode = self.job_gcode
-        self.sm.get_screen('home').preview_job_file()
+#        self.sm.get_screen('home').preview_job_file()
         self.job_loading_loaded = '[b]Job Loaded[/b]'
         self.check_button.disabled = False
         self.home_button.disabled = False

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -171,7 +171,6 @@ class LoadingScreen(Screen):
     def quit_to_home(self):
         self.sm.get_screen('home').job_gcode = self.job_gcode
         self.sm.get_screen('home').job_filename = self.loading_file_name
-        self.sm.get_screen('home').preview_job_file()
         self.sm.current = 'home'
         
     def return_to_filechooser(self):
@@ -219,7 +218,8 @@ class LoadingScreen(Screen):
         log('< load_job_file')
 
         self.job_gcode = preloaded_job_gcode
-   
+        self.sm.get_screen('home').job_gcode = self.job_gcode
+        self.sm.get_screen('home').preview_job_file()
         self.job_loading_loaded = '[b]Job Loaded[/b]'
         self.check_button.disabled = False
         self.home_button.disabled = False

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -380,7 +380,7 @@ class HomeScreen(Screen):
             except:
                 print 'No G-code loaded.'
  
-    def preview_job_file(self):
+    def preview_job_file(self, dt):
         
         # Might leave this here for now - might change if you move datums etc.?      
         log('> get_non_modal_gcode')

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -362,7 +362,7 @@ class HomeScreen(Screen):
         if self.job_gcode != []:
             self.file_data_label.text = '[b]' + self.job_filename + '[/b]'
             # Preview file
-            Clock.schedule_once(self.preview_job_file, 0.1)
+#            Clock.schedule_once(self.preview_job_file, 0.05)
             
         else:
             self.file_data_label.text = '[b]Load a file...[/b]'
@@ -380,7 +380,7 @@ class HomeScreen(Screen):
             except:
                 print 'No G-code loaded.'
  
-    def preview_job_file(self, dt):
+    def preview_job_file(self):
         
         # Might leave this here for now - might change if you move datums etc.?      
         log('> get_non_modal_gcode')

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -362,7 +362,10 @@ class HomeScreen(Screen):
         if self.job_gcode != []:
             self.file_data_label.text = '[b]' + self.job_filename + '[/b]'
             # Preview file
-            Clock.schedule_once(self.preview_job_file, 0.05)
+            try: 
+                Clock.schedule_once(self.preview_job_file, 0.05)
+            except:
+                log('Unable to preview file')
             
         else:
             self.file_data_label.text = '[b]Load a file...[/b]'
@@ -384,7 +387,7 @@ class HomeScreen(Screen):
         
         # Might leave this here for now - might change if you move datums etc.?      
         log('> get_non_modal_gcode')
-        gcode_list = self.gcode_preview_widget.get_non_modal_gcode(self.job_gcode)
+        gcode_list = self.gcode_preview_widget.get_non_modal_gcode(self.job_gcode, True)
 
         log('< get_non_modal_gcode ' + str(len(gcode_list)))
 

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -362,7 +362,7 @@ class HomeScreen(Screen):
         if self.job_gcode != []:
             self.file_data_label.text = '[b]' + self.job_filename + '[/b]'
             # Preview file
-#            Clock.schedule_once(self.preview_job_file, 0.05)
+            Clock.schedule_once(self.preview_job_file, 0.05)
             
         else:
             self.file_data_label.text = '[b]Load a file...[/b]'

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -57,7 +57,7 @@ Builder.load_string("""
                 id: filechooser
                 rootpath: './jobCache/'
                 filter_dirs: True
-                filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode']
+                filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()
                     root.detect_preview_image(filechooser.selection[0])

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -57,7 +57,7 @@ Builder.load_string("""
                 id: filechooser
                 rootpath: './jobCache/'
                 filter_dirs: True
-                filters: ['*.nc','*.NC','*.gcode','*.GCODE']
+                filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode']
                 on_selection: 
                     root.refresh_filechooser()
                     root.detect_preview_image(filechooser.selection[0])

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -53,7 +53,7 @@ Builder.load_string("""
                     id: filechooser_usb
                     path: './jobCache/'
                     filter_dirs: True
-                    filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode']
+                    filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                     on_selection: 
                         root.refresh_filechooser()
 #                         root.detect_preview_image(filechooser_usb.selection[0])

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -52,7 +52,7 @@ Builder.load_string("""
                     size_hint_y: 5
                     id: filechooser_usb
                     path: './jobCache/'
-#                     filter_dirs: True
+                    filter_dirs: True
                     filters: ['*.nc','*.NC','*.gcode','*.GCODE']
                     on_selection: 
                         root.refresh_filechooser()

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -53,7 +53,7 @@ Builder.load_string("""
                     id: filechooser_usb
                     path: './jobCache/'
                     filter_dirs: True
-                    filters: ['*.nc','*.NC','*.gcode','*.GCODE']
+                    filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode']
                     on_selection: 
                         root.refresh_filechooser()
 #                         root.detect_preview_image(filechooser_usb.selection[0])

--- a/src/asmcnc/skavaUI/widget_gcode_view.py
+++ b/src/asmcnc/skavaUI/widget_gcode_view.py
@@ -79,7 +79,7 @@ class GCodeView(Widget):
 #     def __init__(self, **kwargs):
 #         super(GCodeView, self).__init__(**kwargs)
 
-    max_lines_to_read = 1000
+    max_lines_to_read = 2000
 
     def draw_file_in_xy_plane(self, gcode_list):
         log('len(gcode_list) ' + str(len(gcode_list)))

--- a/src/asmcnc/skavaUI/widget_gcode_view.py
+++ b/src/asmcnc/skavaUI/widget_gcode_view.py
@@ -244,7 +244,7 @@ class GCodeView(Widget):
             Color(0, 1, 0, 1)
 
 
-    def get_non_modal_gcode(self, job_file_gcode):
+    def get_non_modal_gcode(self, job_file_gcode, line_cap):
 
         xy_preview_gcode = []
 
@@ -268,7 +268,7 @@ class GCodeView(Widget):
         for draw_line in job_file_gcode:
             
             lines_read += 1
-            if lines_read > self.max_lines_to_read: break
+            if line_cap == True and lines_read > self.max_lines_to_read: break
              
             # Prevent any weird behaviour
             line = draw_line

--- a/src/asmcnc/skavaUI/widget_gcode_view.py
+++ b/src/asmcnc/skavaUI/widget_gcode_view.py
@@ -79,6 +79,7 @@ class GCodeView(Widget):
 #     def __init__(self, **kwargs):
 #         super(GCodeView, self).__init__(**kwargs)
 
+    max_lines_to_read = 1000
 
     def draw_file_in_xy_plane(self, gcode_list):
         log('len(gcode_list) ' + str(len(gcode_list)))
@@ -93,14 +94,13 @@ class GCodeView(Widget):
         plane = 'G17'
         move = 'G0'
         lines_read = 0
-        max_lines_to_read = 1000
 
         log('> for line in gcode_list')
         
         for line in gcode_list:
 
             lines_read += 1
-            if lines_read > 1000: break
+            if lines_read > self.max_lines_to_read: break
 
             for bit in line.split(' '):
                 # find plane
@@ -263,7 +263,12 @@ class GCodeView(Widget):
         line_number = 0
         log('> get_non_modal_gcode: process loop')
         
+        lines_read = 0
+        
         for draw_line in job_file_gcode:
+            
+            lines_read += 1
+            if lines_read > self.max_lines_to_read: break
              
             # Prevent any weird behaviour
             line = draw_line

--- a/src/asmcnc/skavaUI/widget_gcode_view.py
+++ b/src/asmcnc/skavaUI/widget_gcode_view.py
@@ -325,20 +325,30 @@ class GCodeView(Widget):
                 start = bit[0]             
 
                 if start == 'X':
-                    last_x = float(bit[1:])
-                    if last_x > self.max_x: self.max_x = last_x
-                    if last_x < self.min_x: self.min_x = last_x
-                    last_x = bit[1:]
+                    try: 
+                        last_x = float(bit[1:])
+                        if last_x > self.max_x: self.max_x = last_x
+                        if last_x < self.min_x: self.min_x = last_x
+                        last_x = bit[1:]
+                    except: 
+                        print 'Line not for preview (' + str(line_number) + '): ' + line
                 elif start == 'Y':
-                    last_y = float(bit[1:])
-                    if last_y > self.max_y: self.max_y = last_y
-                    if last_y < self.min_y: self.min_y = last_y
-                    last_y = bit[1:]
+                    try: 
+                        last_y = float(bit[1:])
+                        if last_y > self.max_y: self.max_y = last_y
+                        if last_y < self.min_y: self.min_y = last_y
+                        last_y = bit[1:]
+                    except: 
+                        print 'Line not for preview (' + str(line_number) + '): ' + line                        
+                        
                 elif start == 'Z':
-                    last_z = float(bit[1:])
-                    if last_z > self.max_z: self.max_z = last_z
-                    if last_z < self.min_z: self.min_z = last_z
-                    last_z = bit[1:]
+                    try:
+                        last_z = float(bit[1:])
+                        if last_z > self.max_z: self.max_z = last_z
+                        if last_z < self.min_z: self.min_z = last_z
+                        last_z = bit[1:]
+                    except: 
+                        print 'Line not for preview (' + str(line_number) + '): ' + line
                 elif start == 'F': feed_rate = bit[1:]
                 elif start == 'I': i = bit[1:]
                 elif start == 'J': j = bit[1:]


### PR DESCRIPTION
Fixes: 

- #194 filters gcode and nc files in the USB filechooser as well
- #193 added try-except clauses around and in the preview function to handle errors
- #155 added in a max line break to the get_non_modal_gcode function when it is used for preview; line cap flags means that this break does not happen when function is being used to detect boundary conflicts. 
- increased max preview lines. this number is really down to preference, so please let me know if want more or less preview lines. 