### PR TITLE
Double monitor

### DIFF
--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -34,7 +34,7 @@ Builder.load_string("""
         max_lines: 60
         
 <ScrollableLabelStatus>:
-    scroll_y:0
+    scroll_y:1
 
     canvas.before:
         Color:
@@ -49,7 +49,7 @@ Builder.load_string("""
         text_size: self.width, None
         font_size: '12sp'
         text: root.text
-        max_lines: 60
+        max_lines: 3
 
 <GCodeMonitor>
     
@@ -57,162 +57,214 @@ Builder.load_string("""
     consoleStatusText:consoleStatusText
     gCodeInput:gCodeInput
     
-    BoxLayout:
-    
+    BoxLayout: 
         size: self.parent.size
-        pos: self.parent.pos      
+        pos: self.parent.pos
+        orientation: "vertical"
         padding: 5
         spacing: 5
-        orientation: "horizontal" 
+        
         canvas:
             Color:
                 rgba: 0,0,0,0.2
             Rectangle:
                 size: self.size
-                pos: self.pos
+                pos: self.pos            
 
-
+        BoxLayout:
+        
+            size: self.parent.size
+            pos: self.parent.pos      
+#            padding_horizontal: 5
+            spacing: 5
+            orientation: "horizontal" 
+#             canvas:
+#                 Color:
+#                     rgba: 0,0,0,0.2
+#                 Rectangle:
+#                     size: self.size
+#                     pos: self.pos
+    
+    
+            
+            BoxLayout:
+                padding_horizontal: 5
+                spacing: 5
+                orientation: "vertical"
+                size_hint_x: 0.9
+                
+                BoxLayout:
+                    padding: 0
+                    spacing: 2
+                    orientation: 'horizontal'
+                    size_hint_y: 0.1
+     
+                    TextInput:
+    #                     size_hint_y: 0.1                        
+                        id:gCodeInput
+                        multiline: False
+                        text: ''
+                        on_text_validate: root.send_gcode_textinput()
+                    
+                    Button:
+                        text: "Enter"
+                        on_press: root.send_gcode_textinput()
+    #                     size_hint_y:0.1
+                        size_hint_x:0.2
+                        background_color: .6, 1, 0.6, 1
+     
+    #             BoxLayout:
+    #                 padding: 5
+    #                 spacing: 5
+    #                 orientation: 'horizontal'
+    #                 size_hint_y: 0.1
+    #  
+    #                 canvas:
+    #                     Color:
+    #                         rgba: 0,0,0,0.2
+    #                     Rectangle:
+    #                         size: self.size
+    #                         pos: self.pos
+    #                 Label:
+    #                     text: 'Hide'
+    #                 ToggleButton:
+    #                     state: root.hide_received_ok
+    #                     text: 'oks'
+    #                     on_state: root.hide_received_ok = self.state                              
+    #                 ToggleButton:
+    #                     state: root.hide_received_status
+    #                     on_state: root.hide_received_status = self.state
+    #                     text: 'state'
+    #  
+                ScrollableLabelCommands:
+                    size_hint_y: 0.8                     
+                    id: consoleScrollText
+                
+#                 BoxLayout:
+#                     padding: 0
+#                     spacing: 5
+#                     orientation: 'horizontal'
+#                     size_hint_y: 0.08
+#      
+#                     canvas:
+#                         Color:
+#                             rgba: 0,0,0,0.2
+#                         Rectangle:
+#                             size: self.size
+#                             pos: self.pos
+#                 
+#                     Label:
+#                         text: 'Status'
+#                         text_size: self.size
+#                         halign: 'left'
+#                         valign: 'middle'
+                        
+    #                 Button:
+    #                     size_hint_x: 0.3
+    #                     on_press: root.pause_status_toggle()
+    #                     on_release: root.unpause_status_updates()
+    #                     text: 'hold screen'
+                                            
+    #             ScrollableLabelStatus:
+    #                 size_hint_y: 0.3                  
+    #                 id: consoleStatusText
+    #  
+            BoxLayout:
+                padding_horizontal: 5
+                spacing: 5
+                orientation: "vertical"
+                size_hint_x: 0.17
+     
+    #             Button:
+    #                 text: "Enter"
+    #                 on_press: root.send_gcode_textinput()
+    #                 size_hint_y:0.1
+    #                 background_color: .6, 1, 0.6, 1
+    
+                ToggleButton:
+                    state: root.hide_received_ok
+                    markup: True
+                    text: 'Hide oks'
+                    on_state: root.hide_received_ok = self.state               
+                    size_hint_y:0.1
+                Button:
+                    text: "Settings"
+                    on_press: root.send_gcode_preset("$$")
+                    size_hint_y:0.1
+                Button:
+                    text: "Params"
+                    on_press: root.send_gcode_preset("$#")
+                    size_hint_y:0.1
+                Button:
+                    text: "State"
+                    on_press: root.send_gcode_preset("$G")
+                    size_hint_y:0.1
+                Button:
+                    text: "Build"
+                    size_hint_y:0.1
+                    on_press: root.send_gcode_preset("$I")
+                Button:
+                    text: "StartUp"
+                    on_press: root.send_gcode_preset("$N")
+                    size_hint_y:0.1
+                Button:
+                    text: "Check $C"
+                    on_press: root.toggle_check_mode()
+                    size_hint_y:0.1
+                Button:
+                    text: "Help"
+                    on_press: root.send_gcode_preset("$")
+                    size_hint_y:0.1
+                Button:
+                    text: "Clear"
+                    on_press: root.clear_monitor()
+                    size_hint_y:0.1
+                    background_color: 1, .8, 0, 1
         
         BoxLayout:
-            padding: 0
-            spacing: 5
-            orientation: "vertical"
-            size_hint_x: 0.9
+            padding: 5
+            spacing: 0
+            orientation: 'horizontal'
+            size_hint_y: 0.09
             
-            BoxLayout:
-                padding: 0
-                spacing: 2
-                orientation: 'horizontal'
-                size_hint_y: 0.1
- 
-                TextInput:
-#                     size_hint_y: 0.1                        
-                    id:gCodeInput
-                    multiline: False
-                    text: ''
-                    on_text_validate: root.send_gcode_textinput()
-                
-                Button:
-                    text: "Enter"
-                    on_press: root.send_gcode_textinput()
-#                     size_hint_y:0.1
-                    size_hint_x:0.2
-                    background_color: .6, 1, 0.6, 1
- 
-#             BoxLayout:
-#                 padding: 5
-#                 spacing: 5
-#                 orientation: 'horizontal'
-#                 size_hint_y: 0.1
-#  
-#                 canvas:
-#                     Color:
-#                         rgba: 0,0,0,0.2
-#                     Rectangle:
-#                         size: self.size
-#                         pos: self.pos
-#                 Label:
-#                     text: 'Hide'
-#                 ToggleButton:
-#                     state: root.hide_received_ok
-#                     text: 'oks'
-#                     on_state: root.hide_received_ok = self.state                              
-#                 ToggleButton:
-#                     state: root.hide_received_status
-#                     on_state: root.hide_received_status = self.state
-#                     text: 'state'
-#  
-            ScrollableLabelCommands:
-                size_hint_y: 0.7                       
-                id: consoleScrollText
-            
-            BoxLayout:
-                padding: 0
-                spacing: 5
-                orientation: 'horizontal'
-                size_hint_y: 0.08
- 
-                canvas:
-                    Color:
-                        rgba: 0,0,0,0.2
-                    Rectangle:
-                        size: self.size
-                        pos: self.pos
-            
-                Label:
-                    text: 'Status'
-                    text_size: self.size
-                    halign: 'left'
-                    valign: 'middle'
+            canvas:
+                Color:
+                    rgba: 0,0,0,0.2
+                Rectangle:
+                    size: self.size
+                    pos: self.pos
                     
-#                 Button:
-#                     size_hint_x: 0.3
-#                     on_press: root.pause_status_toggle()
-#                     on_release: root.unpause_status_updates()
-#                     text: 'hold screen'
-                                        
-            ScrollableLabelStatus:
-                size_hint_y: 0.3                  
-                id: consoleStatusText
- 
-        BoxLayout:
-            padding: 0
-            spacing: 5
-            orientation: "vertical"
-            size_hint_x: 0.17
- 
-#             Button:
-#                 text: "Enter"
-#                 on_press: root.send_gcode_textinput()
-#                 size_hint_y:0.1
-#                 background_color: .6, 1, 0.6, 1
-
-            ToggleButton:
-                state: root.hide_received_ok
-                markup: True
-                text: 'Hide oks'
-                on_state: root.hide_received_ok = self.state               
-                size_hint_y:0.1
-            Button:
-                text: "Settings"
-                on_press: root.send_gcode_preset("$$")
-                size_hint_y:0.1
-            Button:
-                text: "Params"
-                on_press: root.send_gcode_preset("$#")
-                size_hint_y:0.1
-            Button:
-                text: "State"
-                on_press: root.send_gcode_preset("$G")
-                size_hint_y:0.1
-            Button:
-                text: "Build"
-                size_hint_y:0.1
-                on_press: root.send_gcode_preset("$I")
-            Button:
-                text: "StartUp"
-                on_press: root.send_gcode_preset("$N")
-                size_hint_y:0.1
-            Button:
-                text: "Check $C"
-                on_press: root.toggle_check_mode()
-                size_hint_y:0.1
-            Button:
-                text: "Help"
-                on_press: root.send_gcode_preset("$")
-                size_hint_y:0.1
-            Button:
-                text: "Clear"
-                on_press: root.clear_monitor()
-                size_hint_y:0.1
-                background_color: 1, .8, 0, 1                        
+                      
+            Label:
+                text: 'Status'
+                text_size: self.size
+                halign: 'left'
+                valign: 'middle'
+                    
+#         BoxLayout:
+#             padding_horizontal: 5
+#             spacing: 0
+#             orientation: 'horizontal'
+#             size_hint_y: 0.2
+#             
+#             canvas:
+#                 Color:
+#                     rgba: 0,0,0,0.2
+#                 Rectangle:
+#                     size: self.size
+#                     pos: self.pos
+    
+        ScrollableLabelStatus:
+            size_hint_y: 0.2        
+            id: consoleStatusText
+               
          
 """)
 
 from kivy.clock import Clock
 
 WIDGET_UPDATE_DELAY = 0.2
-STATUS_UPDATE_DELAY = 0.1
+STATUS_UPDATE_DELAY = 0.4
 
 class ScrollableLabelCommands(ScrollView):
     text = StringProperty('')

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -12,6 +12,7 @@ from kivy.uix.widget import Widget
 from kivy.base import runTouchApp
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import ObjectProperty, NumericProperty, StringProperty # @UnresolvedImport
+from __builtin__ import True
 
 
 Builder.load_string("""
@@ -187,12 +188,20 @@ from kivy.clock import Clock
 WIDGET_UPDATE_DELAY = 0.2
 STATUS_UPDATE_DELAY = 0.3
 
+STATUS_PAUSE = False
+
 class ScrollableLabelCommands(ScrollView):
     text = StringProperty('')
     
 class ScrollableLabelStatus(ScrollView):
     text = StringProperty('')
     
+    def on_scroll_move(self, *kwargs):
+        STATUS_PAUSE = True
+        Clock.schedule_once(self.unpause_status_update, 3)
+        
+    def unpause_status_update(self, dt):
+        STATUS_PAUSE = False
 
 class GCodeMonitor(Widget):
 
@@ -213,8 +222,8 @@ class GCodeMonitor(Widget):
     def update_monitor_text_buffer(self, input_or_output, content):
         
         # Don't update if content is to be hidden
-        if content.startswith('<') and self.hide_received_status == 'down': 
-            self.status_report_buffer += content + '\n'
+        if content.startswith('<') and self.hide_received_status == 'down':
+            self.status_report_buffer += '\n' + content
             return
         if content == 'ok' and self.hide_received_ok == 'down': return
         
@@ -230,7 +239,7 @@ class GCodeMonitor(Widget):
         
     def update_status_text(self, dt):
         
-        self.consoleStatusText.text = self.status_report_buffer
+        if STATUS_PAUSE == False: self.consoleStatusText.text = self.status_report_buffer
         
     def send_gcode_textinput(self): 
         

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -194,11 +194,9 @@ class GCodeMonitor(Widget):
 
     hide_received_ok = StringProperty('down')
     hide_received_status = StringProperty('down')
-    monitor_text_buffer = 'Welcome to the GCode console...\n'
-    status_report_buffer = 'Welcome to the GCode console...\n'
+    monitor_text_buffer = ['Welcome to the GCode console...']
+    status_report_buffer = ['Welcome to the GCode console...']
 
-    STATUS_PAUSE = False
-    
     def __init__(self, **kwargs):
     
         super(GCodeMonitor, self).__init__(**kwargs)
@@ -211,23 +209,27 @@ class GCodeMonitor(Widget):
         
         # Don't update if content is to be hidden
         if content.startswith('<') and self.hide_received_status == 'down':
-            self.status_report_buffer += '\n' + content 
+            self.status_report_buffer.append(content)
             return
         if content == 'ok' and self.hide_received_ok == 'down': return
         
         # Update buffer with content
-        if input_or_output == 'snd': self.monitor_text_buffer += '> ' + content + '\n'
-        if input_or_output == 'rec': self.monitor_text_buffer += content + '\n'
-        if input_or_output == 'debug': self.monitor_text_buffer += content + '\n'
+        if input_or_output == 'snd': self.monitor_text_buffer.append( '> ' + content)
+        if input_or_output == 'rec': self.monitor_text_buffer.append(content)
+        if input_or_output == 'debug': self.monitor_text_buffer.append(content)
             
     
     def update_display_text(self, dt):   
         
-        self.consoleScrollText.text = self.monitor_text_buffer
+        self.consoleScrollText.text = '\n'.join(self.monitor_text_buffer)
+        if len(self.monitor_text_buffer) > 61:
+            del self.monitor_text_buffer[0:len(self.monitor_text_buffer)-60]
         
     def update_status_text(self, dt):
         
-        if not self.STATUS_PAUSE: self.consoleStatusText.text = self.status_report_buffer
+        self.consoleStatusText.text = '\n'.join(self.status_report_buffer)
+        if len(self.status_report_buffer) > 4:
+            del self.status_report_buffer[0:len(self.status_report_buffer)-3]
         
     def send_gcode_textinput(self): 
         

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -227,6 +227,9 @@ class GCodeMonitor(Widget):
         
     def update_status_text(self, dt):
         
+        if self.m.state == 'Alarm' and not 'Alarm' in self.status_report_buffer:
+            self.status_report_buffer.append('Please reset for status update')
+        
         self.consoleStatusText.text = '\n'.join(self.status_report_buffer)
         if len(self.status_report_buffer) > 4:
             del self.status_report_buffer[0:len(self.status_report_buffer)-3]

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -227,7 +227,7 @@ class GCodeMonitor(Widget):
         
     def update_status_text(self, dt):
         
-        if self.m.state == 'Alarm' and not 'Alarm' in self.status_report_buffer:
+        if self.m.state() == 'Alarm' and not ('Alarm' in s for s in self.status_report_buffer):
             self.status_report_buffer.append('Please reset for status update')
         
         self.consoleStatusText.text = '\n'.join(self.status_report_buffer)

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -227,7 +227,7 @@ class GCodeMonitor(Widget):
         
     def update_status_text(self, dt):
         
-        if self.m.state() == 'Alarm' and not ('Alarm' in s for s in self.status_report_buffer):
+        if self.m.state() == 'Alarm' and not any('Alarm' in s for s in self.status_report_buffer):
             self.status_report_buffer.append('Please reset for status update')
         
         self.consoleStatusText.text = '\n'.join(self.status_report_buffer)

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -12,8 +12,6 @@ from kivy.uix.widget import Widget
 from kivy.base import runTouchApp
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import ObjectProperty, NumericProperty, StringProperty # @UnresolvedImport
-from __builtin__ import True
-from bCNC.lib.midiparser import TRUE
 
 
 Builder.load_string("""

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -71,21 +71,11 @@ Builder.load_string("""
                 size: self.size
                 pos: self.pos            
 
-        BoxLayout:
-        
+        BoxLayout:      
             size: self.parent.size
             pos: self.parent.pos      
-#            padding_horizontal: 5
             spacing: 5
-            orientation: "horizontal" 
-#             canvas:
-#                 Color:
-#                     rgba: 0,0,0,0.2
-#                 Rectangle:
-#                     size: self.size
-#                     pos: self.pos
-    
-    
+            orientation: "horizontal"    
             
             BoxLayout:
                 padding_horizontal: 5
@@ -99,8 +89,7 @@ Builder.load_string("""
                     orientation: 'horizontal'
                     size_hint_y: 0.1
      
-                    TextInput:
-    #                     size_hint_y: 0.1                        
+                    TextInput:                      
                         id:gCodeInput
                         multiline: False
                         text: ''
@@ -109,78 +98,19 @@ Builder.load_string("""
                     Button:
                         text: "Enter"
                         on_press: root.send_gcode_textinput()
-    #                     size_hint_y:0.1
                         size_hint_x:0.2
                         background_color: .6, 1, 0.6, 1
-     
-    #             BoxLayout:
-    #                 padding: 5
-    #                 spacing: 5
-    #                 orientation: 'horizontal'
-    #                 size_hint_y: 0.1
-    #  
-    #                 canvas:
-    #                     Color:
-    #                         rgba: 0,0,0,0.2
-    #                     Rectangle:
-    #                         size: self.size
-    #                         pos: self.pos
-    #                 Label:
-    #                     text: 'Hide'
-    #                 ToggleButton:
-    #                     state: root.hide_received_ok
-    #                     text: 'oks'
-    #                     on_state: root.hide_received_ok = self.state                              
-    #                 ToggleButton:
-    #                     state: root.hide_received_status
-    #                     on_state: root.hide_received_status = self.state
-    #                     text: 'state'
-    #  
+      
                 ScrollableLabelCommands:
                     size_hint_y: 0.8                     
                     id: consoleScrollText
-                
-#                 BoxLayout:
-#                     padding: 0
-#                     spacing: 5
-#                     orientation: 'horizontal'
-#                     size_hint_y: 0.08
-#      
-#                     canvas:
-#                         Color:
-#                             rgba: 0,0,0,0.2
-#                         Rectangle:
-#                             size: self.size
-#                             pos: self.pos
-#                 
-#                     Label:
-#                         text: 'Status'
-#                         text_size: self.size
-#                         halign: 'left'
-#                         valign: 'middle'
-                        
-    #                 Button:
-    #                     size_hint_x: 0.3
-    #                     on_press: root.pause_status_toggle()
-    #                     on_release: root.unpause_status_updates()
-    #                     text: 'hold screen'
-                                            
-    #             ScrollableLabelStatus:
-    #                 size_hint_y: 0.3                  
-    #                 id: consoleStatusText
-    #  
+                                         
             BoxLayout:
                 padding_horizontal: 5
                 spacing: 5
                 orientation: "vertical"
                 size_hint_x: 0.17
-     
-    #             Button:
-    #                 text: "Enter"
-    #                 on_press: root.send_gcode_textinput()
-    #                 size_hint_y:0.1
-    #                 background_color: .6, 1, 0.6, 1
-    
+        
                 ToggleButton:
                     state: root.hide_received_ok
                     markup: True
@@ -241,18 +171,6 @@ Builder.load_string("""
                 halign: 'left'
                 valign: 'middle'
                     
-#         BoxLayout:
-#             padding_horizontal: 5
-#             spacing: 0
-#             orientation: 'horizontal'
-#             size_hint_y: 0.2
-#             
-#             canvas:
-#                 Color:
-#                     rgba: 0,0,0,0.2
-#                 Rectangle:
-#                     size: self.size
-#                     pos: self.pos
     
         ScrollableLabelStatus:
             size_hint_y: 0.2        


### PR DESCRIPTION
- Stops kivy from idling/freezing/lagging
- Addition of a status update monitor in the settings tab > gcode monitor.
- Have modified how text was stored in the scrollview label for gcode monitor and implemented in status monitor: originally it was one long continuously bloating string, now it is a list, and obsolete elements are deleted. 
- When status is not updating due to machine being in alarm state, status widget tells user "Please reset for status updates". This prevents screen from lagging during alarm state, and is also useful. 