### PR TITLE
Final calibration edits

### DIFF
--- a/src/asmcnc/calibration_app/screen_distance_2_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_2_y.py
@@ -229,6 +229,7 @@ class DistanceScreen2yClass(Screen):
         self.sm.current = 'distance1y'
 
     def skip_section(self):
+        self.sm.get_screen('calibration_complete').calibration_cancelled = False
         self.sm.get_screen('tape_measure_alert').return_to_screen = 'calibration_complete'   
         self.sm.current = 'tape_measure_alert'
           

--- a/src/asmcnc/calibration_app/screen_distance_4_x.py
+++ b/src/asmcnc/calibration_app/screen_distance_4_x.py
@@ -279,7 +279,7 @@ class DistanceScreen4xClass(Screen):
         distance_screen1x = screen_distance_1_x.DistanceScreen1xClass(name = 'distance1x', screen_manager = self.sm, machine = self.m)     
         self.sm.add_widget(distance_screen1x)
         self.sm.get_screen('homing').return_to_screen = 'distance1x'
-        self.sm.get_screen('homing').cancel_to_screen = 'prep'
+        self.sm.get_screen('homing').cancel_to_screen = 'calibration_complete'
         self.sm.current = 'homing'
     
     def quit_calibration(self):

--- a/src/asmcnc/calibration_app/screen_distance_4_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_4_y.py
@@ -285,7 +285,7 @@ class DistanceScreen4yClass(Screen):
         distance_screen1y = screen_distance_1_y.DistanceScreen1yClass(name = 'distance1y', screen_manager = self.sm, machine = self.m)
         self.sm.add_widget(distance_screen1y)
         self.sm.get_screen('homing').return_to_screen = 'distance1y'
-        self.sm.get_screen('homing').cancel_to_screen = 'prep'   
+        self.sm.get_screen('homing').cancel_to_screen = 'calibration_complete'   
 
         self.sm.get_screen('tape_measure_alert').return_to_screen = 'homing'
         self.sm.current = 'tape_measure_alert'

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -63,10 +63,8 @@ class FinishedCalScreenClass(Screen):
         if self.calibration_cancelled == True:
             self.screen_text.text = '[color=455A64]Calibration Cancelled.[/color]'
         else: 
-            self.screen_text.text = '[color=455A64]Calibration Complete![/color]'           
+            self.screen_text.text = '[color=455A64]Calibration Complete![/color]'                   
 
-        
-        self.poll_for_success = Clock.schedule_once(self.exit_screen, 1.5)
         if self.sm.has_screen('measurement'):
             self.sm.remove_widget(self.sm.get_screen('measurement'))
         if self.sm.has_screen('backlash'):
@@ -79,9 +77,15 @@ class FinishedCalScreenClass(Screen):
             self.sm.remove_widget(self.sm.get_screen('calibration_landing'))
         if self.sm.has_screen('tape_measure_alert'):
             self.sm.remove_widget(self.sm.get_screen('tape_measure_alert'))
-        
+
+        print('all done')
+            
+    def on_enter(self):
+        self.poll_for_success = Clock.schedule_once(self.exit_screen, 1.5)
+ 
     def exit_screen(self, dt):
-        self.sm.current = 'lobby'
+        if not self.sm.current == 'alarmScreen':
+            self.sm.current = 'lobby'
         
     def on_leave(self):
         

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -49,7 +49,7 @@ Builder.load_string("""
 class FinishedCalScreenClass(Screen):
     
     screen_text = ObjectProperty()
-    calibration_cancelled = False
+    calibration_cancelled = True
     
     def __init__(self, **kwargs):
         super(FinishedCalScreenClass, self).__init__(**kwargs)

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -84,4 +84,16 @@ class FinishedCalScreenClass(Screen):
         self.sm.current = 'lobby'
         
     def on_leave(self):
+        if self.sm.has_screen('measurement'):
+            self.sm.remove_widget(self.sm.get_screen('measurement'))
+        if self.sm.has_screen('backlash'):
+            self.sm.remove_widget(self.sm.get_screen('backlash'))
+        if self.sm.has_screen('prep'):
+            self.sm.remove_widget(self.sm.get_screen('prep'))
+        if self.sm.has_screen('wait'):
+            self.sm.remove_widget(self.sm.get_screen('wait'))
+        if self.sm.has_screen('calibration_landing'):
+            self.sm.remove_widget(self.sm.get_screen('calibration_landing'))
+        if self.sm.has_screen('tape_measure_alert'):
+            self.sm.remove_widget(self.sm.get_screen('tape_measure_alert'))
         self.sm.remove_widget(self.sm.get_screen('calibration_complete'))

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -74,8 +74,6 @@ class FinishedCalScreenClass(Screen):
             self.sm.remove_widget(self.sm.get_screen('calibration_landing'))
         if self.sm.has_screen('tape_measure_alert'):
             self.sm.remove_widget(self.sm.get_screen('tape_measure_alert'))
-
-        print('all done')
             
     def on_enter(self):
         self.poll_for_success = Clock.schedule_once(self.exit_screen, 1.5)
@@ -84,8 +82,6 @@ class FinishedCalScreenClass(Screen):
         if not self.sm.current == 'alarmScreen':
             self.sm.current = 'lobby'
         
-    def on_leave(self):
-        print('leaving cal screen')
-        
+    def on_leave(self):       
         if self.sm.has_screen('calibration_complete'):
             self.sm.remove_widget(self.sm.get_screen('calibration_complete'))

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -84,6 +84,9 @@ class FinishedCalScreenClass(Screen):
         self.sm.current = 'lobby'
         
     def on_leave(self):
+        
+        print('leaving cal screen')
+        
         if self.sm.has_screen('measurement'):
             self.sm.remove_widget(self.sm.get_screen('measurement'))
         if self.sm.has_screen('backlash'):

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -56,7 +56,9 @@ class FinishedCalScreenClass(Screen):
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
 
-    def on_enter(self):
+    def on_pre_enter(self):
+        
+        print('Calibration cancelled')
 
         if self.calibration_cancelled == True:
             self.screen_text.text = '[color=455A64]Calibration Cancelled.[/color]'

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -57,9 +57,6 @@ class FinishedCalScreenClass(Screen):
         self.m=kwargs['machine']
 
     def on_pre_enter(self):
-        
-        print('Calibration cancelled')
-
         if self.calibration_cancelled == True:
             self.screen_text.text = '[color=455A64]Calibration Cancelled.[/color]'
         else: 
@@ -88,19 +85,7 @@ class FinishedCalScreenClass(Screen):
             self.sm.current = 'lobby'
         
     def on_leave(self):
-        
         print('leaving cal screen')
         
-        if self.sm.has_screen('measurement'):
-            self.sm.remove_widget(self.sm.get_screen('measurement'))
-        if self.sm.has_screen('backlash'):
-            self.sm.remove_widget(self.sm.get_screen('backlash'))
-        if self.sm.has_screen('prep'):
-            self.sm.remove_widget(self.sm.get_screen('prep'))
-        if self.sm.has_screen('wait'):
-            self.sm.remove_widget(self.sm.get_screen('wait'))
-        if self.sm.has_screen('calibration_landing'):
-            self.sm.remove_widget(self.sm.get_screen('calibration_landing'))
-        if self.sm.has_screen('tape_measure_alert'):
-            self.sm.remove_widget(self.sm.get_screen('tape_measure_alert'))
-        self.sm.remove_widget(self.sm.get_screen('calibration_complete'))
+        if self.sm.has_screen('calibration_complete'):
+            self.sm.remove_widget(self.sm.get_screen('calibration_complete'))

--- a/src/asmcnc/calibration_app/screen_landing.py
+++ b/src/asmcnc/calibration_app/screen_landing.py
@@ -134,18 +134,19 @@ class CalibrationLandingScreenClass(Screen):
         self.sm.current = 'lobby'
         
     def next_screen(self):
-        
-        wait_screen = screen_wait.WaitScreenClass(name = 'wait', screen_manager = self.sm, machine = self.m)
-        self.sm.add_widget(wait_screen)
-        tape_measure_screen = screen_tape_measure.TapeMeasureScreenClass(name = 'tape_measure_alert', screen_manager = self.sm, machine = self.m)
-        self.sm.add_widget(tape_measure_screen)
-        final_screen = screen_finished.FinishedCalScreenClass(name = 'calibration_complete', screen_manager = self.sm, machine = self.m)
-        self.sm.add_widget(final_screen)
-        
-        
+        if not self.sm.has_screen('wait'):       
+            wait_screen = screen_wait.WaitScreenClass(name = 'wait', screen_manager = self.sm, machine = self.m)
+            self.sm.add_widget(wait_screen)
+        if not self.sm.has_screen('tape_measure_alert'):
+            tape_measure_screen = screen_tape_measure.TapeMeasureScreenClass(name = 'tape_measure_alert', screen_manager = self.sm, machine = self.m)
+            self.sm.add_widget(tape_measure_screen)
+        if not self.sm.has_screen('calibration_complete'):
+            final_screen = screen_finished.FinishedCalScreenClass(name = 'calibration_complete', screen_manager = self.sm, machine = self.m)
+            self.sm.add_widget(final_screen)
         if not self.sm.has_screen('prep'):
             prep_screen = screen_prep_calibration.PrepCalibrationScreenClass(name = 'prep', screen_manager = self.sm, machine = self.m)
             self.sm.add_widget(prep_screen)
+
         self.sm.current = 'prep'
 
     def on_leave(self):

--- a/src/asmcnc/calibration_app/screen_prep_calibration.py
+++ b/src/asmcnc/calibration_app/screen_prep_calibration.py
@@ -202,6 +202,6 @@ class PrepCalibrationScreenClass(Screen):
 
         self.sm.get_screen('measurement').axis = 'X'
         self.sm.get_screen('homing').return_to_screen = 'measurement'
-        self.sm.get_screen('homing').cancel_to_screen = 'prep'  
+        self.sm.get_screen('homing').cancel_to_screen = 'calibration_complete'  
         self.sm.current = 'homing'
 

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -422,6 +422,8 @@ class HomingScreen(Screen):
         if self.poll_for_success != None: Clock.unschedule(self.poll_for_success)
         if self.poll_for_ready != None: Clock.unschedule(self.poll_for_ready)
         self.quit_home = False
+        
+        
 
 
         

--- a/src/asmcnc/skavaUI/screen_homing.py
+++ b/src/asmcnc/skavaUI/screen_homing.py
@@ -416,6 +416,7 @@ class HomingScreen(Screen):
             # ... will trigger an alarm screen
             self.m.s.cancel_sequential_stream(reset_grbl_after_cancel = False)
             self.m.soft_reset()
+            self.sm.current = self.cancel_to_screen
     
     def on_leave(self):
         if self.poll_for_success != None: Clock.unschedule(self.poll_for_success)


### PR DESCRIPTION
- added in some checks to prevent screens being re-made if they already exist
- routed homing cancellation via the calibration _complete screen, so that any leftover screens get cleared up even in the event of an alarm screen being triggered