### PR TITLE
Added "M06" to blacklist of gcode lines

### DIFF
--- a/src/asmcnc/apps/shapeCutter_app/cut_parameters/sC_job_parameters.py
+++ b/src/asmcnc/apps/shapeCutter_app/cut_parameters/sC_job_parameters.py
@@ -633,7 +633,7 @@ class ShapeCutterJobParameters(object):
             # Strip comments/spaces/new line and capitalize:
             l_block = re.sub('\s|\(.*?\)', '', (line.strip()).upper())  
             
-            if l_block.find('%') == -1 and l_block.find('M6') == -1 and l_block.find('G28') == -1:    # Drop undesirable lines
+            if l_block.find('%') == -1 and l_block.find('M6') == -1 and l_block.find('M06') == -1 and l_block.find('G28') == -1:    # Drop undesirable lines
                 preloaded_job_gcode.append(l_block)
                 
         self.gcode_lines = preloaded_job_gcode   

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -200,7 +200,7 @@ class LoadingScreen(Screen):
             # Strip comments/spaces/new line and capitalize:
             l_block = re.sub('\s|\(.*?\)', '', (line.strip()).upper())  
             
-            if l_block.find('%') == -1 and l_block.find('M6') == -1 and l_block.find('G28') == -1:    # Drop undesirable lines
+            if l_block.find('%') == -1 and l_block.find('M6') == -1 and l_block.find('M06') == -1 and l_block.find('G28') == -1:    # Drop undesirable lines
                 preloaded_job_gcode.append(l_block)  #append cleaned up gcode to object
                 
         job_file.close()


### PR DESCRIPTION
Lines containing this M06 will get dropped from the job_file.
(Previously "M6" *was* caught, but some protocols export this as M06, so the cmd was sneaking through).

Closes #220 