### PR TITLE
Clear btn on gcode monitor clears but bricks its output

### DIFF
--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -252,7 +252,7 @@ class GCodeMonitor(Widget):
 
     def clear_monitor(self): 
         
-        self.monitor_text_buffer = ""
+        self.monitor_text_buffer = ['Welcome to the GCode console...']
 
 #     def pause_status_toggle(self):
 #         if self.STATUS_PAUSE == False:


### PR DESCRIPTION
Replaced `var = string` to `var = array` 
Closes #274 