### PR TITLE
Drop img preview container in filechoosers and dangerous usb 'clean on move'

### DIFF
--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -1,8 +1,6 @@
 '''
 Created on 19 Aug 2017
-
 @author: Ed
-
 Screen allows user to select their job for loading into easycut, either from JobCache or from a memory stick.
 '''
 # config
@@ -22,52 +20,45 @@ from shutil import copy
 from asmcnc.comms import usb_storage
 
 Builder.load_string("""
-
-<SCfilechooser_shape_cutter_params>:
-
-    on_enter: root.refresh_filechooser_shape_cutter_params()
-
-    filechooser_shape_cutter_params:filechooser_shape_cutter_params
+<SCFileChooser>:
+    on_enter: root.refresh_filechooser()
+    filechooser:filechooser
     load_button:load_button
     delete_selected_button:delete_selected_button
     delete_all_button:delete_all_button
     image_delete:image_delete
     image_delete_all:image_delete_all
     image_select:image_select
-
     BoxLayout:
         padding: 0
         spacing: 10
         size: root.size
         pos: root.pos
         orientation: "vertical"
-
         BoxLayout:
             orientation: 'horizontal'
             size: self.parent.size
             pos: self.parent.pos
             spacing: 10
-            filechooser_shape_cutter_paramsListView:
+            FileChooserListView:
                 size_hint_x: 5
-                id: filechooser_shape_cutter_params
+                id: filechooser
                 rootpath: './asmcnc/apps/shapeCutter_app/parameter_cache/'
                 filter_dirs: True
                 filters: ['*.csv', '*.CSV']
                 on_selection: 
-                    root.refresh_filechooser_shape_cutter_params()
+                    root.refresh_filechooser()
        
-
                 
         BoxLayout:
             size_hint_y: None
             height: 100
-
             Button:
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.refresh_filechooser_shape_cutter_params() 
+                    root.refresh_filechooser() 
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -88,7 +79,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.delete_selected(filechooser_shape_cutter_params.selection[0])
+                    root.delete_selected(filechooser.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -149,7 +140,7 @@ Builder.load_string("""
                 disabled: True
                 size_hint_x: 1
                 on_release: 
-                    root.return_to_SC17(filechooser_shape_cutter_params.selection[0])
+                    root.return_to_SC17(filechooser.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -164,32 +155,30 @@ Builder.load_string("""
                         y: self.parent.y
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
-
                 
 """)
 
-# parameter_file_dir = './asmcnc/apps/shapeCutter_app/parameter_cache/'
-parameter_file_dir = '/home/pi/easycut-smartbench/src/asmcnc/apps/shapeCutter_app/parameter_cache/'
+parameter_file_dir = './asmcnc/apps/shapeCutter_app/parameter_cache/'
 
 
-class SCfilechooser_shape_cutter_params(Screen):
+class SCFileChooser(Screen):
 
     
     def __init__(self, **kwargs):
 
-        super(SCfilechooser_shape_cutter_params, self).__init__(**kwargs)
+        super(SCFileChooser, self).__init__(**kwargs)
         self.shapecutter_sm = kwargs['shapecutter']
         self.j = kwargs['job_parameters']
 #         self.usb_stick = usb_storage.USB_storage() # object to manage presence of USB stick (fun in Linux)
 #         self.usb_stick.enable() # start the object scanning for USB stick
         
     def on_enter(self):
-        self.refresh_filechooser_shape_cutter_params()
+        self.refresh_filechooser()
 
-    def refresh_filechooser_shape_cutter_params(self):
+    def refresh_filechooser(self):
 
         try:
-            if self.filechooser_shape_cutter_params.selection[0] != 'C':
+            if self.filechooser.selection[0] != 'C':
 
                 self.load_button.disabled = False
                 self.image_select.source = './asmcnc/skavaUI/img/file_select_select.png'
@@ -212,7 +201,7 @@ class SCfilechooser_shape_cutter_params(Screen):
             self.delete_selected_button.disabled = True
             self.image_delete.source = './asmcnc/skavaUI/img/file_select_delete_disabled.png'
 
-        self.filechooser_shape_cutter_params._update_files()
+        self.filechooser._update_files()
 
 
     def return_to_SC17(self, file_selection):
@@ -223,8 +212,7 @@ class SCfilechooser_shape_cutter_params(Screen):
     def delete_selected(self, filename):
         if os.path.isfile(filename):
             os.remove(filename)
-            print ("Removing files: " + filename)
-            Clock.schedule_once(lambda dt: self.refresh_filechooser_shape_cutter_params(), 0.25)
+            Clock.schedule_once(lambda dt: self.refresh_filechooser(), 0.25)
           
         
     def delete_all(self):
@@ -233,10 +221,8 @@ class SCfilechooser_shape_cutter_params(Screen):
         if files_in_cache:
             for file in files_in_cache:
                 os.remove(parameter_file_dir+file)
-                print ("Removing files: " + parameter_file_dir+file)
-        self.refresh_filechooser_shape_cutter_params()       
+        self.refresh_filechooser()       
 
 
     def quit_to_home(self):
         self.shapecutter_sm.previous_screen()  
-        

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -28,7 +28,6 @@ Builder.load_string("""
     on_enter: root.refresh_filechooser()
 
     filechooser:filechooser
-    modelPreviewImage:modelPreviewImage
     load_button:load_button
     delete_selected_button:delete_selected_button
     delete_all_button:delete_all_button
@@ -57,22 +56,7 @@ Builder.load_string("""
                 on_selection: 
                     root.refresh_filechooser()
                     root.detect_preview_image(filechooser.selection[0])
-            BoxLayout:
-                size: self.parent.size
-                pos: self.parent.pos
-                padding: 10
-                size_hint_x: 5
-                canvas:
-                    Color: 
-                        rgba: 1,1,1,.1
-                    Rectangle: 
-                        size: self.size
-                        pos: self.pos
-                Image:
-                    id:modelPreviewImage
-                    source: root.no_preview_found_img_path
-                    size: self.parent.size
-                    allow_stretch: True                
+       
 
                 
         BoxLayout:
@@ -84,7 +68,6 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.get_FTP_files()
                     root.refresh_filechooser() 
                     self.background_color = hex('#FFFFFF00')
                 on_press:
@@ -187,12 +170,10 @@ Builder.load_string("""
 """)
 
 parameter_file_dir = './asmcnc/apps/shapeCutter_app/parameter_cache/'
-ftp_file_dir = '../../router_ftp/'   # Linux location where incoming files are FTP'd to
+
 
 class SCFileChooser(Screen):
 
-    no_preview_found_img_path = './asmcnc/skavaUI/img/image_preview_inverted_large.png'    
-    preview_image_path = None
     
     def __init__(self, **kwargs):
 
@@ -232,35 +213,6 @@ class SCFileChooser(Screen):
             self.image_delete.source = './asmcnc/skavaUI/img/file_select_delete_disabled.png'
 
         self.filechooser._update_files()
-
-    
-    def get_FTP_files(self):
-
-        if sys.platform != "win32":
-            ftp_files = os.listdir(ftp_file_dir)
-            if ftp_files:
-                for file in ftp_files:
-                    copy(ftp_file_dir + file, job_cache_dir) # "copy" overwrites same-name file at destination
-                    os.remove(ftp_file_dir + file) # clean original space
-
-        
-    def detect_preview_image(self, nc_file_path):
-        
-        # Assume there is no image preview to be found, so set image to default preview
-        self.preview_image_path = None
-        self.modelPreviewImage.source = self.no_preview_found_img_path
-        
-        # Scan file for image identifier in gcode e.g. (preview_img=123.png)
-        original_file = open(nc_file_path, 'r')
-        for line in original_file:
-            if line.find('(preview_img') >= 0:
-                image_name = line.strip().split(':')[1][:-1]
-                image_dir_path = os.path.dirname(nc_file_path)
-                self.preview_image_path = image_dir_path + '/' + image_name
-                if os.path.isfile(self.preview_image_path):
-                    self.modelPreviewImage.source = self.preview_image_path
-                break
-        original_file.close()       
 
 
     def return_to_SC17(self, file_selection):

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -22,7 +22,7 @@ from asmcnc.comms import usb_storage
 Builder.load_string("""
 <SCFileChooser>:
     on_enter: root.refresh_filechooser()
-    filechooser:filechooser
+    filechooser_sc_params:filechooser_sc_params
     load_button:load_button
     delete_selected_button:delete_selected_button
     delete_all_button:delete_all_button
@@ -42,7 +42,7 @@ Builder.load_string("""
             spacing: 10
             FileChooserListView:
                 size_hint_x: 5
-                id: filechooser
+                id: filechooser_sc_params
                 rootpath: './asmcnc/apps/shapeCutter_app/parameter_cache/'
                 filter_dirs: True
                 filters: ['*.csv', '*.CSV']
@@ -79,7 +79,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.delete_selected(filechooser.selection[0])
+                    root.delete_selected(filechooser_sc_params.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -140,7 +140,7 @@ Builder.load_string("""
                 disabled: True
                 size_hint_x: 1
                 on_release: 
-                    root.return_to_SC17(filechooser.selection[0])
+                    root.return_to_SC17(filechooser_sc_params.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -178,7 +178,7 @@ class SCFileChooser(Screen):
     def refresh_filechooser(self):
 
         try:
-            if self.filechooser.selection[0] != 'C':
+            if self.filechooser_sc_params.selection[0] != 'C':
 
                 self.load_button.disabled = False
                 self.image_select.source = './asmcnc/skavaUI/img/file_select_select.png'
@@ -201,7 +201,7 @@ class SCFileChooser(Screen):
             self.delete_selected_button.disabled = True
             self.image_delete.source = './asmcnc/skavaUI/img/file_select_delete_disabled.png'
 
-        self.filechooser._update_files()
+        self.filechooser_sc_params._update_files()
 
 
     def return_to_SC17(self, file_selection):

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -222,6 +222,7 @@ class SCFileChooser(Screen):
     def delete_selected(self, filename):
         if os.path.isfile(filename):
             os.remove(filename)
+            print ("Removing files: " + filename)
             Clock.schedule_once(lambda dt: self.refresh_filechooser(), 0.25)
           
         
@@ -231,6 +232,7 @@ class SCFileChooser(Screen):
         if files_in_cache:
             for file in files_in_cache:
                 os.remove(parameter_file_dir+file)
+                print ("Removing files: " + parameter_file_dir+file)
         self.refresh_filechooser()       
 
 

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -221,16 +221,16 @@ class SCFileChooser(Screen):
 
     def delete_selected(self, filename):
         if os.path.isfile(filename):
-            os.remove(filename)
+            os.remove(parameter_file_dir+filename)
             self.refresh_filechooser()    
           
         
     def delete_all(self):
 
-        files_in_cache = os.listdir(job_cache_dir) # clean cache
+        files_in_cache = os.listdir(parameter_file_dir) # clean cache
         if files_in_cache:
             for file in files_in_cache:
-                os.remove(job_cache_dir+file)
+                os.remove(parameter_file_dir+file)
         self.refresh_filechooser()       
 
 

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -221,8 +221,8 @@ class SCFileChooser(Screen):
 
     def delete_selected(self, filename):
         if os.path.isfile(filename):
-            os.remove(parameter_file_dir+filename)
-            self.refresh_filechooser()    
+            os.remove(filename)
+            Clock.schedule_once(lambda dt: self.refresh_filechooser(), 0.25)
           
         
     def delete_all(self):

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -55,7 +55,6 @@ Builder.load_string("""
                 filters: ['*.csv', '*.CSV']
                 on_selection: 
                     root.refresh_filechooser()
-                    root.detect_preview_image(filechooser.selection[0])
        
 
                 

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -23,11 +23,11 @@ from asmcnc.comms import usb_storage
 
 Builder.load_string("""
 
-<SCFileChooser>:
+<SCfilechooser_shape_cutter_params>:
 
-    on_enter: root.refresh_filechooser()
+    on_enter: root.refresh_filechooser_shape_cutter_params()
 
-    filechooser:filechooser
+    filechooser_shape_cutter_params:filechooser_shape_cutter_params
     load_button:load_button
     delete_selected_button:delete_selected_button
     delete_all_button:delete_all_button
@@ -47,14 +47,14 @@ Builder.load_string("""
             size: self.parent.size
             pos: self.parent.pos
             spacing: 10
-            FileChooserListView:
+            filechooser_shape_cutter_paramsListView:
                 size_hint_x: 5
-                id: filechooser
+                id: filechooser_shape_cutter_params
                 rootpath: './asmcnc/apps/shapeCutter_app/parameter_cache/'
                 filter_dirs: True
                 filters: ['*.csv', '*.CSV']
                 on_selection: 
-                    root.refresh_filechooser()
+                    root.refresh_filechooser_shape_cutter_params()
        
 
                 
@@ -67,7 +67,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.refresh_filechooser() 
+                    root.refresh_filechooser_shape_cutter_params() 
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -88,7 +88,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_release: 
-                    root.delete_selected(filechooser.selection[0])
+                    root.delete_selected(filechooser_shape_cutter_params.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -149,7 +149,7 @@ Builder.load_string("""
                 disabled: True
                 size_hint_x: 1
                 on_release: 
-                    root.return_to_SC17(filechooser.selection[0])
+                    root.return_to_SC17(filechooser_shape_cutter_params.selection[0])
                     self.background_color = hex('#FFFFFF00')
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
@@ -168,27 +168,28 @@ Builder.load_string("""
                 
 """)
 
-parameter_file_dir = './asmcnc/apps/shapeCutter_app/parameter_cache/'
+# parameter_file_dir = './asmcnc/apps/shapeCutter_app/parameter_cache/'
+parameter_file_dir = '/home/pi/easycut-smartbench/src/asmcnc/apps/shapeCutter_app/parameter_cache/'
+          
 
-
-class SCFileChooser(Screen):
+class SCfilechooser_shape_cutter_params(Screen):
 
     
     def __init__(self, **kwargs):
 
-        super(SCFileChooser, self).__init__(**kwargs)
+        super(SCfilechooser_shape_cutter_params, self).__init__(**kwargs)
         self.shapecutter_sm = kwargs['shapecutter']
         self.j = kwargs['job_parameters']
 #         self.usb_stick = usb_storage.USB_storage() # object to manage presence of USB stick (fun in Linux)
 #         self.usb_stick.enable() # start the object scanning for USB stick
         
     def on_enter(self):
-        self.refresh_filechooser()
+        self.refresh_filechooser_shape_cutter_params()
 
-    def refresh_filechooser(self):
+    def refresh_filechooser_shape_cutter_params(self):
 
         try:
-            if self.filechooser.selection[0] != 'C':
+            if self.filechooser_shape_cutter_params.selection[0] != 'C':
 
                 self.load_button.disabled = False
                 self.image_select.source = './asmcnc/skavaUI/img/file_select_select.png'
@@ -211,7 +212,7 @@ class SCFileChooser(Screen):
             self.delete_selected_button.disabled = True
             self.image_delete.source = './asmcnc/skavaUI/img/file_select_delete_disabled.png'
 
-        self.filechooser._update_files()
+        self.filechooser_shape_cutter_params._update_files()
 
 
     def return_to_SC17(self, file_selection):
@@ -223,7 +224,7 @@ class SCFileChooser(Screen):
         if os.path.isfile(filename):
             os.remove(filename)
             print ("Removing files: " + filename)
-            Clock.schedule_once(lambda dt: self.refresh_filechooser(), 0.25)
+            Clock.schedule_once(lambda dt: self.refresh_filechooser_shape_cutter_params(), 0.25)
           
         
     def delete_all(self):
@@ -233,7 +234,7 @@ class SCFileChooser(Screen):
             for file in files_in_cache:
                 os.remove(parameter_file_dir+file)
                 print ("Removing files: " + parameter_file_dir+file)
-        self.refresh_filechooser()       
+        self.refresh_filechooser_shape_cutter_params()       
 
 
     def quit_to_home(self):

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -31,7 +31,6 @@ Builder.load_string("""
 
     filechooser:filechooser
     button_usb:button_usb
-    modelPreviewImage:modelPreviewImage
     load_button:load_button
     delete_selected_button:delete_selected_button
     delete_all_button:delete_all_button
@@ -60,24 +59,6 @@ Builder.load_string("""
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()
-                    root.detect_preview_image(filechooser.selection[0])
-            BoxLayout:
-                size: self.parent.size
-                pos: self.parent.pos
-                padding: 10
-                size_hint_x: 5
-                canvas:
-                    Color: 
-                        rgba: 1,1,1,.1
-                    Rectangle: 
-                        size: self.size
-                        pos: self.pos
-                Image:
-                    id:modelPreviewImage
-                    source: root.no_preview_found_img_path
-                    size: self.parent.size
-                    allow_stretch: True                
-
                 
         BoxLayout:
             size_hint_y: None
@@ -218,8 +199,6 @@ ftp_file_dir = '../../router_ftp/'   # Linux location where incoming files are F
 
 class LocalFileChooser(Screen):
 
-    no_preview_found_img_path = './asmcnc/skavaUI/img/image_preview_inverted_large.png'    
-    preview_image_path = None
     
     def __init__(self, **kwargs):
 
@@ -295,25 +274,6 @@ class LocalFileChooser(Screen):
                 for file in ftp_files:
                     copy(ftp_file_dir + file, job_cache_dir) # "copy" overwrites same-name file at destination
                     os.remove(ftp_file_dir + file) # clean original space
-
-        
-    def detect_preview_image(self, nc_file_path):
-        
-        # Assume there is no image preview to be found, so set image to default preview
-        self.preview_image_path = None
-        self.modelPreviewImage.source = self.no_preview_found_img_path
-        
-        # Scan file for image identifier in gcode e.g. (preview_img=123.png)
-        original_file = open(nc_file_path, 'r')
-        for line in original_file:
-            if line.find('(preview_img') >= 0:
-                image_name = line.strip().split(':')[1][:-1]
-                image_dir_path = os.path.dirname(nc_file_path)
-                self.preview_image_path = image_dir_path + '/' + image_name
-                if os.path.isfile(self.preview_image_path):
-                    self.modelPreviewImage.source = self.preview_image_path
-                break
-        original_file.close()       
 
 
     def go_to_loading_screen(self, file_selection):

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -26,7 +26,6 @@ Builder.load_string("""
     on_enter: root.refresh_filechooser()
 
     filechooser_usb:filechooser_usb
-    cut_usb_files_switch:cut_usb_files_switch
     load_button:load_button
     image_select:image_select
 

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -26,7 +26,6 @@ Builder.load_string("""
     on_enter: root.refresh_filechooser()
 
     filechooser_usb:filechooser_usb
-    modelPreviewImage:modelPreviewImage
     cut_usb_files_switch:cut_usb_files_switch
     load_button:load_button
     image_select:image_select
@@ -57,7 +56,6 @@ Builder.load_string("""
                     filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                     on_selection: 
                         root.refresh_filechooser()
-#                         root.detect_preview_image(filechooser_usb.selection[0])
                         print filechooser_usb.selection[0]
                 BoxLayout:
                     size_hint_y: 1
@@ -71,25 +69,7 @@ Builder.load_string("""
                         size_hint_x: 6
                         halign: 'left'
                         text: 'Remove files from USB after import'
-            
-            BoxLayout:
-                size: self.parent.size
-                pos: self.parent.pos
-                padding: 10
-                size_hint_x: 5
-                canvas:
-                    Color: 
-                        rgba: 1,1,1,.1
-                    Rectangle: 
-                        size: self.size
-                        pos: self.pos
-                Image:
-                    id:modelPreviewImage
-                    source: root.no_preview_found_img_path
-                    size: self.parent.size
-                    allow_stretch: True                
-
-                
+               
         BoxLayout:
             size_hint_y: None
             height: 100
@@ -167,9 +147,6 @@ verbose = True
 class USBFileChooser(Screen):
 
 
-    no_preview_found_img_path = './asmcnc/skavaUI/img/image_preview_inverted_large.png'
-
-
     def __init__(self, **kwargs):
         super(USBFileChooser, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
@@ -203,33 +180,7 @@ class USBFileChooser(Screen):
 
         self.filechooser_usb._update_files()
 
-    
-    preview_image_path = None
-    
-    def detect_preview_image(self, nc_file_path):
         
-        if verbose: print "Detecting image for: " + nc_file_path
-        
-        # Assume there is no image preview to be found, so set image to default preview
-        self.preview_image_path = None
-        self.modelPreviewImage.source = self.no_preview_found_img_path
-
-        # Scan file for image identifier in gcode e.g. (preview_img=123.png)
-        try:
-            original_file = open(nc_file_path, 'r')
-            for line in original_file:
-                if line.find('(preview_img') >= 0:
-                    image_name = line.strip().split(':')[1][:-1]
-                    image_dir_path = os.path.dirname(nc_file_path)
-                    self.preview_image_path = image_dir_path + '/' + image_name
-                    if os.path.isfile(self.preview_image_path):
-                        self.modelPreviewImage.source = self.preview_image_path
-                    break
-            original_file.close()  
-        except:
-            print 'Handled error: Failed to open USB file preview image... selection too quick?'
-
-    
     def import_usb_file(self, file_selection):
         
         # Move over the nc file
@@ -242,28 +193,15 @@ class USBFileChooser(Screen):
             if self.cut_usb_files_switch.active:
                 os.remove(file_selection) # clean original space       
         
-        # Move over the preview image
-        if self.preview_image_path:
-            if os.path.isfile(self.preview_image_path):
-                
-                # ... to cache
-                copy(self.preview_image_path, job_cache_dir) # "copy" overwrites same-name file at destination
-                
-                # Clean USB
-                if self.cut_usb_files_switch.active:
-                    os.remove(self.preview_image_path) # clean original space
-            
+
         self.go_to_loading_screen(file_selection)
         
 
     def quit_to_local(self):
         self.manager.current = 'local_filechooser'
-        #self.manager.transition.direction = 'up' 
-  
-        
+          
     def quit_to_home(self):
         self.manager.current = 'home'
-        #self.manager.transition.direction = 'up'
         
     def go_to_loading_screen(self, file_selection):
 

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -57,22 +57,7 @@ Builder.load_string("""
                     on_selection: 
                         root.refresh_filechooser()
                         print filechooser_usb.selection[0]
-                BoxLayout:
-                    size_hint_y: 1
-                    orientation: 'horizontal'
-                    spacing: 10
-                    Switch:
-                        size_hint_x: 2
-                        active: False
-                        id: cut_usb_files_switch
-                    Label:
-                        size_hint_x: 6
-                        halign: 'left'
-                        text: 'Remove files from USB after import'
-                    Label:
-                        size_hint_x: 8
-                        halign: 'left'
-                        text: ''
+
                
         BoxLayout:
             size_hint_y: None
@@ -192,13 +177,7 @@ class USBFileChooser(Screen):
             
             # ... to cache
             copy(file_selection, job_cache_dir) # "copy" overwrites same-name file at destination
-            
-            # Clean USB
-            if self.cut_usb_files_switch.active:
-                os.remove(file_selection) # clean original space       
-        
-
-        self.go_to_loading_screen(file_selection)
+            self.go_to_loading_screen(file_selection)
         
 
     def quit_to_local(self):

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -69,6 +69,10 @@ Builder.load_string("""
                         size_hint_x: 6
                         halign: 'left'
                         text: 'Remove files from USB after import'
+                    Label:
+                        size_hint_x: 8
+                        halign: 'left'
+                        text: ''
                
         BoxLayout:
             size_hint_y: None


### PR DESCRIPTION
Img preview was defunct anyway, so dropped for both local and usb filechoosers.
Now bigger space for longer filenames.
Also dropped switch on the usb filechooser which was designed to delete the file from the usb stick after copying it to the console. It was dangerous (caused crashes) as wasn't used enough to fix.

Closes #282 