### PR TITLE
Fast screen switching caused gcode error, also error handling did not stop stream

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -128,9 +128,13 @@ class RouterMachine(object):
     def stop_from_gcode_error(self):
         # Note this should be a implementation of door functionality, but this is a fast implementation since there are multiple possible door calls which we need to manage.
         self._grbl_feed_hold()
-        # Allow machine to decelerate in XYZ before resetting to kill spindle, or it'll alarm due to resetting in motion
         self._stop_all_streaming()  # In case alarm happened during stream, stop that
+
+        # Allow machine to decelerate in XYZ before resetting to kill spindle, or it'll alarm due to resetting in motion
+        Clock.schedule_once(lambda dt: self.set_led_colour('RED'),0.5)
         Clock.schedule_once(lambda dt: self._grbl_soft_reset(), 1.5)
+        Clock.schedule_once(lambda dt: self.vac_off(), 2.0)
+
 
     def resume_from_gcode_error(self):
         Clock.schedule_once(lambda dt: self.set_led_colour('BLUE'),0.1)
@@ -465,18 +469,18 @@ class RouterMachine(object):
     def set_led_colour(self, colour_name):
 
         # NEVER SEND MID-JOB. Chars defining RGB will fill up the serial buffer unless handled somehow
-#         if not self.s.is_job_streaming and not self.s.is_sequential_streaming:
+        if not self.s.is_job_streaming and not self.s.is_sequential_streaming:
         
-        self.led_colour_status = colour_name 
-
-        if colour_name == 'RED':        self.s.write_command("*LFF0000")
-        elif colour_name == 'GREEN':    self.s.write_command("*L11FF00")
-        elif colour_name == 'BLUE':     self.s.write_command("*L1100FF")
-        elif colour_name == 'WHITE':    self.s.write_command("*LFFFFFF")
-        elif colour_name == 'YELLOW':   self.s.write_command("*LFFFF00")
-        elif colour_name == 'ORANGE':   self.s.write_command("*LFF8000")
-        elif colour_name == 'MAGENTA':  self.s.write_command("*LFF00FF")
-        elif colour_name == 'OFF':      self.s.write_command("*L110000")
+            self.led_colour_status = colour_name 
+    
+            if colour_name == 'RED':        self.s.write_command("*LFF0000")
+            elif colour_name == 'GREEN':    self.s.write_command("*L11FF00")
+            elif colour_name == 'BLUE':     self.s.write_command("*L1100FF")
+            elif colour_name == 'WHITE':    self.s.write_command("*LFFFFFF")
+            elif colour_name == 'YELLOW':   self.s.write_command("*LFFFF00")
+            elif colour_name == 'ORANGE':   self.s.write_command("*LFF8000")
+            elif colour_name == 'MAGENTA':  self.s.write_command("*LFF00FF")
+            elif colour_name == 'OFF':      self.s.write_command("*L110000")
          
         else: print ("Colour not recognised: " + colour_name + "\n")
 
@@ -498,8 +502,8 @@ class RouterMachine(object):
         if situation == "datum_has_been_set":
             strobe_colour1 = 'GREEN'
             strobe_colour2 = 'GREEN'
-            colour_1_period = 1
-            colour_2_period = 1
+            colour_1_period = 0.5
+            colour_2_period = 0.5
             cycles = 1
             end_on_colour = self.led_colour_status
             self._strobe_loop(strobe_colour1, strobe_colour2, colour_1_period, colour_2_period, cycles, end_on_colour)

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -131,9 +131,11 @@ class RouterMachine(object):
         self._stop_all_streaming()  # In case alarm happened during stream, stop that
 
         # Allow machine to decelerate in XYZ before resetting to kill spindle, or it'll alarm due to resetting in motion
-        Clock.schedule_once(lambda dt: self.set_led_colour('RED'),0.5)
         Clock.schedule_once(lambda dt: self._grbl_soft_reset(), 1.5)
+
+        # Sulk
         Clock.schedule_once(lambda dt: self.vac_off(), 2.0)
+        Clock.schedule_once(lambda dt: self.set_led_colour('RED'),2.1)
 
 
     def resume_from_gcode_error(self):

--- a/src/asmcnc/skavaUI/screen_error.py
+++ b/src/asmcnc/skavaUI/screen_error.py
@@ -161,7 +161,6 @@ class ErrorScreenClass(Screen):
         # use the message to get the error description        
         self.error_description = ERROR_CODES.get(self.message, "")
         self.m.stop_from_gcode_error()
-        self.m.led_restore()
 
         self.button_function = self.return_to_screen
         Clock.schedule_once(lambda dt: self.enable_getout_button(), 1.6)

--- a/src/temp_refactor_notes
+++ b/src/temp_refactor_notes
@@ -1,7 +1,0 @@
-REFACTOR NOTES for branch 304_REFACTOR
-
-Re-enable from serial_connection:
-- door screen 
-- alarm screen
-
-Uncomment gcode widget debug buttons


### PR DESCRIPTION
Delayed LED strobing calls got mixed into the stream if user was very fast in getting to the go button. FIx: check `is_job_streaming`
Also, on triggering a gcode error screen, the machine would not stop. Fix: `_stop_all_streaming` in `m.stop_from_gcode_error`