### PR TITLE
Filechooser improvements: enabled folders, filetype info and dodged crash ./ line

### DIFF
--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -56,6 +56,7 @@ Builder.load_string("""
                 size_hint_y: 5
                 id: filechooser
                 rootpath: './jobCache/'
+                show_hidden: False
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -56,7 +56,6 @@ Builder.load_string("""
                 size_hint_y: 5
                 id: filechooser
                 rootpath: './jobCache/'
-                filter_dirs: True
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()
@@ -224,7 +223,7 @@ class LocalFileChooser(Screen):
         self.refresh_filechooser()
         self.check_USB_status(1)
         self.poll_USB = Clock.schedule_interval(self.check_USB_status, 0.25) # poll status to update button           
-        self.filename_selected_label_text = "Select a file icon above... its full name will appear here."
+        self.filename_selected_label_text = "Only .nc and .gcode files will be shown. Press the icon to display the full filename here."
     
     
     def on_leave(self):

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -220,6 +220,7 @@ class LocalFileChooser(Screen):
         
     def on_enter(self):
         
+        self.filechooser.path = job_cache_dir  # Filechooser path reset to root on each re-entry, so user doesn't start at bottom of previously selected folder
         self.usb_stick.enable() # start the object scanning for USB stick
         self.refresh_filechooser()
         self.check_USB_status(1)

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -46,7 +46,7 @@ Builder.load_string("""
             FileChooserIconView:
                 size_hint_y: 5
                 id: filechooser_usb
-#                 path: './jobCache/'
+                show_hidden: False
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -138,23 +138,33 @@ verbose = True
 
 class USBFileChooser(Screen):
 
+
     filename_selected_label_text = StringProperty()
     usb_stick = ObjectProperty()
 
+
     def __init__(self, **kwargs):
+ 
         super(USBFileChooser, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
+
     
     def on_enter(self):
+
         self.refresh_filechooser()
-        self.filename_selected_label_text = "Select a file icon above... its full name will appear here."
+        self.filename_selected_label_text = "Only .nc and .gcode files will be shown. Press the icon to display the full filename here."
+
         
     def on_leave(self):
+
         if self.sm.current != 'local_filechooser' and self.sm.current != 'loading': self.usb_stick.disable()
+
             
     def set_USB_path(self, usb_path):
+
         self.filechooser_usb.rootpath = usb_path
         if verbose: print 'Filechooser_usb path: ' + self.filechooser_usb.path
+
 
     def refresh_filechooser(self):
 
@@ -181,6 +191,7 @@ class USBFileChooser(Screen):
             self.image_select.source = './asmcnc/skavaUI/img/file_select_select_disabled.png'
 
         self.filechooser_usb._update_files()
+
      
     def import_usb_file(self, file_selection):
         
@@ -197,12 +208,17 @@ class USBFileChooser(Screen):
         
 
     def quit_to_local(self):
+
         self.manager.current = 'local_filechooser'
+
           
     def quit_to_home(self):
+
         self.manager.current = 'home'
+
         
     def go_to_loading_screen(self, file_selection):
+
         self.usb_stick.disable()
         self.manager.get_screen('loading').loading_file_name = file_selection
         self.manager.current = 'loading'

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -148,9 +148,17 @@ class USBFileChooser(Screen):
         super(USBFileChooser, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
 
+
+    def set_USB_path(self, usb_path):
+
+        self.usb_path = usb_path
+        self.filechooser_usb.rootpath = usb_path # Filechooser path reset to root on each re-entry, so user doesn't start at bottom of previously selected folder
+        if verbose: print 'Filechooser_usb path: ' + self.filechooser_usb.path
+
     
     def on_enter(self):
 
+        self.filechooser_usb.path = self.usb_path
         self.refresh_filechooser()
         self.filename_selected_label_text = "Only .nc and .gcode files will be shown. Press the icon to display the full filename here."
 
@@ -158,12 +166,6 @@ class USBFileChooser(Screen):
     def on_leave(self):
 
         if self.sm.current != 'local_filechooser' and self.sm.current != 'loading': self.usb_stick.disable()
-
-            
-    def set_USB_path(self, usb_path):
-
-        self.filechooser_usb.rootpath = usb_path
-        if verbose: print 'Filechooser_usb path: ' + self.filechooser_usb.path
 
 
     def refresh_filechooser(self):

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -46,8 +46,7 @@ Builder.load_string("""
             FileChooserIconView:
                 size_hint_y: 5
                 id: filechooser_usb
-                path: './jobCache/'
-                filter_dirs: True
+#                 path: './jobCache/'
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: 
                     root.refresh_filechooser()
@@ -154,7 +153,7 @@ class USBFileChooser(Screen):
         if self.sm.current != 'local_filechooser' and self.sm.current != 'loading': self.usb_stick.disable()
             
     def set_USB_path(self, usb_path):
-        self.filechooser_usb.path = usb_path
+        self.filechooser_usb.rootpath = usb_path
         if verbose: print 'Filechooser_usb path: ' + self.filechooser_usb.path
 
     def refresh_filechooser(self):


### PR DESCRIPTION
- Enabled local & USB folder visibility: Closes #366 
- Removed ./ line in usbstick load file dialogue: Closes #223 
- Indicated filetypes shown: Closes #214 