### PR TITLE
359 remove path names from all displays

### DIFF
--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -80,6 +80,7 @@ Builder.load_string("""
     load_file_now_label:load_file_now_label
     check_gcode_button:check_gcode_button
     check_gcode_label:check_gcode_label
+    filename_label:filename_label
 
     canvas:
         Color: 
@@ -107,6 +108,7 @@ Builder.load_string("""
                 valign: 'top'
  
             Label:
+                id: filename_label
                 text_size: self.size
                 font_size: '15sp'
                 halign: 'center'
@@ -230,6 +232,13 @@ class CheckingScreen(Screen):
     def on_enter(self):
  
         self.job_checking_checked = '[b]Checking Job...[/b]'  
+        # display file selected in the filename display label
+        if sys.platform == 'win32':
+            self.filename_label.text = self.checking_file_name.split("\\")[-1]
+        else:
+            self.filename_label.text = self.checking_file_name.split("/")[-1]
+        
+        
         self.exit_label = 'Cancel'
         
         if self.entry_screen == 'file_loading':        

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -67,14 +67,14 @@ Builder.load_string("""
             Label:
                 id: filename_label
                 text_size: self.size
-                font_size: '16sp'
+                font_size: '20sp'
                 halign: 'center'
                 valign: 'bottom'
                 text: 'Filename here'
                 
             Label:
                 text_size: self.size
-                font_size: '22sp'
+                font_size: '20sp'
                 halign: 'center'
                 valign: 'bottom'
                 text: 'WARNING:'

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -38,7 +38,7 @@ Builder.load_string("""
 
     check_button:check_button
     home_button:home_button
-
+    filename_label:filename_label
 
     canvas:
         Color: 
@@ -65,11 +65,12 @@ Builder.load_string("""
                 markup: True
  
             Label:
+                id: filename_label
                 text_size: self.size
                 font_size: '16sp'
                 halign: 'center'
                 valign: 'bottom'
-                text: root.loading_file_name
+                text: 'Filename here'
                 
             Label:
                 text_size: self.size
@@ -155,8 +156,14 @@ class LoadingScreen(Screen):
         self.job_gcode=kwargs['job']
         
     def on_enter(self):    
-               
+
         self.job_loading_loaded = '[b]Loading Job...[/b]'
+        # display file selected in the filename display label
+        if sys.platform == 'win32':
+            self.filename_label.text = self.loading_file_name.split("\\")[-1]
+        else:
+            self.filename_label.text = self.loading_file_name.split("/")[-1]
+
         self.sm.get_screen('home').gcode_has_been_checked_and_its_ok = False
         self.load_value = 0
         self.check_button.disabled = True

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -45,6 +45,7 @@ Builder.load_string("""
     stop_start:stop_start
     btn_pause_play: btn_pause_play
     play_pause_button_image: play_pause_button_image
+    file_data_label:file_data_label
 
     BoxLayout:
         padding: 0
@@ -110,13 +111,13 @@ Builder.load_string("""
                             Label:
                                 size_hint_x: 5
                                 text_size: self.size
+                                font_size: '20sp'
                                 color: 0,0,0,1
                                 markup: True
                                 text: 'Load a file...'
                                 halign: 'center'
                                 valign: 'middle'
                                 id: file_data_label
-                                text: root.job_filename
                                 
                             Button:
                                 id: btn_pause_play
@@ -285,6 +286,11 @@ class GoScreen(Screen):
             self.reset_go_screen_after_job_finished()
             self.no_job = False
             self.stop_start.disabled = False
+
+            if sys.platform == 'win32':
+                self.file_data_label.text = '[b]' + self.job_filename.split("\\")[-1] + '[/b]'
+            else:
+                self.file_data_label.text = '[b]' + self.job_filename.split("/")[-1] + '[/b]'
             
         elif self.job_in_progress == False and self.job_gcode == []:
             # if job has not been loaded

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -226,13 +226,12 @@ Builder.load_string("""
                                     id: file_data_label
                                     size_hint_x: 4
                                     text_size: self.size
+                                    font_size: '20sp'
                                     color: 0,0,0,1
                                     markup: True
                                     text: 'Load a file...'
                                     halign: 'center'
                                     valign: 'middle'
-                                    # text: 'Data'
-
 
                             BoxLayout:
                                 size_hint_y: 3
@@ -342,7 +341,12 @@ class HomeScreen(Screen):
 
         # File label at the top
         if self.job_gcode != []:
-            self.file_data_label.text = '[b]' + self.job_filename + '[/b]'
+            
+            if sys.platform == 'win32':
+                self.file_data_label.text = '[b]' + self.job_filename.split("\\")[-1] + '[/b]'
+            else:
+                self.file_data_label.text = '[b]' + self.job_filename.split("/")[-1] + '[/b]'
+                
             # Preview file
             try: 
                 Clock.schedule_once(self.preview_job_file, 0.05)


### PR DESCRIPTION
Fixed for all screens displaying the job name. Closes #359  