### PR TITLE
Serial refactoring

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -53,8 +53,6 @@ class RouterMachine(object):
         # Establish 's'erial comms and initialise
         self.s = serial_connection.SerialConnection(self, self.sm)
         self.s.establish_connection(win_serial_port)
-        print "Serial connection status:", self.s.is_connected()
-        self.s.initialise_grbl()
 
 
     # For manual moves, recalculate the absolute limits, factoring in the limit-switch safety distance (how close we want to get to the switches)

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -113,14 +113,13 @@ class SerialConnection(object):
 
         log('Starting services')
         self.s.flushInput()  # Flush startup text in serial input
-        # Clock.schedule_once(self.grbl_scanner, 0)   # Listen for messages from grbl
         self.next_poll_time = time.time()
         t = threading.Thread(target=self.grbl_scanner)
         t.daemon = True
         t.start()
-
-        self.m.resume_from_alarm()  # Clear any hard switch presses that may have happened during boot
-
+        
+        # Clear any hard switch presses that may have happened during boot
+        self.m.resume_from_alarm()  
 
 
 
@@ -136,10 +135,10 @@ class SerialConnection(object):
     VERBOSE_ALL_RESPONSE = False
     VERBOSE_STATUS = False
 
+
     def grbl_scanner(self):
         
         log('Running grbl_scanner thread')
-
 
         while True:
 

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -99,7 +99,6 @@ class SerialConnection(object):
             log('Initialising grbl...')
             self.write_direct("\r\n\r\n", realtime = False, show_in_sys = False, show_in_console = False)    # Wakes grbl
 
-
     # is serial port connected?
     def is_connected(self):
 
@@ -112,22 +111,16 @@ class SerialConnection(object):
     # called by first kivy screen when safe to assume kivy processing is completed, to ensure correct clock scheduling
     def start_services(self, dt):
 
-        log('Flushing serial')
+        log('Starting services')
         self.s.flushInput()  # Flush startup text in serial input
         # Clock.schedule_once(self.grbl_scanner, 0)   # Listen for messages from grbl
         self.next_poll_time = time.time()
         t = threading.Thread(target=self.grbl_scanner)
         t.daemon = True
-        log('Opening grbl_scanner thread')
         t.start()
 
-        self.m.resume_from_alarm() # Clear any hard switch presses that may have happened during boot
+        self.m.resume_from_alarm()  # Clear any hard switch presses that may have happened during boot
 
-#         Clock.schedule_once(self.activate_first_screen, 1) # Delay for reset call to complete
-# 
-# 
-#     def activate_first_screen(self, dt):
-#         self.sm.current = 'safety'
 
 
 

--- a/src/asmcnc/skavaUI/screen_safety_warning.py
+++ b/src/asmcnc/skavaUI/screen_safety_warning.py
@@ -14,6 +14,7 @@ from kivy.uix.widget import Widget
 from kivy.clock import Clock
 
 import sys, os
+from datetime import datetime
 
 from asmcnc.skavaUI import widget_status_bar # @UnresolvedImport
 
@@ -198,6 +199,12 @@ Builder.load_string("""
 
 """)
 
+
+def log(message):
+    timestamp = datetime.now()
+    print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + message)
+
+
 class SafetyScreen(Screen):
 
     def __init__(self, **kwargs):
@@ -210,8 +217,12 @@ class SafetyScreen(Screen):
         self.status_container.add_widget(self.status_bar_widget)
         self.status_bar_widget.cheeky_color = '#1976d2'
 
+
     def on_enter(self):
-        Clock.schedule_once(lambda dt: self.m.resume_from_alarm(), 2)
+        log('Safety screen UP')
+        log('Starting services')
+
+#         Clock.schedule_once(lambda dt: self.m.resume_from_alarm(), 2)
 #         self.m.resume_from_alarm()
         
         

--- a/src/asmcnc/skavaUI/screen_safety_warning.py
+++ b/src/asmcnc/skavaUI/screen_safety_warning.py
@@ -220,7 +220,6 @@ class SafetyScreen(Screen):
 
     def on_enter(self):
         log('Safety screen UP')
-        log('Starting services')
 
 #         Clock.schedule_once(lambda dt: self.m.resume_from_alarm(), 2)
 #         self.m.resume_from_alarm()

--- a/src/asmcnc/skavaUI/screen_safety_warning.py
+++ b/src/asmcnc/skavaUI/screen_safety_warning.py
@@ -201,13 +201,16 @@ Builder.load_string("""
 
 
 def log(message):
+    
     timestamp = datetime.now()
     print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + message)
 
 
 class SafetyScreen(Screen):
 
+
     def __init__(self, **kwargs):
+        
         super(SafetyScreen, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
@@ -219,15 +222,19 @@ class SafetyScreen(Screen):
 
 
     def on_enter(self):
+        
         log('Safety screen UP')
-
-#         Clock.schedule_once(lambda dt: self.m.resume_from_alarm(), 2)
-#         self.m.resume_from_alarm()
         
         
     def go_to_next_screen(self):
+        
         self.sm.current = 'squaring_decision'
         
+        
     def on_leave(self):
+        
         if self.sm.current != 'alarmScreen' and self.sm.current != 'errorScreen' and self.sm.current != 'door': 
             self.sm.remove_widget(self.sm.get_screen('safety'))
+            
+
+            

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -63,8 +63,7 @@ class WelcomeScreenClass(Screen):
 
     def on_enter(self):
         if self.m.s.is_connected():
-            Clock.schedule_once(self.m.s.start_services, 1)
-#             self.m.s.start_services(0)
+            Clock.schedule_once(self.m.s.start_services, 2)
             Clock.schedule_once(self.go_to_next_screen, 3)
     
     def go_to_next_screen(self, dt):

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -63,8 +63,8 @@ class WelcomeScreenClass(Screen):
 
     def on_enter(self):
         if self.m.s.is_connected():
-            Clock.schedule_once(self.m.s.start_services, 2)
-            Clock.schedule_once(self.go_to_next_screen, 3)
+            Clock.schedule_once(self.m.s.start_services, 3)
+            Clock.schedule_once(self.go_to_next_screen, 4)
     
     def go_to_next_screen(self, dt):
         self.sm.current = 'safety'

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -49,6 +49,7 @@ Builder.load_string("""
 
 
 def log(message):
+    
     timestamp = datetime.now()
     print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + message)
 
@@ -57,16 +58,23 @@ class WelcomeScreenClass(Screen):
     
     
     def __init__(self, **kwargs):
+        
         super(WelcomeScreenClass, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
 
+
     def on_enter(self):
+        
         if self.m.s.is_connected():
+            # Allow kivy to have fully loaded before doing any calls which require scheduling
             Clock.schedule_once(self.m.s.start_services, 3)
+            # Allow time for machine reset sequence
             Clock.schedule_once(self.go_to_next_screen, 4)
     
+    
     def go_to_next_screen(self, dt):
+
         self.sm.current = 'safety'
         
 

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -1,0 +1,74 @@
+'''
+Created on 12 December 2019
+Landing Screen for the Calibration App
+
+@author: Letty
+'''
+
+import gc
+
+from kivy.lang import Builder
+from kivy.uix.screenmanager import ScreenManager, Screen
+from kivy.properties import ObjectProperty, StringProperty
+from kivy.uix.widget import Widget
+from kivy.clock import Clock
+from datetime import datetime
+
+# from asmcnc.calibration_app import screen_prep_calibration
+
+Builder.load_string("""
+
+<WelcomeScreenClass>:
+
+
+    canvas:
+        Color: 
+            rgba: hex('##FAFAFA')
+        Rectangle: 
+            size: self.size
+            pos: self.pos
+             
+    BoxLayout:
+        orientation: 'horizontal'
+        padding: 90,50
+        spacing: 0
+        size_hint_x: 1
+
+        BoxLayout:
+            orientation: 'vertical'
+            size_hint_x: 0.8
+
+            Label:
+                text_size: self.size
+                font_size: '40sp'
+                halign: 'center'
+                valign: 'middle'
+                text: '[color=455A64]Hi there :-)[/color]'
+                markup: 'True'
+""")
+
+
+def log(message):
+    timestamp = datetime.now()
+    print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + message)
+
+
+class WelcomeScreenClass(Screen):
+    
+    
+    def __init__(self, **kwargs):
+        super(WelcomeScreenClass, self).__init__(**kwargs)
+        self.sm=kwargs['screen_manager']
+        self.m=kwargs['machine']
+
+    def on_enter(self):
+        if self.m.s.is_connected():
+            Clock.schedule_once(self.m.s.start_services, 1)
+#             self.m.s.start_services(0)
+            Clock.schedule_once(self.go_to_next_screen, 3)
+    
+    def go_to_next_screen(self, dt):
+        self.sm.current = 'safety'
+        
+
+ 

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ www.yetitool.com
 #os.environ['KIVY_GL_BACKEND'] = 'sdl2'
 import time
 import sys, os
+from datetime import datetime
 
 from kivy.config import Config
 from kivy.clock import Clock
@@ -55,6 +56,7 @@ from asmcnc.skavaUI import screen_squaring_manual_vs_square # @UnresolvedImport
 from asmcnc.skavaUI import screen_homing_prepare # @UnresolvedImport
 from asmcnc.skavaUI import screen_homing_active # @UnresolvedImport
 from asmcnc.skavaUI import screen_squaring_active # @UnresolvedImport
+from asmcnc.skavaUI import screen_welcome # @UnresolvedImport
 
 
 # developer testing
@@ -98,6 +100,11 @@ if sys.platform != 'win32':
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
         start_screen = 'pc_alert'
+
+def log(message):
+    timestamp = datetime.now()
+    print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + message)
+
 
 class SkavaUI(App):
 
@@ -144,6 +151,7 @@ class SkavaUI(App):
         prepare_to_home_screen = screen_homing_prepare.HomingScreenPrepare(name = 'prepare_to_home', screen_manager = sm, machine =m)
         homing_active_screen = screen_homing_active.HomingScreenActive(name = 'homing_active', screen_manager = sm, machine =m)
         squaring_active_screen = screen_squaring_active.SquaringScreenActive(name = 'squaring_active', screen_manager = sm, machine =m)
+        welcome_screen = screen_welcome.WelcomeScreenClass(name = 'welcome', screen_manager = sm, machine =m)
 
 
 
@@ -174,12 +182,15 @@ class SkavaUI(App):
         sm.add_widget(prepare_to_home_screen)
         sm.add_widget(homing_active_screen)
         sm.add_widget(squaring_active_screen)
-        
-        # set screen to start on
-        sm.current = 'safety'
-#         sm.current = 'squaring_decision'
-        return sm
+        sm.add_widget(welcome_screen)
 
+        # Setting the first screen:        
+        # sm.current is set at the end of start_services in serial_connection 
+        # This ensures kivy has fully loaded and initial kivy schedule calls are safely made before screen is presented
+        sm.current = 'welcome'
+
+        log('Screen manager activated')
+        return sm
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29443660/80247955-e5e50880-8666-11ea-8d76-4897cee098d3.png)

This was a deep dive on initialising `serial_communications`
As a result we now have clarity on when different elements are called upon during boot.
These elements get called in the new "Welcome screen"
Sequence is as follows:
- Only called `on_enter` of welcome screen, starting services - delayed to ensure that all kivy functions are complete and clock schedules don't get flattened
- Start services calls `reset_on_alarm` as part of its routine

Also a lot clearer in `serial_connection` as to what's going on (fewer inter-module calls)