### PR TITLE
Boot timing adjustment to enable blue LEDs

### DIFF
--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -75,7 +75,7 @@ class WelcomeScreenClass(Screen):
                 # Allow time for machine reset sequence
                 Clock.schedule_once(self.go_to_next_screen, 2)
     
-            # RasPi boot timings
+            # RasPi boot timings: note test on hard boot, since hard boot takes longer
             if sys.platform != 'win32':
                 # Allow kivy to have fully loaded before doing any calls which require scheduling
                 Clock.schedule_once(self.m.s.start_services, 4)

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -5,7 +5,7 @@ Landing Screen for the Calibration App
 @author: Letty
 '''
 
-import gc
+import sys, os
 
 from kivy.lang import Builder
 from kivy.uix.screenmanager import ScreenManager, Screen
@@ -43,7 +43,7 @@ Builder.load_string("""
                 font_size: '40sp'
                 halign: 'center'
                 valign: 'middle'
-                text: '[color=455A64]Starting EasyCut...[/color]'
+                text: '[color=455A64]Starting SmartBench...[/color]'
                 markup: 'True'
 """)
 
@@ -67,10 +67,20 @@ class WelcomeScreenClass(Screen):
     def on_enter(self):
         
         if self.m.s.is_connected():
-            # Allow kivy to have fully loaded before doing any calls which require scheduling
-            Clock.schedule_once(self.m.s.start_services, 3)
-            # Allow time for machine reset sequence
-            Clock.schedule_once(self.go_to_next_screen, 4)
+
+            # PC boot timings
+            if sys.platform == 'win32':
+                # Allow kivy to have fully loaded before doing any calls which require scheduling
+                Clock.schedule_once(self.m.s.start_services, 1)
+                # Allow time for machine reset sequence
+                Clock.schedule_once(self.go_to_next_screen, 2)
+    
+            # RasPi boot timings
+            if sys.platform != 'win32':
+                # Allow kivy to have fully loaded before doing any calls which require scheduling
+                Clock.schedule_once(self.m.s.start_services, 4)
+                # Allow time for machine reset sequence
+                Clock.schedule_once(self.go_to_next_screen, 5)
     
     
     def go_to_next_screen(self, dt):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29443660/80581881-c6066980-8a05-11ea-9f26-5b4b1ca3eb03.png)

Turns out the hard boot timings are a bit longer than soft boot timings, on the pi. So after all that serial comms refactoring, I never tested the final use case, which needed a second longer for the blue LEDs to process! 