### PR TITLE
Hide spindle overload for non-pro users

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -377,7 +377,7 @@ class RouterMachine(object):
 # SETTINGS GETTERS
     def serial_number(self): 
         try: self.s.setting_50
-        except: return 0.03
+        except: return 0
         else: return self.s.setting_50
 
 # POSITONAL GETTERS            

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -376,10 +376,10 @@ class RouterMachine(object):
 
 # SETTINGS GETTERS
     def product_code(self): 
-        if self.s.setting_50 != None: return self.s.setting_50(:4)
+        if self.s.setting_50 != None: return self.s.setting_50[:4]
         else: return 0
     def serial_number(self): 
-        if self.s.setting_50 != None: return self.s.setting_50(5:7)
+        if self.s.setting_50 != None: return self.s.setting_50[5:7]
         else: return 0
 
 # POSITONAL GETTERS            

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -377,11 +377,11 @@ class RouterMachine(object):
 # SETTINGS GETTERS
     def product_code(self): 
         try: self.s.setting_50
-        except NameError: return 0
+        except: return 0
         else: return self.s.setting_50[:4]
     def serial_number(self): 
         try: self.s.setting_50
-        except NameError: return 0
+        except: return 0
         else: return self.s.setting_50[5:7]
 
 # POSITONAL GETTERS            

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -376,11 +376,13 @@ class RouterMachine(object):
 
 # SETTINGS GETTERS
     def product_code(self): 
-        try: return self.s.setting_50[:4]
+        try: self.s.setting_50
         except NameError: return 0
+        else: return self.s.setting_50[:4]
     def serial_number(self): 
-        try: return self.s.setting_50[5:7]
+        try: self.s.setting_50
         except NameError: return 0
+        else: return self.s.setting_50[5:7]
 
 # POSITONAL GETTERS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -376,11 +376,11 @@ class RouterMachine(object):
 
 # SETTINGS GETTERS
     def product_code(self): 
-        if self.s.setting_50 != None: return self.s.setting_50[:4]
-        else: return 0
+        try: return self.s.setting_50[:4]
+        except NameError: return 0
     def serial_number(self): 
-        if self.s.setting_50 != None: return self.s.setting_50[5:7]
-        else: return 0
+        try: return self.s.setting_50[5:7]
+        except NameError: return 0
 
 # POSITONAL GETTERS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -377,13 +377,8 @@ class RouterMachine(object):
 # SETTINGS GETTERS
     def serial_number(self): 
         try: self.s.setting_50
-        except: return 0
-        else: return self.s.setting_50[:len(self.s.setting_50 - 3)]
-
-    def product_code(self): 
-        try: self.s.setting_50
-        except: return 0
-        else: return self.s.setting_50[len(self.s.setting_50 - 2): len(self.s.setting_50)]
+        except: return 0.03
+        else: return self.s.setting_50
 
 # POSITONAL GETTERS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -374,7 +374,13 @@ class RouterMachine(object):
         settings = ['$22=1','$20=1','$21=1']
         self.s.start_sequential_stream(settings)
 
-
+# SETTINGS GETTERS
+    def product_code(self): 
+        if self.s.setting_50 != None: return self.s.setting_50(:4)
+        else: return 0
+    def serial_number(self): 
+        if self.s.setting_50 != None: return self.s.setting_50(5:7)
+        else: return 0
 
 # POSITONAL GETTERS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -378,11 +378,12 @@ class RouterMachine(object):
     def serial_number(self): 
         try: self.s.setting_50
         except: return 0
-        else: return self.s.setting_50[:4]
+        else: return self.s.setting_50[:len(self.s.setting_50 - 3)]
+
     def product_code(self): 
         try: self.s.setting_50
         except: return 0
-        else: return self.s.setting_50[5:7]
+        else: return self.s.setting_50[len(self.s.setting_50 - 2): len(self.s.setting_50)]
 
 # POSITONAL GETTERS            
         

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -375,11 +375,11 @@ class RouterMachine(object):
         self.s.start_sequential_stream(settings)
 
 # SETTINGS GETTERS
-    def product_code(self): 
+    def serial_number(self): 
         try: self.s.setting_50
         except: return 0
         else: return self.s.setting_50[:4]
-    def serial_number(self): 
+    def product_code(self): 
         try: self.s.setting_50
         except: return 0
         else: return self.s.setting_50[5:7]

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -377,7 +377,7 @@ class RouterMachine(object):
 # SETTINGS GETTERS
     def serial_number(self): 
         try: self.s.setting_50
-        except: return 0
+        except: return 0.03
         else: return self.s.setting_50
 
 # POSITONAL GETTERS            

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -730,6 +730,7 @@ class SerialConnection(object):
             elif setting == '$30': self.setting_30 = value;  # Max spindle speed, RPM
             elif setting == '$31': self.setting_31 = value;  # Min spindle speed, RPM
             elif setting == '$32': self.setting_32 = value;  # Laser mode, boolean
+            elif setting == '$50': self.setting_50 = value; # Serial number and product code
             elif setting == '$100': self.setting_100 = value;  # X steps/mm
             elif setting == '$101': self.setting_101 = value;  # Y steps/mm
             elif setting == '$102': self.setting_102 = value;  # Z steps/mm

--- a/src/asmcnc/skavaUI/popup_info.py
+++ b/src/asmcnc/skavaUI/popup_info.py
@@ -398,47 +398,6 @@ class PopupWarning(Widget):
 
         popup.open()
 
-class PopupWarningWithBack(Widget):   
-    def __init__(self, screen_manager, warning_message):
-        
-        self.sm = screen_manager
-        
-        description = warning_message
-        
-        img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
-        label = Label(size_hint_y=1, text_size=(360, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
-        
-        ok_button = Button(text='[b]Ok[/b]', markup = True)
-        ok_button.background_normal = ''
-        ok_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
-       
-        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[20,0,20,0])
-        btn_layout.add_widget(ok_button)
-        
-        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[40,20,40,20])
-        layout_plan.add_widget(img)
-        layout_plan.add_widget(label)
-        layout_plan.add_widget(btn_layout)
-        
-        popup = Popup(title='Warning!',
-                      title_color=[0, 0, 0, 1],
-                      title_font= 'Roboto-Bold',
-                      title_size = '20sp',
-                      content=layout_plan,
-                      size_hint=(None, None),
-                      size=(500, 400),
-                      auto_dismiss= False
-                      )
-        
-        popup.separator_color = [230 / 255., 74 / 255., 25 / 255., 1.]
-        popup.separator_height = '4dp'
-        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
-        
-        ok_button.bind(on_press=popup.dismiss)    
-
-        popup.open()
-
-
 class PopupWait(Widget):   
     def __init__(self, screen_manager):
         

--- a/src/asmcnc/skavaUI/popup_info.py
+++ b/src/asmcnc/skavaUI/popup_info.py
@@ -510,7 +510,7 @@ class PopupDevModePassword(Widget):
         
         img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
         label = Label(size_hint_y=1, text_size=(360, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
-        textinput = TextInput(size_hint_y=1, text = '')
+        textinput = TextInput(size_hint_y=0.7, text = '')
 
         ok_button = Button(text='[b]Ok[/b]', markup = True)
         ok_button.background_normal = ''

--- a/src/asmcnc/skavaUI/popup_info.py
+++ b/src/asmcnc/skavaUI/popup_info.py
@@ -11,11 +11,7 @@ from kivy.uix.popup import Popup
 from kivy.properties import StringProperty  # @UnresolvedImport
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.widget import Widget
-
-from kivy.uix.popup import Popup
 from kivy.uix.textinput import TextInput
-from kivy.uix.boxlayout import BoxLayout
-from kivy.uix.label import Label
 from kivy.uix.label import Label
 from kivy.uix.button import  Button
 from kivy.uix.image import Image
@@ -493,5 +489,57 @@ class PopupDeveloper(Widget):
         ok_button.bind(on_press=dev_app)
         back_button.bind(on_press=popup.dismiss)       
 
+
+        popup.open()
+
+class PopupDevModePassword(Widget):   
+    def __init__(self, screen_manager):
+        
+        self.sm = screen_manager
+        
+        description = "Please enter the password"
+
+        def check_password(*args):
+          if textinput.text == "dev":
+            self.sm.get_screen('dev').dev_mode_toggle.state = "down"
+            self.sm.get_screen('dev').developer_mode = True
+
+          else:
+            self.sm.get_screen('dev').dev_mode_toggle.state = "normal"
+            self.sm.get_screen('dev').developer_mode = False
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1, text_size=(360, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+        textinput = TextInput(size_hint_y=1, text = '')
+
+        ok_button = Button(text='[b]Ok[/b]', markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+       
+        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[20,0,20,0])
+        btn_layout.add_widget(ok_button)
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[40,20,40,20])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(textinput)
+        layout_plan.add_widget(btn_layout)
+        
+        popup = Popup(title='Warning!',
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(500, 400),
+                      auto_dismiss= False
+                      )
+        
+        popup.separator_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+        popup.separator_height = '4dp'
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        
+        ok_button.bind(on_press=check_password)
+        ok_button.bind(on_press=popup.dismiss)    
 
         popup.open()

--- a/src/asmcnc/skavaUI/popup_info.py
+++ b/src/asmcnc/skavaUI/popup_info.py
@@ -398,6 +398,47 @@ class PopupWarning(Widget):
 
         popup.open()
 
+class PopupWarningWithBack(Widget):   
+    def __init__(self, screen_manager, warning_message):
+        
+        self.sm = screen_manager
+        
+        description = warning_message
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1, text_size=(360, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+        
+        ok_button = Button(text='[b]Ok[/b]', markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+       
+        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[20,0,20,0])
+        btn_layout.add_widget(ok_button)
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[40,20,40,20])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(btn_layout)
+        
+        popup = Popup(title='Warning!',
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(500, 400),
+                      auto_dismiss= False
+                      )
+        
+        popup.separator_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+        popup.separator_height = '4dp'
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        
+        ok_button.bind(on_press=popup.dismiss)    
+
+        popup.open()
+
+
 class PopupWait(Widget):   
     def __init__(self, screen_manager):
         

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -328,7 +328,7 @@ class DeveloperScreen(Screen):
     def toggle_dev_mode(self):
         if self.dev_mode_toggle.state == 'normal':
             self.developer_mode = False
-        elif self.dev_mode_toggle == 'down':
+        elif self.dev_mode_toggle.state == 'down':
             self.developer_mode = True
 
     def square_axes(self):

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -285,6 +285,7 @@ class DeveloperScreen(Screen):
     virtual_hw_mode = StringProperty('normal') # toggles between 'normal' or 'down'(/looks like it's been pressed)
     scraped_grbl_settings = []
 
+    developer_mode = False
 
     def __init__(self, **kwargs):
 

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -19,6 +19,8 @@ from kivy.clock import Clock
 from asmcnc.comms import usb_storage
 import sys, os
 
+from asmcnc.skavaUI import popup_info
+
 PLATFORM_REPOSITORY = "https://github.com/YetiTool/console-raspi3b-plus-platform.git"
 PLATFORM_DIRECTORY = "/home/pi/console-raspi3b-plus-platform"
 PLATFORM_HOME= "/home/pi/"
@@ -329,7 +331,7 @@ class DeveloperScreen(Screen):
         if self.dev_mode_toggle.state == 'normal':
             self.developer_mode = False
         elif self.dev_mode_toggle.state == 'down':
-            self.developer_mode = True
+            popup_info.PopupDevModePassword(self.sm)
 
     def square_axes(self):
         pass

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -35,6 +35,7 @@ Builder.load_string("""
     pl_hash_label:pl_hash_label
     pl_branch_label:pl_branch_label
     fw_version_label:fw_version_label
+    dev_mode_toggle: dev_mode_toggle
 #     latest_platform_version_label:latest_platform_version_label
 
     GridLayout:
@@ -227,8 +228,10 @@ Builder.load_string("""
                 color: 1,1,1,1
                 id: sw_hash_label 
                 
-            Label: 
-                text: ''
+            ToggleButton: 
+                id: dev_mode_toggle
+                text: 'Toggle dev mode'
+                on_press: root.toggle_dev_mode()
                 
             Label: 
                 text: 'EC version'
@@ -321,6 +324,12 @@ class DeveloperScreen(Screen):
     def quit_to_console(self):
         print 'Bye!'
         sys.exit()
+
+    def toggle_dev_mode(self):
+        if self.dev_mode_toggle.state == 'normal':
+            self.developer_mode = False
+        elif self.dev_mode_toggle == 'down':
+            self.developer_mode = True
 
     def square_axes(self):
         pass

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -431,7 +431,7 @@ class GoScreen(Screen):
         self.poll_for_job_progress(0)
 
         # show overload status if running precision pro
-        if (self.m.product_code() == '03' or self.sm.get_screen('dev').developer_mode == True):
+        if (str(self.m.serial_number()).endswith('03') or self.sm.get_screen('dev').developer_mode == True):
             self.update_overload_label(self.m.s.overload_state)
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -431,7 +431,7 @@ class GoScreen(Screen):
         self.poll_for_job_progress(0)
 
         # show overload status if running precision pro
-        if (str(self.m.serial_number()).endswith('03') or self.sm.get_screen('dev').developer_mode == True):
+        if ((str(self.m.serial_number())).endswith('03') or self.sm.get_screen('dev').developer_mode == True):
             self.update_overload_label(self.m.s.overload_state)
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -431,16 +431,18 @@ class GoScreen(Screen):
         self.poll_for_job_progress(0)
 
         # show overload status if running precision pro
-        if self.m.product_code() == '12' or self.sm.get_screen('dev').developer_mode == True: # proxy product code for now
+        if (self.m.product_code() == '12' or self.sm.get_screen('dev').developer_mode == True): # proxy product code for now
             self.update_overload_label(self.m.s.overload_state)
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1
+
+            print "show overload status"
+
         else: 
             self.spindle_overload_container.size_hint_y = 0
             self.spindle_overload_container.opacity = 0
 
-
-
+            print "don't show overload status"
 
         self.loop_for_job_progress = Clock.schedule_interval(self.poll_for_job_progress, 1)  # then poll repeatedly
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -50,6 +50,7 @@ Builder.load_string("""
     progress_percentage_label:progress_percentage_label
     btn_back_img:btn_back_img
     overload_status_label:overload_status_label
+    spindle_overload_container:spindle_overload_container
     
     BoxLayout:
         padding: 0
@@ -325,6 +326,7 @@ Builder.load_string("""
 
 
                     BoxLayout:
+                        id: spindle_overload_container
                         orientation: 'vertical'
                         size_hint_y: 0.25
                         padding: 00
@@ -427,7 +429,18 @@ class GoScreen(Screen):
 
         # get initial values on screen loading
         self.poll_for_job_progress(0)
-        self.update_overload_label(self.m.s.overload_state)
+
+        # show overload status if running precision pro
+        if self.m.product_code() == '12' or self.sm.get_screen('developer').developer_mode == True: # proxy product code for now
+            self.update_overload_label(self.m.s.overload_state)
+            self.spindle_overload_container.size_hint_y = 0.25
+            self.spindle_overload_container.opacity = 1
+        else: 
+            self.spindle_overload_container.size_hint_y = 0
+            self.spindle_overload_container.opacity = 0
+
+
+
 
         self.loop_for_job_progress = Clock.schedule_interval(self.poll_for_job_progress, 1)  # then poll repeatedly
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -431,7 +431,7 @@ class GoScreen(Screen):
         self.poll_for_job_progress(0)
 
         # show overload status if running precision pro
-        if (self.m.product_code() == '12' or self.sm.get_screen('dev').developer_mode == True): # proxy product code for now
+        if (self.m.product_code() == '03' or self.sm.get_screen('dev').developer_mode == True):
             self.update_overload_label(self.m.s.overload_state)
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -436,13 +436,10 @@ class GoScreen(Screen):
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1
 
-            print "show overload status"
-
         else: 
+            self.spindle_overload_container.height = 0
             self.spindle_overload_container.size_hint_y = 0
             self.spindle_overload_container.opacity = 0
-
-            print "don't show overload status"
 
         self.loop_for_job_progress = Clock.schedule_interval(self.poll_for_job_progress, 1)  # then poll repeatedly
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -431,7 +431,7 @@ class GoScreen(Screen):
         self.poll_for_job_progress(0)
 
         # show overload status if running precision pro
-        if self.m.product_code() == '12' or self.sm.get_screen('developer').developer_mode == True: # proxy product code for now
+        if self.m.product_code() == '12' or self.sm.get_screen('dev').developer_mode == True: # proxy product code for now
             self.update_overload_label(self.m.s.overload_state)
             self.spindle_overload_container.size_hint_y = 0.25
             self.spindle_overload_container.opacity = 1

--- a/src/asmcnc/skavaUI/screen_welcome.py
+++ b/src/asmcnc/skavaUI/screen_welcome.py
@@ -81,6 +81,9 @@ class WelcomeScreenClass(Screen):
                 Clock.schedule_once(self.m.s.start_services, 4)
                 # Allow time for machine reset sequence
                 Clock.schedule_once(self.go_to_next_screen, 5)
+                # Get grbl settings
+                Clock.schedule_once(lambda dt: self.m.get_grbl_settings(), 5.5)
+
     
     
     def go_to_next_screen(self, dt):

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -186,10 +186,6 @@ class QuickCommands(Widget):
             if self.m.fw_can_operate_zUp_on_pause():
                 self.sm.current = 'lift_z_on_pause_or_not'
             else:
-
-                info = "FOR TESTING: Full serial number setting is " + str(self.m.serial_number())
-                popup_info.PopupInfo(self.sm, 400, info)               
-
                 self.sm.current = 'go'
 
 

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -186,6 +186,10 @@ class QuickCommands(Widget):
             if self.m.fw_can_operate_zUp_on_pause():
                 self.sm.current = 'lift_z_on_pause_or_not'
             else:
+
+                info = "FOR TESTING: Full serial number setting is " + str(self.m.serial_number())
+                popup_info.PopupInfo(self.sm, 400, info)               
+
                 self.sm.current = 'go'
 
 


### PR DESCRIPTION
- Currently don't have product codes, but all logic is in place for when we know what they are
- Added password protection into dev screen for "toggle dev mode" 
- If dev mode is on, then spindle overload widget is displayed regardless of product code :) 