### PR TITLE
Download logs

### DIFF
--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -355,7 +355,7 @@ class DeveloperScreen(Screen):
     def send_logs(self):
         if self.usb_stick.is_usb_mounted_flag == True:
             # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
-            os.system("journalctl > smartbench_logs.txt && sudo mv smartbench_logs.txt /media/usb/")
+            os.system("journalctl > smartbench_logs.txt && cp smartbench_logs.txt /media/usb/ && rm smartbench_logs.txt")
         
     def email_state(self):
         os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/e-mail-state.sh")

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -354,7 +354,7 @@ class DeveloperScreen(Screen):
 
     def send_logs(self):
         # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
-        os.system("journalctl > smartbench_logs.txt && mv smartbench_logs.txt /media/usb/")      
+        os.system("journalctl \> smartbench_logs.txt \&\& mv smartbench_logs.txt /media/usb/")      
         
     def email_state(self):
         os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/e-mail-state.sh")

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -353,8 +353,9 @@ class DeveloperScreen(Screen):
 ## Diagnostics
 
     def send_logs(self):
-        # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
-        os.system("journalctl \> smartbench_logs.txt \&\& mv smartbench_logs.txt /media/usb/")      
+        if usb_stick.is_usb_mounted_flag == True:
+            # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
+            os.system("journalctl > smartbench_logs.txt && sudo mv smartbench_logs.txt /media/usb/")
         
     def email_state(self):
         os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/e-mail-state.sh")

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -353,7 +353,7 @@ class DeveloperScreen(Screen):
 ## Diagnostics
 
     def send_logs(self):
-        if usb_stick.is_usb_mounted_flag == True:
+        if self.usb_stick.is_usb_mounted_flag == True:
             # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
             os.system("journalctl > smartbench_logs.txt && sudo mv smartbench_logs.txt /media/usb/")
         

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -355,7 +355,7 @@ class DeveloperScreen(Screen):
     def send_logs(self):
         if self.usb_stick.is_usb_mounted_flag == True:
             # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
-            os.system("journalctl > smartbench_logs.txt && cp smartbench_logs.txt /media/usb/ && rm smartbench_logs.txt")
+            os.system("journalctl > smartbench_logs.txt && cp --no-preserve=mode,ownership smartbench_logs.txt /media/usb/ && rm smartbench_logs.txt")
         
     def email_state(self):
         os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/e-mail-state.sh")

--- a/src/asmcnc/skavaUI/screen_developer.py
+++ b/src/asmcnc/skavaUI/screen_developer.py
@@ -355,7 +355,7 @@ class DeveloperScreen(Screen):
     def send_logs(self):
         if self.usb_stick.is_usb_mounted_flag == True:
             # os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/scp-logs.sh")
-            os.system("journalctl > smartbench_logs.txt && cp --no-preserve=mode,ownership smartbench_logs.txt /media/usb/ && rm smartbench_logs.txt")
+            os.system("journalctl > smartbench_logs.txt && sudo cp --no-preserve=mode,ownership smartbench_logs.txt /media/usb/ && rm smartbench_logs.txt")
         
     def email_state(self):
         os.system("/home/pi/console-raspi3b-plus-platform/ansible/templates/e-mail-state.sh")


### PR DESCRIPTION
- Fixed, can now download journalctl logs onto a memory stick (comes out as smartbench_logs.txt) 