### PR TITLE
Power cycle screen fix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -97,12 +97,12 @@ def check_and_update_config():
         os.system('sudo sed -i "s/check_config=True/check_config=False/" /home/pi/easycut-smartbench/src/config.txt')
         check_and_update_gpu_mem()
 
-def check_and_launch_powercycle_screen():
+def check_and_launch_powercycle_screen(self):
     # Check whether machine needs to be power cycled (currently only after a software update)
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
-        start_screen = 'pc_alert'
+        self.start_screen = 'pc_alert'
 
 
 if sys.platform != 'win32' and sys.platform != 'darwin':

--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def check_and_update_config():
         os.system('sudo sed -i "s/check_config=True/check_config=False/" /home/pi/easycut-smartbench/src/config.txt')
         check_and_update_gpu_mem()
 
-def launch powercycle_screen()
+def check_and_launch_powercycle_screen()
     # Check whether machine needs to be power cycled (currently only after a software update)
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
@@ -110,6 +110,8 @@ if sys.platform != 'win32' and sys.platform != 'darwin':
     ## Easycut config
     check_and_update_config()
 
+    # if software update has happened, launch the power cycle screen instead
+    check_and_launch_powercycle_screen()
 
 def log(message):
     timestamp = datetime.now()

--- a/src/main.py
+++ b/src/main.py
@@ -97,12 +97,15 @@ def check_and_update_config():
         os.system('sudo sed -i "s/check_config=True/check_config=False/" /home/pi/easycut-smartbench/src/config.txt')
         check_and_update_gpu_mem()
 
-def check_and_launch_powercycle_screen(self):
+        # if software update has happened, launch the power cycle screen instead
+        check_and_launch_powercycle_screen()        
+
+def check_and_launch_powercycle_screen():
     # Check whether machine needs to be power cycled (currently only after a software update)
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
-        self.start_screen = 'pc_alert'
+        nonlocal start_screen = 'pc_alert'
 
 
 if sys.platform != 'win32' and sys.platform != 'darwin':
@@ -110,8 +113,7 @@ if sys.platform != 'win32' and sys.platform != 'darwin':
     ## Easycut config
     check_and_update_config()
 
-    # if software update has happened, launch the power cycle screen instead
-    check_and_launch_powercycle_screen()
+    print start_screen
 
 def log(message):
     timestamp = datetime.now()

--- a/src/main.py
+++ b/src/main.py
@@ -73,7 +73,7 @@ Cmport = 'COM3'
 initial_version = 'v1.3.1'
 
 # default starting screen
-start_screen = 'safety'
+start_screen = 'welcome'
 
 # Config management
 def check_and_update_gpu_mem():
@@ -97,17 +97,18 @@ def check_and_update_config():
         os.system('sudo sed -i "s/check_config=True/check_config=False/" /home/pi/easycut-smartbench/src/config.txt')
         check_and_update_gpu_mem()
 
-
-if sys.platform != 'win32' and sys.platform != 'darwin':
-    
-    ## Easycut config
-    check_and_update_config()
-    
+def launch powercycle_screen()
     # Check whether machine needs to be power cycled (currently only after a software update)
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
         start_screen = 'pc_alert'
+
+
+if sys.platform != 'win32' and sys.platform != 'darwin':
+    
+    ## Easycut config
+    check_and_update_config()
 
 
 def log(message):
@@ -205,13 +206,7 @@ class SkavaUI(App):
         # Setting the first screen:        
         # sm.current is set at the end of start_services in serial_connection 
         # This ensures kivy has fully loaded and initial kivy schedule calls are safely made before screen is presented
-        sm.current = 'welcome'
-#         sm.current = 'go'
-
-        # maintenance_screen = screen_maintenance.MaintenanceScreenClass(name = 'maintenance', screen_manager = sm, machine =m)
-        # sm.add_widget(maintenance_screen)
-        # sm.current = 'maintenance'
-
+        sm.current = start_screen
 
         log('Screen manager activated: ' + str(sm.current))
 

--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def check_and_update_config():
         os.system('sudo sed -i "s/check_config=True/check_config=False/" /home/pi/easycut-smartbench/src/config.txt')
         check_and_update_gpu_mem()
 
-def check_and_launch_powercycle_screen()
+def check_and_launch_powercycle_screen():
     # Check whether machine needs to be power cycled (currently only after a software update)
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):

--- a/src/main.py
+++ b/src/main.py
@@ -105,7 +105,8 @@ def check_and_launch_powercycle_screen():
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
-        global start_screen = 'pc_alert'
+        global start_screen
+        start_screen = 'pc_alert'
 
 
 if sys.platform != 'win32' and sys.platform != 'darwin':

--- a/src/main.py
+++ b/src/main.py
@@ -105,7 +105,7 @@ def check_and_launch_powercycle_screen():
     pc_alert = (os.popen('grep "power_cycle_alert=True" /home/pi/easycut-smartbench/src/config.txt').read())
     if pc_alert.startswith('power_cycle_alert=True'):
         os.system('sudo sed -i "s/power_cycle_alert=True/power_cycle_alert=False/" /home/pi/easycut-smartbench/src/config.txt') 
-        nonlocal start_screen = 'pc_alert'
+        global start_screen = 'pc_alert'
 
 
 if sys.platform != 'win32' and sys.platform != 'darwin':

--- a/src/settings/settings_manager.py
+++ b/src/settings/settings_manager.py
@@ -31,6 +31,8 @@ class Settings(object):
         self.refresh_platform_version()
         self.refresh_latest_sw_version()
         self.refresh_sw_version()
+
+## VERSION REFRESH
         
     def refresh_sw_version(self):
         self.sw_version = str(os.popen("git describe --tags").read()).strip('\n')
@@ -67,6 +69,9 @@ class Settings(object):
 
     def refresh_latest_platform_version(self):
         self.latest_platform_version = str(os.popen("cd /home/pi/console-raspi3b-plus-platform/ && git fetch --tags --quiet && git describe --tags `git rev-list --tags --max-count=1`").read()).strip('\n')
+
+
+## GET SOFTWARE UPDATES
 
     def get_sw_update_via_wifi(self):
         if sys.platform != 'win32' and sys.platform != 'darwin':       
@@ -140,7 +145,9 @@ class Settings(object):
             clone_new_EC_and_restart()
 
         else: return False
-            
+
+
+## USB SOFTWARE UPDATE            
     def get_sw_update_via_usb(self):
     
         def find_usb_directory():
@@ -194,6 +201,8 @@ class Settings(object):
             return checkout_success
 
 
+
+## FIRMWARE UPDATE FUNCTIONS
     def get_fw_update(self):
         os.system("sudo pigpiod")
         print "pigpio daemon started"


### PR DESCRIPTION
Use of start_screen variable had been replaced by self.sm.current = 'welcome' in main.

Also refactored some of the pc alert code into functions and added under check config. 

Should all work again now, although will need testing with a bona fide software update. 