### PR TITLE
Maintenance prompt overrides & start-up message

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -54,6 +54,7 @@ class RouterMachine(object):
     smartbench_values_dir = '/home/pi/easycut-smartbench/src/sb_values/'
     
     ### Individual files to hold persistent values
+    set_up_options_file_path = smartbench_values_dir + 'set_up_options.txt'
     z_touch_plate_thickness_file_path = smartbench_values_dir + 'z_touch_plate_thickness.txt'
     calibration_settings_file_path = smartbench_values_dir + 'calibration_settings.txt'
     z_head_maintenance_settings_file_path = smartbench_values_dir + 'z_head_maintenance_settings.txt'   
@@ -90,6 +91,9 @@ class RouterMachine(object):
     spindle_cooldown_time_seconds = 10 # YETI value is 10 seconds
     spindle_cooldown_rpm = 20000 # YETI value is 20k 
 
+    reminders_enabled = True
+
+    trigger_setup = False
             
     def __init__(self, win_serial_port, screen_manager):
 
@@ -112,6 +116,12 @@ class RouterMachine(object):
         if not path.exists(self.smartbench_values_dir):
             log("Creating sb_values dir...")
             os.mkdir(self.smartbench_values_dir)
+
+        if not path.exists(self.set_up_options_file_path):
+            log("Creating sb_values dir...")
+            file = open(self.set_up_options_file_path, "w+")
+            file.write(str(self.trigger_setup))
+            file.close()
 
         if not path.exists(self.z_touch_plate_thickness_file_path):
             log("Creating z touch plate thickness file...")
@@ -156,12 +166,46 @@ class RouterMachine(object):
             file.close()
 
     def get_persistent_values(self):
+        self.read_set_up_options()
         self.read_z_touch_plate_thickness()
         self.read_calibration_settings()
         self.read_z_head_maintenance_settings()
         self.read_z_head_laser_offset_values()
         self.read_spindle_brush_values()
         self.read_spindle_cooldown_settings()
+
+
+    ## SET UP OPTIONS
+    def read_set_up_options(self):
+        try: 
+            file = open(self.set_up_options_file_path, 'r')
+            trigger_bool_string  = float(file.read())
+            file.close()
+
+            if trigger_bool_string == 'False': self.m.trigger_setup = False
+            else: self.m.trigger_setup = True
+
+            log("Read in set up options")
+            return True
+
+        except:
+            log("Unable to read in set up options")
+            return False
+
+    def write_set_up_options(self, value):
+
+        try:
+            file = open(self.set_up_options_file_path, 'w+')
+            file.write(str(value))
+            file.close()
+
+            self.m.trigger_setup = value
+            log("set up options written to file")
+            return True
+
+        except:
+            log("Unable to write set up options")
+            return False
 
 
     ## TOUCH PLATE THICKENESS

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -118,7 +118,7 @@ class RouterMachine(object):
             os.mkdir(self.smartbench_values_dir)
 
         if not path.exists(self.set_up_options_file_path):
-            log("Creating sb_values dir...")
+            log("Creating set up options file...")
             file = open(self.set_up_options_file_path, "w+")
             file.write(str(self.trigger_setup))
             file.close()
@@ -179,10 +179,10 @@ class RouterMachine(object):
     def read_set_up_options(self):
         try: 
             file = open(self.set_up_options_file_path, 'r')
-            trigger_bool_string  = float(file.read())
+            trigger_bool_string  = str(file.read())
             file.close()
 
-            if trigger_bool_string == 'False': self.trigger_setup = False
+            if trigger_bool_string == 'False' or trigger_bool_string == False: self.trigger_setup = False
             else: self.trigger_setup = True
 
             log("Read in set up options")

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -182,8 +182,8 @@ class RouterMachine(object):
             trigger_bool_string  = float(file.read())
             file.close()
 
-            if trigger_bool_string == 'False': self.m.trigger_setup = False
-            else: self.m.trigger_setup = True
+            if trigger_bool_string == 'False': self.trigger_setup = False
+            else: self.trigger_setup = True
 
             log("Read in set up options")
             return True
@@ -199,7 +199,7 @@ class RouterMachine(object):
             file.write(str(value))
             file.close()
 
-            self.m.trigger_setup = value
+            self.trigger_setup = value
             log("set up options written to file")
             return True
 

--- a/src/asmcnc/skavaUI/popup_info.py
+++ b/src/asmcnc/skavaUI/popup_info.py
@@ -21,18 +21,31 @@ from kivy.graphics import Color, Rectangle
 
 class PopupWelcome(Widget):
 
-    def __init__(self, screen_manager, description):
+    def __init__(self, screen_manager, machine, description):
         
-        self.shapecutter_sm = screen_manager
+        self.sm = screen_manager
+        self.m = machine
         
+        def set_trigger_to_false(*args):
+          self.m.write_set_up_options(False)
+          self.sm.get_screen('lobby').carousel.load_next(mode='next')
+
+        def set_trigger_to_true(*args):
+          self.m.write_set_up_options(True)
+
         img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
-        label = Label(size_hint_y=2, text_size=(360, None), markup=True, halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0])
+        label = Label(size_hint_y=2, text_size=(340, None), markup=True, halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0])
         
         ok_button = Button(text='[b]Ok[/b]', markup = True)
         ok_button.background_normal = ''
         ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
-        
-        btn_layout = BoxLayout(orientation='horizontal', spacing=15, padding=[150,20,150,0])
+
+        remind_me_button = Button(text='[b]Remind me later[/b]', markup = True)
+        remind_me_button.background_normal = ''
+        remind_me_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+
+        btn_layout = BoxLayout(orientation='horizontal', spacing=15, padding=[90,20,90,0])
+        btn_layout.add_widget(remind_me_button)       
         btn_layout.add_widget(ok_button)
         
         layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[10,10,10,10])
@@ -56,6 +69,9 @@ class PopupWelcome(Widget):
         popup.separator_height = '4dp'
 
         ok_button.bind(on_press=popup.dismiss)
+        ok_button.bind(on_press=set_trigger_to_false)
+        remind_me_button.bind(on_press=popup.dismiss)
+        remind_me_button.bind(on_press=set_trigger_to_true)
 
         popup.open()
         

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -425,14 +425,14 @@ class GoScreen(Screen):
     def on_enter(self):
 
         # Check brush use and lifetime: 
-        if self.m.spindle_brush_use_seconds >= 0.9*self.m.spindle_brush_lifetime_seconds:
+        if self.m.spindle_brush_use_seconds >= 0.9*self.m.spindle_brush_lifetime_seconds and self.m.reminders_enabled == True:
             brush_warning = "[b]Check your spindle brushes before starting your job![/b]\n\n" + \
             "You have used SmartBench for [b]" + str(int(self.m.spindle_brush_use_seconds/3600)) + " hours[/b] " + \
             "since you updated your spindle brush settings, and you told us that they only have lifetime of [b]" + \
             str(int(self.m.spindle_brush_lifetime_seconds/3600)) + " hours[/b]!"
             brush_reminder_popup = popup_info.PopupReminder(self.sm, self.am, self.m, brush_warning, 'brushes')
 
-        if self.m.time_since_z_head_lubricated_seconds >= (50*3600):
+        if self.m.time_since_z_head_lubricated_seconds >= (50*3600) and self.m.reminders_enabled == True:
             lubrication_warning = "[b]Lubricate the z head before starting your job![/b]\n\n" + \
             "You have used SmartBench for [b]" + str(int(self.m.time_since_z_head_lubricated_seconds/3600)) + " hours[/b] " + \
             "since you last told us that you lubricated the Z head\n\n" + \
@@ -440,7 +440,7 @@ class GoScreen(Screen):
             "Saying 'OK' will reset this reminder."
             lubrication_reminder_popup = popup_info.PopupReminder(self.sm, self.am, self.m, lubrication_warning, 'lubrication')
 
-        if self.m.time_since_calibration_seconds >= (320*3600):
+        if self.m.time_since_calibration_seconds >= (320*3600) and self.m.reminders_enabled == True:
             calibration_warning = "[b]Calibrate SmartBench before starting your job![/b]\n\n" + \
             "You have used SmartBench for [b]" + str(int(self.m.time_since_calibration_seconds/3600)) + " hours[/b] " + \
             "since you last completed a full calibration\n\n" + \

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -429,14 +429,14 @@ class LobbyScreen(Screen):
         if not sys.platform == "win32":
             self.m.set_led_colour('GREEN')
 
+        if self.m.trigger_setup == True: self.help_popup()
+
     def help_popup(self):
-        print "pop up press"
-        
         description = "\nUse the arrows to go through the menu,\nand select an app to get started.\n\n " \
-                    "If this is your first time, make sure you\nuse " \
-                    "the [b]Wifi[/b] and [b]Calibrate[/b] apps to set up\nthe SmartBench console. \n\n " \
+                    "If this is your first time, make sure you use\n" \
+                    "the [b]Wifi[/b], [b]Maintenance[/b], and [b]Calibrate[/b] apps\nto set up SmartBench. \n\n " \
                     "For more help, please visit:\n[b]https://www.yetitool.com/support[/b]\n"
-        popup_info.PopupWelcome(self.sm, description)
+        popup_info.PopupWelcome(self.sm, self.m, description)
  
     def pro_app(self):
         self.am.start_pro_app()


### PR DESCRIPTION
Options in dev screen to:
- disable reminders
- set all values to full
- Factory reset maintenance values

Factory resetting maintenance values sets everything back to default or zero values, and sets the trigger of a Welcome pop-up that tells users to set up their machines before first use. 