### PR TITLE
End of check

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -277,7 +277,6 @@ class SerialConnection(object):
     stream_pause_start_time = 0
     stream_paused_accumulated_time = 0
 
-    enabling_check_event = None
     check_streaming_started = False
     
     def check_job(self, job_object):
@@ -293,9 +292,6 @@ class SerialConnection(object):
                 # check has now started:
                 self.check_streaming_started = True
 
-                # for benefit of check screen, just in case
-                if self.enabling_check_event != None: Clock.unschedule(self.enabling_check_event)
-
                 # Set up error logging
                 self.suppress_error_screens = True
                 self.response_log = []
@@ -307,10 +303,10 @@ class SerialConnection(object):
                 Clock.schedule_interval(partial(self.return_check_outcome, job_object), 0.1)
 
             else:
-                self.enabling_check_event = Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
+                Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
 
         # Sleep to ensure check mode ok isn't included in log, AND to ensure it's enabled before job run
-        self.enabling_check_event = Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
+        Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
 
     def return_check_outcome(self, job_object, dt):
         if len(self.response_log) >= len(job_object):

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -278,6 +278,7 @@ class SerialConnection(object):
     stream_paused_accumulated_time = 0
 
     enabling_check_event = None
+    waiting_for_check = False
     check_streaming_started = False
     
     def check_job(self, job_object):
@@ -289,10 +290,12 @@ class SerialConnection(object):
         def check_job_inner_function():
             # Check that check mode has been enabled before running:
             if self.m_state == "Check":
-                if self.enabling_check_event != None: Clock.unschedule(self.enabling_check_event)
 
                 # check has now started:
                 self.check_streaming_started = True
+
+                # for benefit of check screen, just in case
+                if self.enabling_check_event != None: Clock.unschedule(self.enabling_check_event)
 
                 # Set up error logging
                 self.suppress_error_screens = True

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -395,7 +395,6 @@ class SerialConnection(object):
             if self.c_line != []:
                 del self.c_line[0] # Delete the block character count corresponding to the last 'ok'
 
-
     # After streaming is completed
     def end_stream(self):
 

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -278,7 +278,6 @@ class SerialConnection(object):
     stream_paused_accumulated_time = 0
 
     enabling_check_event = None
-    waiting_for_check = False
     check_streaming_started = False
     
     def check_job(self, job_object):

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -308,7 +308,6 @@ class SerialConnection(object):
                 Clock.schedule_interval(partial(self.return_check_outcome, job_object), 0.1)
 
             else:
-                if self.enabling_check_event != None: Clock.unschedule(self.enabling_check_event)
                 self.enabling_check_event = Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
 
         # Sleep to ensure check mode ok isn't included in log, AND to ensure it's enabled before job run

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -304,7 +304,7 @@ class SerialConnection(object):
         Clock.schedule_once(lambda dt: check_job_inner_function(), 0.9)
 
     def return_check_outcome(self, job_object, dt):
-        if len(self.response_log) >= len(job_object): # + 2
+        if len(self.response_log) >= len(job_object):
             self.suppress_error_screens = False
             self.sm.get_screen('check_job').error_log = self.response_log
             return False

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -542,12 +542,6 @@ class CheckingScreen(Screen):
 
         print check_again
 
-        if self.m.s.enabling_check_event != None: 
-            Clock.unschedule(self.m.s.enabling_check_event)
-            check_again = True
-
-            print 'scheduling event'
-
         if self.m.s.check_streaming_started:
             if self.m.s.is_job_streaming: self.m.s.cancel_stream()
             else: check_again = True

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -533,7 +533,7 @@ class CheckingScreen(Screen):
     def stop_check_in_serial(self, pass_no):
 
         check_again = False
-        pass_no +1
+        pass_no += 1
 
         print pass_no
 

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -543,7 +543,10 @@ class CheckingScreen(Screen):
         print check_again
 
         if self.m.s.check_streaming_started:
-            if self.m.s.is_job_streaming: self.m.s.cancel_stream()
+            if self.m.s.is_job_streaming:
+                self.m.s.cancel_stream()
+                print 'cancel streaming'
+
             else: check_again = True
 
             print 'check streaming'

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -535,13 +535,16 @@ class CheckingScreen(Screen):
         check_again = False
         pass_no +1
 
+        print self.m.s.check_streaming_started
+        print self.m.s.is_job_streaming
+
         if self.m.s.enabling_check_event != None: 
             Clock.unschedule(self.m.s.enabling_check_event)
             check_again = True
 
         if self.m.s.check_streaming_started:
             if self.m.s.is_job_streaming: self.m.s.cancel_stream()
-            else: check_agin = True
+            else: check_again = True
 
         elif (pass_no > 2) and (self.m.state() == "Check") and (not check_again): self.m.disable_check_mode()
 

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -535,21 +535,9 @@ class CheckingScreen(Screen):
         check_again = False
         pass_no += 1
 
-        print pass_no
-
-        print self.m.s.check_streaming_started
-        print self.m.s.is_job_streaming
-
-        print check_again
-
         if self.m.s.check_streaming_started:
-            if self.m.s.is_job_streaming:
-                self.m.s.cancel_stream()
-                print 'cancel streaming'
-
+            if self.m.s.is_job_streaming: self.m.s.cancel_stream()
             else: check_again = True
-
-            print 'check streaming'
 
         elif (pass_no > 2) and (self.m.state() == "Check") and (not check_again): self.m.disable_check_mode()
 

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -554,6 +554,7 @@ class CheckingScreen(Screen):
         # self.quit_button.disabled = True
         if self.error_out_event != None: 
             Clock.unschedule(self.error_out_event)
+        if self.error_log == []: self.m.s.cancel_stream()
         self.job_gcode = []
         self.checking_file_name = ''
         self.job_checking_checked = ''
@@ -566,7 +567,6 @@ class CheckingScreen(Screen):
         self.as_high_as = 5000
         self.flag_spindle_off = True
         self.error_log = []
-        if self.m.s.is_job_streaming: self.m.s.cancel_stream()
         if self.loop_for_job_progress != None: self.loop_for_job_progress.cancel()
 
 

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -230,7 +230,7 @@ class CheckingScreen(Screen):
 
     flag_spindle_off = True
 
-    poll_for_serial_streaming_state = None
+    serial_function_called = False
     
     def __init__(self, **kwargs):
         super(CheckingScreen, self).__init__(**kwargs)
@@ -410,7 +410,9 @@ class CheckingScreen(Screen):
 
         # because this is called by a clock function,
         # so put this check in just in case the user exits the screen prior to this
-        if self.sm.current == 'check_job': 
+        if self.sm.current == 'check_job':
+
+            self.serial_function_called = True
 
             # utilise check_job from serial_conn
             self.m.s.check_job(objectifile)
@@ -573,7 +575,9 @@ class CheckingScreen(Screen):
         self.sm.current = 'home'       
     
     def on_leave(self, *args):
-        self.stop_check_in_serial(0)
+        if self.serial_function_called: 
+            self.stop_check_in_serial(0)
+            self.serial_function_called = False
         if self.error_out_event != None: Clock.unschedule(self.error_out_event)
         self.job_gcode = []
         self.checking_file_name = ''

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -429,10 +429,6 @@ class CheckingScreen(Screen):
         if self.error_log != []:
             Clock.unschedule(self.error_out_event)
             if self.loop_for_job_progress != None: self.loop_for_job_progress.cancel()
-
-            # There is a $C on each end of the job object; these two lines just strip of the associated 'ok's        
-#             del self.error_log[0]
-#             del self.error_log[(len(self.error_log)-1)]
             
             # If 'error' is found in the error log, tell the user
             if any('error' in listitem for listitem in self.error_log):
@@ -570,7 +566,7 @@ class CheckingScreen(Screen):
         self.as_high_as = 5000
         self.flag_spindle_off = True
         self.error_log = []
-        self.m.s.cancel_stream()
+        if self.m.s.is_job_streaming: self.m.s.cancel_stream()
         if self.loop_for_job_progress != None: self.loop_for_job_progress.cancel()
 
 

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -556,7 +556,7 @@ class CheckingScreen(Screen):
 
         elif (pass_no > 2) and (self.m.state() == "Check") and (not check_again): self.m.disable_check_mode()
 
-        if check_again or pass_no < 3: Clock.schedule_once(lambda dt: self.stop_check_in_serial(pass_no), 0.5)
+        if check_again or (pass_no < 3): Clock.schedule_once(lambda dt: self.stop_check_in_serial(pass_no), 1)
 
     def quit_to_home(self): 
         

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -535,16 +535,24 @@ class CheckingScreen(Screen):
         check_again = False
         pass_no +1
 
+        print pass_no
+
         print self.m.s.check_streaming_started
         print self.m.s.is_job_streaming
+
+        print check_again
 
         if self.m.s.enabling_check_event != None: 
             Clock.unschedule(self.m.s.enabling_check_event)
             check_again = True
 
+            print 'scheduling event'
+
         if self.m.s.check_streaming_started:
             if self.m.s.is_job_streaming: self.m.s.cancel_stream()
             else: check_again = True
+
+            print 'check streaming'
 
         elif (pass_no > 2) and (self.m.state() == "Check") and (not check_again): self.m.disable_check_mode()
 


### PR DESCRIPTION
set this to cancel stream depending on where serial is in streaming process, instead of forcing an all-purpose cancel. 