### PR TITLE
Interrupt bars

### DIFF
--- a/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
+++ b/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
@@ -21,7 +21,7 @@ ALARM_CODES_DICT = {
 	"ALARM:4" : "Probe fail. Probe was not in the expected state before starting probe cycle.",
 	"ALARM:5" : "Probe fail. Tool did not contact the probe within the search distance.",
 	"ALARM:6" : "Homing fail: SmartBench was reset during active homing cycle.",
-	"ALARM:7" : "Homing fail: the stop bar was triggered during the homing cycle.",
+	"ALARM:7" : "Homing fail: the intrrupt bar was triggered during the homing cycle.",
 	"ALARM:8" : "Homing fail: during the homing cycle, an axis failed to clear the limit switch when pulling off.",
 	"ALARM:9" : "Homing fail: could not find the limit switch within search distance.",
 	"ALARM:10": "Homing fail: on dual axis machines, could not find the second limit switch for self-squaring."

--- a/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
+++ b/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
@@ -21,7 +21,7 @@ ALARM_CODES_DICT = {
 	"ALARM:4" : "Probe fail. Probe was not in the expected state before starting probe cycle.",
 	"ALARM:5" : "Probe fail. Tool did not contact the probe within the search distance.",
 	"ALARM:6" : "Homing fail: SmartBench was reset during active homing cycle.",
-	"ALARM:7" : "Homing fail: the intrrupt bar was triggered during the homing cycle.",
+	"ALARM:7" : "Homing fail: the interrupt bar was triggered during the homing cycle.",
 	"ALARM:8" : "Homing fail: during the homing cycle, an axis failed to clear the limit switch when pulling off.",
 	"ALARM:9" : "Homing fail: could not find the limit switch within search distance.",
 	"ALARM:10": "Homing fail: on dual axis machines, could not find the second limit switch for self-squaring."

--- a/src/asmcnc/skavaUI/screen_door.py
+++ b/src/asmcnc/skavaUI/screen_door.py
@@ -253,6 +253,8 @@ class DoorScreen(Screen):
     def on_pre_enter(self):
         self.resume_button.disabled = True
         self.cancel_button.disabled = True
+        self.resume_button.opacity = 0
+        self.cancel_button.opacity = 0
 
     def on_enter(self):
 
@@ -302,6 +304,8 @@ class DoorScreen(Screen):
 
 
     def ready_to_resume(self, dt): 
+        self.resume_button.opacity = 1
+        self.cancel_button.opacity = 1
         self.resume_button.disabled = False
         self.cancel_button.disabled = False
         self.anim_stop_bar.repeat = True

--- a/src/asmcnc/skavaUI/screen_door.py
+++ b/src/asmcnc/skavaUI/screen_door.py
@@ -87,7 +87,7 @@ Builder.load_string("""
             Label:
                 size_hint: (None, None)
                 font_size: '30sp'
-                text: '[b]Stop bar pushed![/b]'
+                text: '[b]Interrupt bar pushed![/b]'
                 color: [0,0,0,1]
                 markup: True
                 halign: 'left'

--- a/src/asmcnc/skavaUI/screen_error.py
+++ b/src/asmcnc/skavaUI/screen_error.py
@@ -32,7 +32,7 @@ ERROR_CODES = {
     "error:10" : "Soft limits cannot be enabled without homing also enabled.",
     "error:11" : "Max characters per line exceeded. Line was not processed and executed.",
     "error:12" : "(Compile Option Grbl '$' setting value exceeds the maximum step rate supported.",
-    "error:13" : "Stop bar detected as pressed. Check all four contacts at the stop bar ends are not pressed. Pressing each switch a few times may clear the contact.",
+    "error:13" : "Interrupt bar detected as pressed. Check all four contacts at the interrupt bar ends are not pressed. Pressing each switch a few times may clear the contact.",
     "error:14" : "(Grbl-Mega Only Build info or startup line exceeded EEPROM line length limit.",
     "error:15" : "Have you homed the machine yet? If not, please do so now.\nJog target exceeds machine travel. Command ignored.",
     "error:16" : "Jog command with no '=' or contains prohibited g-code.",


### PR DESCRIPTION
- Change UI instances of "stop bar" to "interrupt bar"
- Hid stop/resume buttons from door screen until job can be cancelled or resumed. 