### PR TITLE
Homing laser offset

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1158,6 +1158,10 @@ class RouterMachine(object):
 
         if axis == 'X' or axis == 'XY' or axis == 'YX':
 
+
+            print("Laser offset value: " + str(self.laser_offset_x_value))
+            print("Pos value: " + str(self.mpos_x()))
+
             print("Try to move to: " + str(self.mpos_x() + float(self.laser_offset_x_value)))
             print("Limit at: " + str(float(self.x_min_jog_abs_limit)))
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1158,7 +1158,7 @@ class RouterMachine(object):
 
         if axis == 'X' or axis == 'XY' or axis == 'YX':
 
-
+            # Keep this is for beta testing, as 
             print("Laser offset value: " + str(self.laser_offset_x_value))
             print("Pos value: " + str(self.mpos_x()))
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1157,9 +1157,13 @@ class RouterMachine(object):
     def jog_spindle_to_laser_datum(self, axis):
 
         if axis == 'X' or axis == 'XY' or axis == 'YX':
+
+            print("Try to move to: " + str(self.mpos_x() + float(self.laser_offset_x_value)))
+            print("Limit at: " + str(float(self.x_min_jog_abs_limit)))
+
             # Check that movement is within bounds before jogging
-            if (self.mpos_x() + float(self.laser_offset_x_value) < float(self.x_max_jog_abs_limit)
-            and self.mpos_x() + float(self.laser_offset_x_value) > float(self.x_min_jog_abs_limit)):
+            if (self.mpos_x() + float(self.laser_offset_x_value) <= float(self.x_max_jog_abs_limit)
+            and self.mpos_x() + float(self.laser_offset_x_value) >= float(self.x_min_jog_abs_limit)):
 
                 self.jog_relative('X', self.laser_offset_x_value, 6000.0)
 
@@ -1167,8 +1171,8 @@ class RouterMachine(object):
 
         if axis == 'Y' or axis == 'XY' or axis == 'YX':
             # Check that movement is within bounds before jogging
-            if (self.mpos_y() + float(self.laser_offset_y_value) < float(self.y_max_jog_abs_limit)
-            and self.mpos_y() + float(self.laser_offset_y_value) > float(self.y_min_jog_abs_limit)):
+            if (self.mpos_y() + float(self.laser_offset_y_value) <= float(self.y_max_jog_abs_limit)
+            and self.mpos_y() + float(self.laser_offset_y_value) >= float(self.y_min_jog_abs_limit)):
 
                 self.jog_relative('Y', self.laser_offset_y_value, 6000.0)
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1158,8 +1158,8 @@ class RouterMachine(object):
 
         if axis == 'X' or axis == 'XY' or axis == 'YX':
             # Check that movement is within bounds before jogging
-            if (self.mpos_x() + float(self.laser_offset_x_value) <= float(self.x_max_jog_abs_limit)
-            and self.mpos_x() + float(self.laser_offset_x_value) >= float(self.x_min_jog_abs_limit)):
+            if (self.mpos_x() + float(self.laser_offset_x_value) < float(self.x_max_jog_abs_limit)
+            and self.mpos_x() + float(self.laser_offset_x_value) > float(self.x_min_jog_abs_limit)):
 
                 self.jog_relative('X', self.laser_offset_x_value, 6000.0)
 
@@ -1167,8 +1167,8 @@ class RouterMachine(object):
 
         if axis == 'Y' or axis == 'XY' or axis == 'YX':
             # Check that movement is within bounds before jogging
-            if (self.mpos_y() + float(self.laser_offset_y_value) <= float(self.y_max_jog_abs_limit)
-            and self.mpos_y() + float(self.laser_offset_y_value) >= float(self.y_min_jog_abs_limit)):
+            if (self.mpos_y() + float(self.laser_offset_y_value) < float(self.y_max_jog_abs_limit)
+            and self.mpos_y() + float(self.laser_offset_y_value) > float(self.y_min_jog_abs_limit)):
 
                 self.jog_relative('Y', self.laser_offset_y_value, 6000.0)
 

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -172,7 +172,7 @@ class HomingScreenActive(Screen):
             print("result from addition and subtraction: " + str(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
 
-            self.m.jog_relative('X', self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
+            self.m.jog_relative('X', abs(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance), 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -172,7 +172,7 @@ class HomingScreenActive(Screen):
             print("result from addition and subtraction: " + str(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
 
-            self.m.jog_relative('X', abs(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance), 3000)
+            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -169,10 +169,10 @@ class HomingScreenActive(Screen):
             print("laser offset: "  + str(self.m.laser_offset_x_value))
             print("setting 27: " + str(self.m.s.setting_27))
             print("safety: " + str(self.m.limit_switch_safety_distance))
-            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
+            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance + 0.1))
 
 
-            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
+            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance + 0.1, 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -163,6 +163,15 @@ class HomingScreenActive(Screen):
     def post_homing_sequence(self):
         # If laser is enabled, move by offset
         if self.m.is_laser_enabled:
+
+
+
+            print("laser offset: "  + str(self.m.laser_offset_x_value))
+            print("setting 27: " + str(self.m.s.setting_27))
+            print("safety: " + str(self.m.limit_switch_safety_distance))
+            print("result from addition and subtraction: " + str(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
+
+
             self.m.jog_relative('X', self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -164,19 +164,14 @@ class HomingScreenActive(Screen):
         # If laser is enabled, move by offset
         if self.m.is_laser_enabled:
 
-
+            step_tolerance = 0.01
 
             print("laser offset: "  + str(self.m.laser_offset_x_value))
-            print("setting 27: " + str(self.m.s.setting_27))
-            print("safety: " + str(self.m.limit_switch_safety_distance))
-            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
-            print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) - self.m.laser_offset_x_value))
+            print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value)
 
 
-            self.m.jog_absolute_single_axis('X', float(self.m.x_min_jog_abs_limit) - self.m.laser_offset_x_value, 3000)
-
-
+            self.m.jog_absolute_single_axis('X', float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value, 3000)
             # self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -169,7 +169,7 @@ class HomingScreenActive(Screen):
             print("laser offset: "  + str(self.m.laser_offset_x_value))
             print("setting 27: " + str(self.m.s.setting_27))
             print("safety: " + str(self.m.limit_switch_safety_distance))
-            print("result from addition and subtraction: " + str(self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
+            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
 
             self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -168,7 +168,7 @@ class HomingScreenActive(Screen):
 
             print("laser offset: "  + str(self.m.laser_offset_x_value))
 
-            print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value)
+            print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value))
 
 
             self.m.jog_absolute_single_axis('X', float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value, 3000)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -161,6 +161,9 @@ class HomingScreenActive(Screen):
             Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)
             Clock.schedule_once(lambda dt: self.m.set_led_colour("GREEN"),1)
 
+        if self.m.is_laser_enabled:
+            self.m.jog_relative('X', self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
+
 
     def after_successful_completion_return_to_screen(self):
         self.sm.current = self.return_to_screen

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -171,8 +171,13 @@ class HomingScreenActive(Screen):
             print("safety: " + str(self.m.limit_switch_safety_distance))
             print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
+            print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) - self.m.laser_offset_x_value))
 
-            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
+
+            self.m.jog_absolute_single_axis('X', float(self.m.x_min_jog_abs_limit) - self.m.laser_offset_x_value, 3000)
+
+
+            # self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -169,10 +169,10 @@ class HomingScreenActive(Screen):
             print("laser offset: "  + str(self.m.laser_offset_x_value))
             print("setting 27: " + str(self.m.s.setting_27))
             print("safety: " + str(self.m.limit_switch_safety_distance))
-            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance + 0.1))
+            print("result from addition and subtraction: " + str(abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance))
 
 
-            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance + 0.1, 3000)
+            self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -161,18 +161,14 @@ class HomingScreenActive(Screen):
 
 
     def post_homing_sequence(self):
+
         # If laser is enabled, move by offset
         if self.m.is_laser_enabled:
 
             step_tolerance = 0.01
 
-            print("laser offset: "  + str(self.m.laser_offset_x_value))
-
             print("Jog absolute: " + str(float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value))
-
-
             self.m.jog_absolute_single_axis('X', float(self.m.x_min_jog_abs_limit) + step_tolerance - self.m.laser_offset_x_value, 3000)
-            # self.m.jog_relative('X', abs(self.m.laser_offset_x_value) - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
 
         # allow breather for sequential stream to process
         Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -156,13 +156,18 @@ class HomingScreenActive(Screen):
                         '$I' # Echo grbl version info, which will be read by sw, and internal parameters sync'd
                         ]
             self.m.s.start_sequential_stream(grbl_settings)
-            
-            # allow breather for sequential scream to process
-            Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)
-            Clock.schedule_once(lambda dt: self.m.set_led_colour("GREEN"),1)
 
+            Clock.schedule_once(lambda dt: self.post_homing_sequence(), 1)
+
+
+    def post_homing_sequence(self):
+        # If laser is enabled, move by offset
         if self.m.is_laser_enabled:
             self.m.jog_relative('X', self.m.laser_offset_x_value - self.m.s.setting_27 + self.m.limit_switch_safety_distance, 3000)
+
+        # allow breather for sequential stream to process
+        Clock.schedule_once(lambda dt: self.after_successful_completion_return_to_screen(),1)
+        Clock.schedule_once(lambda dt: self.m.set_led_colour("GREEN"),1)
 
 
     def after_successful_completion_return_to_screen(self):


### PR DESCRIPTION
After homing, if the laser is enabled SB moves back to minimum position that laser datum can still be used (as when setting the datum with laser crosshair, SB will jog towards home for a distance of the laser-spindle offset). 

This minimum position from home is the summation of the laser offset value, a safety from the limit switches, and a positional tolerance. 