### PR TITLE
Dismiss updating popup if SW is up to date, needs testing

### DIFF
--- a/src/asmcnc/apps/SWupdater_app/screen_update_SW.py
+++ b/src/asmcnc/apps/SWupdater_app/screen_update_SW.py
@@ -535,7 +535,7 @@ class SWUpdateScreen(Screen):
 
     def get_sw_update_over_wifi(self):
 
-        popup_info.PopupWait(self.sm,  self.l)
+        updating_wait_popup = popup_info.PopupWait(self.sm,  self.l)
 
         def do_sw_update():
 
@@ -567,6 +567,8 @@ class SWUpdateScreen(Screen):
                     )
 
                 Clock.schedule_once(lambda dt: popup_info.PopupMiniInfo(self.sm, self.l, message), 3)
+
+            Clock.schedule_once( lambda dt: updating_wait_popup.popup.dismiss(), 0.1)
 
         Clock.schedule_once(lambda dt: do_sw_update(), 2)
 


### PR DESCRIPTION
Currently, if user tries to update SW and it's already up-to-date, the please wait popup doesn't go away! Then console needs a hard restart to clear it - obvs not ideal

Has been catching out production, so hoping this fix will help reduce git repo failure rate. 