### PR TITLE
Maintenance bugfixes

### DIFF
--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -87,9 +87,23 @@ class BrushSaveWidget(Widget):
 
         # TIME FOR DATA VALIDATION
 
-        # Read from screen and convert hours into seconds
-        use = float(self.sm.get_screen('maintenance').brush_use_widget.brush_use.text)*3600
-        lifetime = float(self.sm.get_screen('maintenance').brush_life_widget.brush_life.text)*3600 
+        # Read from screen
+        use_str = self.sm.get_screen('maintenance').brush_use_widget.brush_use.text
+        lifetime_str = self.sm.get_screen('maintenance').brush_life_widget.brush_life.text
+
+        if use_str == '' or lifetime_str == '':
+            # throw popup, return without saving
+            warning_message = (
+                    self.l.get_str("There was a problem saving your settings.") + \
+                    "\n\n" + \
+                    self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
+                )
+            popup_info.PopupError(self.sm, self.l, warning_message)
+            return
+
+        #  Convert hours into seconds
+        use = float(use_str) * 3600
+        lifetime = float(lifetime_str) * 3600
 
         # Brush use
         if use >= 0 and use <= 999*3600: pass # all good, carry on

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -91,7 +91,72 @@ class BrushSaveWidget(Widget):
         use_str = self.sm.get_screen('maintenance').brush_use_widget.brush_use.text
         lifetime_str = self.sm.get_screen('maintenance').brush_life_widget.brush_life.text
 
-        if use_str == '' or lifetime_str == '':
+        try:
+            #  Convert hours into seconds
+            use = float(use_str) * 3600
+            lifetime = float(lifetime_str) * 3600
+
+            # Brush use
+            if use >= 0 and use <= 999*3600: pass # all good, carry on
+            else: 
+                # throw popup, return without saving
+                brush_use_validation_error = (
+                        self.l.get_str("The number of hours the brushes have been used for should be between 0 and 999.") + \
+                        "\n\n" + \
+                        self.l.get_str("Please enter a new value.")
+                    )
+
+                popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
+                return
+
+
+            # Brush life
+            if lifetime >= 100*3600 and lifetime <= 999*3600: pass # all good, carry on
+            else: 
+                # throw popup, return without saving
+                brush_life_validation_error = (
+                        self.l.get_str("The maximum brush lifetime should be between 100 and 999 hours.") + \
+                        "\n\n" + \
+                        self.l.get_str("Please enter a new value.")
+                    )
+
+                popup_info.PopupError(self.sm, self.l, brush_life_validation_error)
+                return
+
+            # Check use <= lifetime
+            if use <= lifetime: pass # all good, carry on
+            else: 
+                # throw popup, return without saving
+                brush_both_validation_error = (
+                        self.l.get_str("The brush use hours should be less than or equal to the lifetime!") + \
+                        "\n\n" + \
+                        self.l.get_str("Please check your values.")
+                    )
+
+                popup_info.PopupError(self.sm, self.l, brush_both_validation_error)
+                return
+
+
+            # write new values to file
+            if self.m.write_spindle_brush_values(use, lifetime):
+
+                saved_success = self.l.get_str("Settings saved!")
+                popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
+
+            else:
+                warning_message = (
+                        self.l.get_str("There was a problem saving your settings.") + \
+                        "\n\n" + \
+                        self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
+                    )
+                popup_info.PopupError(self.sm, self.l, warning_message)
+
+
+            # Update the monitor :)
+            value = 1 - float(self.m.spindle_brush_use_seconds/self.m.spindle_brush_lifetime_seconds)
+            self.sm.get_screen('maintenance').brush_monitor_widget.set_percentage(value)
+
+        except:
             # throw popup, return without saving
             warning_message = (
                     self.l.get_str("There was a problem saving your settings.") + \
@@ -100,68 +165,3 @@ class BrushSaveWidget(Widget):
                 )
             popup_info.PopupError(self.sm, self.l, warning_message)
             return
-
-        #  Convert hours into seconds
-        use = float(use_str) * 3600
-        lifetime = float(lifetime_str) * 3600
-
-        # Brush use
-        if use >= 0 and use <= 999*3600: pass # all good, carry on
-        else: 
-            # throw popup, return without saving
-            brush_use_validation_error = (
-                    self.l.get_str("The number of hours the brushes have been used for should be between 0 and 999.") + \
-                    "\n\n" + \
-                    self.l.get_str("Please enter a new value.")
-                )
-
-            popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
-            return
-
-
-        # Brush life
-        if lifetime >= 100*3600 and lifetime <= 999*3600: pass # all good, carry on
-        else: 
-            # throw popup, return without saving
-            brush_life_validation_error = (
-                    self.l.get_str("The maximum brush lifetime should be between 100 and 999 hours.") + \
-                    "\n\n" + \
-                    self.l.get_str("Please enter a new value.")
-                )
-
-            popup_info.PopupError(self.sm, self.l, brush_life_validation_error)
-            return
-
-        # Check use <= lifetime
-        if use <= lifetime: pass # all good, carry on
-        else: 
-            # throw popup, return without saving
-            brush_both_validation_error = (
-                    self.l.get_str("The brush use hours should be less than or equal to the lifetime!") + \
-                    "\n\n" + \
-                    self.l.get_str("Please check your values.")
-                )
-
-            popup_info.PopupError(self.sm, self.l, brush_both_validation_error)
-            return
-
-
-        # write new values to file
-        if self.m.write_spindle_brush_values(use, lifetime):
-
-            saved_success = self.l.get_str("Settings saved!")
-            popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
-
-        else:
-            warning_message = (
-                    self.l.get_str("There was a problem saving your settings.") + \
-                    "\n\n" + \
-                    self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
-                )
-            popup_info.PopupError(self.sm, self.l, warning_message)
-
-
-        # Update the monitor :)
-        value = 1 - float(self.m.spindle_brush_use_seconds/self.m.spindle_brush_lifetime_seconds)
-        self.sm.get_screen('maintenance').brush_monitor_widget.set_percentage(value)
-

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
@@ -105,12 +105,24 @@ class ZMiscSaveWidget(Widget):
 
         self.show_popup = True
 
-        if self.save_touchplate_offset() and self.save_z_head_maintenance():
+        if not self.save_touchplate_offset():
+            if not self.show_popup:
+                warning_message = (
+                        self.l.get_str("Your touchplate offset should be inbetween 1 and 2 mm.") + \
+                        "\n\n" + \
+                        self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
+                    )
+            else:
+                warning_message = (
+                        self.l.get_str("There was a problem saving your settings.") + \
+                        "\n\n" + \
+                        self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
+                    )
 
-            saved_success = self.l.get_str("Settings saved!")
-            popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
-        
-        elif self.show_popup:
+            popup_info.PopupError(self.sm, self.l, warning_message)
+            return
+
+        if not self.save_z_head_maintenance():
             warning_message = (
                     self.l.get_str("There was a problem saving your settings.") + \
                     "\n\n" + \
@@ -118,6 +130,10 @@ class ZMiscSaveWidget(Widget):
                 )
 
             popup_info.PopupError(self.sm, self.l, warning_message)
+            return
+
+        saved_success = self.l.get_str("Settings saved!")
+        popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
 
     def save_touchplate_offset(self):
         # Set offset

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
@@ -103,12 +103,14 @@ class ZMiscSaveWidget(Widget):
 
     def save(self):
 
+        self.show_popup = True
+
         if self.save_touchplate_offset() and self.save_z_head_maintenance():
 
             saved_success = self.l.get_str("Settings saved!")
             popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
         
-        else:
+        elif self.show_popup:
             warning_message = (
                     self.l.get_str("There was a problem saving your settings.") + \
                     "\n\n" + \
@@ -129,6 +131,7 @@ class ZMiscSaveWidget(Widget):
                         self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
                     )
                 popup_info.PopupError(self.sm, self.l, warning_message)
+                self.show_popup = False
                 return False
             else:
                 if self.m.write_z_touch_plate_thickness(touchplate_offset): return True

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
@@ -105,24 +105,12 @@ class ZMiscSaveWidget(Widget):
 
         self.show_popup = True
 
-        if not self.save_touchplate_offset():
-            if not self.show_popup:
-                warning_message = (
-                        self.l.get_str("Your touchplate offset should be inbetween 1 and 2 mm.") + \
-                        "\n\n" + \
-                        self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
-                    )
-            else:
-                warning_message = (
-                        self.l.get_str("There was a problem saving your settings.") + \
-                        "\n\n" + \
-                        self.l.get_str("Please check your settings and try again, or if the problem persists please contact the YetiTool support team.")
-                    )
+        if self.save_touchplate_offset() and self.save_z_head_maintenance():
 
-            popup_info.PopupError(self.sm, self.l, warning_message)
-            return
-
-        if not self.save_z_head_maintenance():
+            saved_success = self.l.get_str("Settings saved!")
+            popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
+        
+        elif self.show_popup:
             warning_message = (
                     self.l.get_str("There was a problem saving your settings.") + \
                     "\n\n" + \
@@ -130,10 +118,6 @@ class ZMiscSaveWidget(Widget):
                 )
 
             popup_info.PopupError(self.sm, self.l, warning_message)
-            return
-
-        saved_success = self.l.get_str("Settings saved!")
-        popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
 
     def save_touchplate_offset(self):
         # Set offset


### PR DESCRIPTION
2 bugfixes:

- Clicking save in the touchplate offset tab in maintenance with an input outside of the permitted range now only shows 1 popup, rather than 2 as it did before
- Clicking save in the brush monitor tab in maintenance with an empty input field no longer crashes the console