### PR TITLE
Tidying up set up comments for production jigs

### DIFF
--- a/src/lb_calibration_app.py
+++ b/src/lb_calibration_app.py
@@ -18,10 +18,6 @@ as default application at startup:
 
 touch /home/pi/YETI_LBCAL_PROD_JIG.txt
 
-# Exit and save file
-
-sudo reboot
-
 #######################################################
 '''
 

--- a/src/lower_beam_qc_app.py
+++ b/src/lower_beam_qc_app.py
@@ -1,7 +1,8 @@
 '''
 Created on 8 Feb 2022
 @author: Dennis
-
+YetiTool's UI for SmartBench
+www.yetitool.com
 
 #######################################################
 LOWER BEAM QC APPLICATION
@@ -15,11 +16,7 @@ PLATFORM
 This app needs following platform changes to run
 as default application at startup: 
 
-/home/pi/easycut-smartbench/ansible/templates/ansible-start.sh
-
 touch /home/pi/YETI_LBQC_PROD_JIG.txt
-
-sudo reboot
 
 ########
 '''

--- a/src/z_head_cycle_app.py
+++ b/src/z_head_cycle_app.py
@@ -5,7 +5,7 @@ YetiTool's UI for SmartBench
 www.yetitool.com
 
 #######################################################
-Z HEAD QC APPLICATION
+Z HEAD CYCLE QC JIG
 
 Used in production to carry out quality control checks. 
 #######################################################

--- a/src/z_head_qc_app.py
+++ b/src/z_head_qc_app.py
@@ -16,28 +16,10 @@ PLATFORM
 This app needs following platform changes to run
 as default application at startup: 
 
-sudo systemctl disable ansible.service
-
 touch /home/pi/YETI_ZHEADQC_PROD_JIG.txt
-
-sudo nano /boot/config.txt
-
-# Copy and paste to end of file: 
-
-        dtoverlay=pi3-disable-bt
-
-# Exit and save file
-
-sudo reboot
 
 #######################################################
 '''
-
-# try:
-#   from hanging_threads import start_monitoring
-#   monitoring_thread = start_monitoring(seconds_frozen=3, test_interval=100)
-# except:
-#   print("Could not import hanging_threads")
 
 from kivy.app import App
 from kivy.uix.screenmanager import ScreenManager, NoTransition


### PR DESCRIPTION
Platform has been changed so that pi now uses ttyAMA0 port as default, which makes some of the set up instructions obsolete. 