### PR TITLE
Overnight cal fix

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1540,7 +1540,7 @@ class OvernightTesting(Screen):
             self.poll_for_tuning_completion = Clock.schedule_interval(self.do_calibration, 5)
 
 
-    def do_calibration(self):
+    def do_calibration(self, dt):
 
         if not self.m.tuning_in_progress:
             Clock.unschedule(self.poll_for_tuning_completion)

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1536,7 +1536,7 @@ class OvernightTesting(Screen):
 
     def do_tuning(self):
         if not self.m.run_calibration and not self.m.tuning_in_progress:
-            self.m.tune_X_and_Z_for_calibration() # CHANGE ME
+            self.m.tune_X_Y_Z_for_calibration()
             self.poll_for_tuning_completion = Clock.schedule_interval(self.do_calibration, 5)
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
@@ -375,9 +375,12 @@ class UploadSerialNumbersScreen(Screen):
 
             self.error_label.text = "Uploading to ZH..."
 
-            Clock.schedule_once(lambda dt: self.m.upload_Y_calibration_settings_from_motor_classes(), 1)
+            # Need slight delay between each command as FW needs time to do each command
+            Clock.schedule_once(lambda dt: self.m.set_sgt_and_toff_calibrated_at_settings(TMC_Y1), 1)
+            Clock.schedule_once(lambda dt: self.m.set_sgt_and_toff_calibrated_at_settings(TMC_Y2), 2)
+            Clock.schedule_once(lambda dt: self.m.upload_Y_calibration_settings_from_motor_classes(), 3)
 
-            self.poll_for_end_of_upload = Clock.schedule_interval(self.report_info_back_to_user_and_return, 5)
+            self.poll_for_end_of_upload = Clock.schedule_interval(self.report_info_back_to_user_and_return, 10)
 
         except:
             self.error_label.text = "Could not get data"

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
@@ -375,12 +375,9 @@ class UploadSerialNumbersScreen(Screen):
 
             self.error_label.text = "Uploading to ZH..."
 
-            # Need slight delay between each command as FW needs time to do each command
-            Clock.schedule_once(lambda dt: self.m.set_sgt_and_toff_calibrated_at_settings(TMC_Y1), 1)
-            Clock.schedule_once(lambda dt: self.m.set_sgt_and_toff_calibrated_at_settings(TMC_Y2), 2)
-            Clock.schedule_once(lambda dt: self.m.upload_Y_calibration_settings_from_motor_classes(), 3)
+            Clock.schedule_once(lambda dt: self.m.upload_Y_calibration_settings_from_motor_classes(), 1)
 
-            self.poll_for_end_of_upload = Clock.schedule_interval(self.report_info_back_to_user_and_return, 10)
+            self.poll_for_end_of_upload = Clock.schedule_interval(self.report_info_back_to_user_and_return, 3)
 
         except:
             self.error_label.text = "Could not get data"

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2172,7 +2172,7 @@ class RouterMachine(object):
                         time.sleep(0.01)
 
                     # But don't measure the backwards fast jogs!
-                    elif self.feed_rate() > 303:
+                    elif self.feed_rate() > 430:
                         log('Feed rate too high, skipping')
                         self.s.record_sg_values_flag = False
                         self.temp_sg_array = []

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2758,10 +2758,10 @@ class RouterMachine(object):
                                 str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 3)) + ", " + \
                                 str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 4))
 
-
-                    log("Max Y axis SG values: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 2)))
-                    log("Max Y1 SG values: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 3)))
-                    log("Max Y2 SG values: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 4)))
+                    log(self.checking_calibration_fail_info)
+                    log("Y axis: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 2)))
+                    log("Y1: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 3)))
+                    log("Y2: " + str(self.get_abs_maximums_from_sg_array(self.temp_sg_array, 4)))
 
 
             if 'Z' in axes:

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2514,15 +2514,26 @@ class RouterMachine(object):
 
         self.calibration_upload_in_progress = True
         self.calibration_upload_fail_info = ''
-        Clock.schedule_once(lambda dt: self.initialise_calibration_upload('Z'), 0.5)
+        self.set_sgt_and_toff_calibrated_at_settings(TMC_Z)
+        Clock.schedule_once(lambda dt: self.initialise_calibration_upload('Z'), 1)
 
     def upload_Y_calibration_settings_from_motor_classes(self):
         self.calibration_upload_in_progress = True
         self.calibration_upload_fail_info = ''
-        Clock.schedule_once(lambda dt: self.initialise_calibration_upload('Y'), 0.5)
+        self.set_sgt_and_toff_calibrated_at_settings(TMC_Y1)
+        self.set_sgt_and_toff_calibrated_at_settings(TMC_Y2)
+        Clock.schedule_once(lambda dt: self.initialise_calibration_upload('Y'), 2)
 
 
     time_to_check_for_upload_prep = 0
+
+
+    def set_sgt_and_toff_calibrated_at_settings(self, motor_index):
+
+        display_text = "SET CALIBRATED AT FOR MOTOR " + str(motor_index) + ", "
+        self.send_command_to_motor(display_text + "SGT", motor = motor_index, command = SET_SGT, value = self.TMC_motor[int(motor_index)].calibrated_at_sgt_setting)
+        self.send_command_to_motor(display_text + "TOFF", motor = motor_index, command = SET_TOFF, value = self.TMC_motor[int(motor_index)].calibrated_at_toff_setting)
+
 
     def initialise_calibration_upload(self, axis):
 
@@ -2615,7 +2626,12 @@ class RouterMachine(object):
 
     def output_uploaded_coefficients(self):
         self.send_command_to_motor("OUTPUT CALIBRATION COEFFICIENTS", command=SET_CALIBR_MODE, value=4)
-        Clock.schedule_once(lambda dt: self.complete_calibration_upload(), 1)
+        Clock.schedule_once(lambda dt: self.output_registers_to_check(), 2)
+
+
+    def output_registers_to_check(self):
+        self.send_command_to_motor("GET REGISTERS", command=GET_REGISTERS)
+        Clock.schedule_once(lambda dt: self.complete_calibration_upload(), 2)
 
 
     def complete_calibration_upload(self):
@@ -2629,13 +2645,6 @@ class RouterMachine(object):
 
         else: 
             Clock.schedule_once(lambda dt: self.complete_calibration_upload(), 1)
-
-
-    def set_sgt_and_toff_calibrated_at_settings(self, motor_index):
-
-        display_text = "SET CALIBRATED AT FOR MOTOR " + str(motor_index) + ", "
-        self.send_command_to_motor(display_text + "SGT", motor = motor_index, command = SET_SGT, value = self.TMC_motor[int(motor_index)].calibrated_at_sgt_setting)
-        self.send_command_to_motor(display_text + "TOFF", motor = motor_index, command = SET_TOFF, value = self.TMC_motor[int(motor_index)].calibrated_at_toff_setting)
 
 
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2531,8 +2531,10 @@ class RouterMachine(object):
     def set_sgt_and_toff_calibrated_at_settings(self, motor_index):
 
         display_text = "SET CALIBRATED AT FOR MOTOR " + str(motor_index) + ", "
-        self.send_command_to_motor(display_text + "SGT", motor = motor_index, command = SET_SGT, value = self.TMC_motor[int(motor_index)].calibrated_at_sgt_setting)
-        self.send_command_to_motor(display_text + "TOFF", motor = motor_index, command = SET_TOFF, value = self.TMC_motor[int(motor_index)].calibrated_at_toff_setting)
+        sgt_val = self.TMC_motor[int(motor_index)].calibrated_at_sgt_setting
+        toff_val = self.TMC_motor[int(motor_index)].calibrated_at_toff_setting
+        self.send_command_to_motor(display_text + "SGT " + str(sgt_val), motor = motor_index, command = SET_SGT, value = sgt_val)
+        self.send_command_to_motor(display_text + "TOFF " + str(toff_val), motor = motor_index, command = SET_TOFF, value = toff_val)
 
 
     def initialise_calibration_upload(self, axis):

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1771,6 +1771,9 @@ class RouterMachine(object):
     # CALIBRATION AND TUNNING PROCEDURES
     #####################################################################
 
+    # IT IS ASSUMED THAT FUNCTIONS THAT TUNE/CALIBRATE JUST X AND Z OR JUST Y ARE FOR FREE MOTORS IN SPACE
+    # IT IS ASSUMED THAT FUNCTIONS THAT TUNE/CALIBRATE ALL THREE AXIS ARE DOING IT ON AN ASSEMBLED MACHINE, WITH ENGAGED MOTORS
+
     # CALL THESE FROM MAIN APP
 
     calibration_tuning_fail_info = ''
@@ -1797,6 +1800,16 @@ class RouterMachine(object):
         log("Jog to check SG values")
         self.tuning_jog_forwards_fast(X = False, Y = True, Z = False)
         self.check_SGs_rezero_and_go_to_next_checks_then_tune(X = False, Y = True, Z = False)
+
+    def tune_X_Y_Z_for_calibration(self):
+
+        self.tuning_in_progress = True
+        log("Tuning X Y and Z...")
+        self.prepare_for_tuning()
+        # THEN JOG AWAY AT MAX SPEED
+        log("Jog to check SG values")
+        self.tuning_jog_forwards_fast(X = True, Y = True, Z = True)
+        self.check_SGs_rezero_and_go_to_next_checks_then_tune(X = True, Y = True, Z = True)
 
     # QUERY THIS FLAG AFTER CALLING CALIBRATION FUNCTIONS, TO SEE IF CALIBRATION HAS FINISHED
     run_calibration = False

--- a/test/protocol_tests/calibration_tuning_tests.py
+++ b/test/protocol_tests/calibration_tuning_tests.py
@@ -56,7 +56,7 @@ class MotorCommandsTest(unittest.TestCase):
             status = "<Run|MPos:0.000,0.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ|WCO:-166.126,-213.609,-21.822|SG:-999,-20,15,-20,-2>"
 
         else:
-            status = "<Run|MPos:0.000,0.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ|WCO:-166.126,-213.609,-21.822|SG:-999,-1,-99,-20,-2>"
+            status = "<Run|MPos:0.000,0.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ|WCO:-166.126,-213.609,-21.822|SG:-999,-16,-15,-20,-2>"
 
         return status
 


### PR DESCRIPTION
- Sets TOFF and SGT parameters explicitly when data is downloaded from database and uploaded to Z Head
- Does tuning as part of the final test recalibration 