### PR TITLE
Prevent alarm between end of first part of final test and tuning

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1246,8 +1246,8 @@ class OvernightTesting(Screen):
 
             if self.poll_for_recalibration_stage != None: Clock.unschedule(self.poll_for_recalibration_stage)
             log("Start recalibration...")
-            self.jog_absolute_xy(self.x_min_jog_abs_limit + 2, self.y_min_jog_abs_limit + 2, 6000)
-            self.jog_absolute_single_axis('Z', self.z_max_jog_abs_limit - 2, 750)
+            self.m.jog_absolute_xy(self.m.x_min_jog_abs_limit + 2, self.m.y_min_jog_abs_limit + 2, 6000)
+            self.m.jog_absolute_single_axis('Z', self.m.z_max_jog_abs_limit - 2, 750)
             self.start_recalibration()
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1246,6 +1246,8 @@ class OvernightTesting(Screen):
 
             if self.poll_for_recalibration_stage != None: Clock.unschedule(self.poll_for_recalibration_stage)
             log("Start recalibration...")
+            self.jog_absolute_xy(self.x_min_jog_abs_limit + 2, self.y_min_jog_abs_limit + 2, 6000)
+            self.jog_absolute_single_axis('Z', self.z_max_jog_abs_limit - 2, 750)
             self.start_recalibration()
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1266,8 +1266,8 @@ class OvernightTesting(Screen):
         self.overnight_running = False
         self.stage = ""
         self.m.send_any_gcode_command('M3 S20000')
-        self.m.jog_absolute_xy(self.m.x_min_jog_abs_limit + 2, self.m.y_min_jog_abs_limit + 2, 6000)
-        self.m.jog_absolute_single_axis('Z', self.m.z_max_jog_abs_limit - 2, 750)
+        self.m.jog_absolute_xy(self.m.x_min_jog_abs_limit + 10, self.m.y_min_jog_abs_limit + 10, 6000)
+        self.m.jog_absolute_single_axis('Z', self.m.z_max_jog_abs_limit - 10, 750)
         self.stop_button.disabled = True
         self.start_tuning_event = Clock.schedule_once(self.do_tuning, 2)
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1900,6 +1900,11 @@ class RouterMachine(object):
         log("Prepare for tuning")
         self.calibration_tuning_fail_info = ''
 
+        log("Pos x: " + self.x_pos_str())
+        log("Pos y: " + self.y_pos_str())
+        log("Pos z: " + self.z_pos_str())
+
+
         self.s.write_command('$20=0')
 
         # Enable raw SG reporting: command REPORT_RAW_SG
@@ -2355,10 +2360,6 @@ class RouterMachine(object):
         self.calibration_tuning_fail_info = ''
 
         self.s.write_command('$20=0')
-
-        # self.s.write_command('$J=G53 X0 F6000')
-        # self.s.write_command('$J=G53 Y0 F6000')
-        # self.s.write_command('$J=G53 Z0 F750')
 
         log("Zero position")
         self.jog_absolute_xy(self.x_min_jog_abs_limit, self.y_min_jog_abs_limit, 6000)

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1910,7 +1910,7 @@ class RouterMachine(object):
         self.send_command_to_motor("REPORT RAW SG SET", command=REPORT_RAW_SG, value=1) # is there a way to check this has sent? 
         self.reset_tuning_flags()
 
-        sleep(0.5) # Is the report raw SG setting messing with jogs? Does putting in a delay fix things? 
+        time.sleep(0.5) # Is the report raw SG setting messing with jogs? Does putting in a delay fix things? 
 
         # Zero position
         log("Zero position")

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1910,8 +1910,6 @@ class RouterMachine(object):
         self.send_command_to_motor("REPORT RAW SG SET", command=REPORT_RAW_SG, value=1) # is there a way to check this has sent? 
         self.reset_tuning_flags()
 
-        time.sleep(0.5) # Is the report raw SG setting messing with jogs? Does putting in a delay fix things? 
-
         # Zero position
         log("Zero position")
         self.jog_absolute_xy(self.x_min_jog_abs_limit, self.y_min_jog_abs_limit, 6000)

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1904,13 +1904,13 @@ class RouterMachine(object):
         log("Pos y: " + self.y_pos_str())
         log("Pos z: " + self.z_pos_str())
 
-
         self.s.write_command('$20=0')
 
         # Enable raw SG reporting: command REPORT_RAW_SG
         self.send_command_to_motor("REPORT RAW SG SET", command=REPORT_RAW_SG, value=1) # is there a way to check this has sent? 
-
         self.reset_tuning_flags()
+
+        sleep(0.5) # Is the report raw SG setting messing with jogs? Does putting in a delay fix things? 
 
         # Zero position
         log("Zero position")


### PR DESCRIPTION
- For whatever reason, at end of final test, when the machine goes straight into the tuning, it would accelerate from a position very close to the end jog position, and then overshoot into the limits. 
- Bug wouldn't show if tuning & recal was started from button push, or if first part of final test goes straight into tuning. Might be some issue with processing other commands (e.g. REPORT RAW SET) causing a micro lag or something, not sure. 
- Anyway, moving SB away from it's landing position and then back fixes the problem!