### PR TITLE
correct board dimensions for FT2 screen, as per Dragos' request

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
@@ -224,8 +224,8 @@ class FinalTestScreen(Screen):
             self.x_board = 1150.3
 
         elif self.board_type == "blue":
-            self.y_board = 1637.9
-            self.x_board = 1149.2
+            self.y_board = 1636.9
+            self.x_board = 1149.1
 
         self.y_pos_command = "G91 G0 Y" + str(self.y_board)
         self.y_neg_command = "G91 G0 Y-" + str(self.y_board)


### PR DESCRIPTION
Brief: 
On FT B2 screen on final test could you do a correction for Y command; from y1637.9 to y1636.9. Thanks
And x1149.2 to x1149.1