### PR TITLE
Resets all checkboxes upon reconnection

### DIFF
--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
@@ -692,3 +692,10 @@ class ZHeadQC1(Screen):
 
     def enter_next_screen(self):
         self.sm.current = 'qc2'
+
+    def reset_checkboxes(self):
+        self.motor_chips_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.temp_voltage_power_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.x_home_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.bake_grbl_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.x_max_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_2.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_2.py
@@ -441,3 +441,8 @@ class ZHeadQC2(Screen):
 
     def set_spindle_analogue(self):
         self.m.s.write_command('$51 = 0')
+
+    def reset_checkboxes(self):
+        self.digital_spindle_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.probe_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.spindle_speed_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
@@ -91,6 +91,10 @@ class ZHeadQC8(Screen):
             Clock.schedule_once(self.back_to_start, 2)
 
     def back_to_start(self, dt):
+        self.sm.get_screen('qc1').reset_checkboxes()
+        self.sm.get_screen('qc2').reset_checkboxes()
+        self.sm.get_screen('qcW136').reset_checkboxes()
+        self.sm.get_screen('qcW112').reset_checkboxes()
         self.sm.current = 'qchome'
         self.connect_button.text = 'Connect and Restart'
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
@@ -759,6 +759,13 @@ class ZHeadQCWarrantyAfterApr21(Screen):
             popup_z_head_qc.PopupFWUpdateDiagnosticsInfo(self.sm, did_fw_update_succeed, str(self.stdout))
             self.test_fw_update_button.text = "  19. Test FW Update"
 
+            self.sm.get_screen('qc1').reset_checkboxes()
+            self.sm.get_screen('qc2').reset_checkboxes()
+            self.sm.get_screen('qcW136').reset_checkboxes()
+            self.sm.get_screen('qcW112').reset_checkboxes()
+            Clock.unschedule(self.poll_for_temps_power)
+            self.poll_for_temps_power = Clock.schedule_interval(self.temp_power_check, TEMP_POWER_POLL)
+
         disconnect_and_update()
 
     def update_status_text(self, dt):
@@ -773,3 +780,11 @@ class ZHeadQCWarrantyAfterApr21(Screen):
 
     def stop(self):
         popup_info.PopupStop(self.m, self.sm, self.l)
+
+    def reset_checkboxes(self):
+        self.temp_voltage_power_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.x_home_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.x_max_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.spindle_speed_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.z_home_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.probe_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
@@ -559,6 +559,11 @@ class ZHeadQCWarrantyBeforeApr21(Screen):
             popup_z_head_qc.PopupFWUpdateDiagnosticsInfo(self.sm, did_fw_update_succeed, str(self.stdout))
             self.test_fw_update_button.text = '  17. Test FW Update'
 
+            self.sm.get_screen('qc1').reset_checkboxes()
+            self.sm.get_screen('qc2').reset_checkboxes()
+            self.sm.get_screen('qcW136').reset_checkboxes()
+            self.sm.get_screen('qcW112').reset_checkboxes()
+
         disconnect_and_update()
 
 
@@ -571,3 +576,9 @@ class ZHeadQCWarrantyBeforeApr21(Screen):
 
     def back_to_choice(self):
         self.sm.current = 'qcWC'
+
+    def reset_checkboxes(self):
+        self.x_home_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.x_max_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.z_home_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"
+        self.probe_check.source = "./asmcnc/skavaUI/img/checkbox_inactive.png"

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
@@ -146,6 +146,11 @@ class ZHeadQCHome(Screen):
             popup_z_head_qc.PopupFWUpdateDiagnosticsInfo(self.sm, did_fw_update_succeed, str(self.stdout))
             self.update_usb_button_label()
 
+            self.sm.get_screen('qc1').reset_checkboxes()
+            self.sm.get_screen('qc2').reset_checkboxes()
+            self.sm.get_screen('qcW136').reset_checkboxes()
+            self.sm.get_screen('qcW112').reset_checkboxes()
+
         disconnect_and_update()
 
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
@@ -159,6 +159,10 @@ class ZHeadWarrantyChoice(Screen):
             Clock.unschedule(self.poll_for_reconnection)
             Clock.schedule_once(self.m.s.start_services, 1)
             self.connection_button.text = "Disconnect Z Head"
+            self.sm.get_screen('qc1').reset_checkboxes()
+            self.sm.get_screen('qc2').reset_checkboxes()
+            self.sm.get_screen('qcW136').reset_checkboxes()
+            self.sm.get_screen('qcW112').reset_checkboxes()
 
 
     def toggle_usb_mounted(self):


### PR DESCRIPTION
Every screen that has a checkbox now has an additional function called reset_checkboxes which clears ticks and crosses, and is called every time serial connection is reconnected