### PR TITLE
Reset calibration timer when reconnecting z head

### DIFF
--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_3.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_3.py
@@ -40,7 +40,7 @@ Builder.load_string("""
             
             Label:
                 id: calibrate_time
-                text: '00:30:00'
+                text: '0:30:00'
                 font_size: dp(50)
 
 """)
@@ -84,20 +84,27 @@ class ZHeadQC3(Screen):
         seconds = time_left
 
         def count_down(seconds):
-            if seconds == 0:
-                if self.sm.current == self.name:
-                    self.sm.current = 'qc4'
-                    return
-            
-            if seconds > 0:
-                seconds -= 1
-                self.seconds = seconds
+            if self.timer_started:
+                if seconds == 0:
+                    if self.sm.current == self.name:
+                        self.sm.current = 'qc4'
+                        return
+                
+                if seconds > 0:
+                    seconds -= 1
+                    self.seconds = seconds
 
-            self.calibrate_time.text = str(datetime.timedelta(seconds=seconds))
+                self.calibrate_time.text = str(datetime.timedelta(seconds=seconds))
 
-            Clock.schedule_once(lambda dt: count_down(seconds), 1)
+                Clock.schedule_once(lambda dt: count_down(seconds), 1)
 
         Clock.schedule_once(lambda dt: count_down(seconds), 0)
 
     def enter_prev_screen(self):
         self.sm.current = 'qc2'
+
+    def reset_timer(self):
+        self.seconds = self.one_minute * 30
+        self.timer_started = False
+        self.user_text.text = "Getting ready..."
+        self.calibrate_time.text = '0:30:00'

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
@@ -95,6 +95,7 @@ class ZHeadQC8(Screen):
         self.sm.get_screen('qc2').reset_checkboxes()
         self.sm.get_screen('qcW136').reset_checkboxes()
         self.sm.get_screen('qcW112').reset_checkboxes()
+        self.sm.get_screen('qc3').reset_timer()
         self.sm.current = 'qcconnecting'
         self.connect_button.text = 'Connect and Restart'
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
@@ -763,6 +763,7 @@ class ZHeadQCWarrantyAfterApr21(Screen):
             self.sm.get_screen('qc2').reset_checkboxes()
             self.sm.get_screen('qcW136').reset_checkboxes()
             self.sm.get_screen('qcW112').reset_checkboxes()
+            self.sm.get_screen('qc3').reset_timer()
             Clock.unschedule(self.poll_for_temps_power)
             self.poll_for_temps_power = Clock.schedule_interval(self.temp_power_check, TEMP_POWER_POLL)
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
@@ -563,6 +563,7 @@ class ZHeadQCWarrantyBeforeApr21(Screen):
             self.sm.get_screen('qc2').reset_checkboxes()
             self.sm.get_screen('qcW136').reset_checkboxes()
             self.sm.get_screen('qcW112').reset_checkboxes()
+            self.sm.get_screen('qc3').reset_timer()
 
         disconnect_and_update()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
@@ -150,6 +150,7 @@ class ZHeadQCHome(Screen):
             self.sm.get_screen('qc2').reset_checkboxes()
             self.sm.get_screen('qcW136').reset_checkboxes()
             self.sm.get_screen('qcW112').reset_checkboxes()
+            self.sm.get_screen('qc3').reset_timer()
 
         disconnect_and_update()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
@@ -163,6 +163,7 @@ class ZHeadWarrantyChoice(Screen):
             self.sm.get_screen('qc2').reset_checkboxes()
             self.sm.get_screen('qcW136').reset_checkboxes()
             self.sm.get_screen('qcW112').reset_checkboxes()
+            self.sm.get_screen('qc3').reset_timer()
 
 
     def toggle_usb_mounted(self):


### PR DESCRIPTION
Whenever z head reconnection is performed, an additional function reset_timer is called which resets the calibration timer on z_head_qc_3 back to 30 minutes and stops the current countdown, so that a new countdown can be started when the screen is entered again.