### PR TITLE
Set Z current to 25 when v1.3 Z Heads are plugged into QC jig

### DIFF
--- a/src/asmcnc/comms/motors.py
+++ b/src/asmcnc/comms/motors.py
@@ -6,11 +6,16 @@ from asmcnc.comms.yeti_grbl_protocol.c_defines import *
 
 class motor_class(object):
 
-    got_registers              = False # this will update the first time that registers are read in
+    got_registers = False # this will update the first time that registers are read in
 
     def __init__(self, given_index):
 
         self.index = given_index # index of this motor in "all_units" dictionary
+        self.reset_registers()
+
+    def reset_registers(self):
+
+        self.got_registers = False
 
         # REGISTERS
         self.shadowRegisters         = [0,0,0,0,0]    

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -170,12 +170,16 @@ class RouterMachine(object):
         if self.s.is_connected():
             self.s.s.close()
         self.clear_motor_registers()
+        self.s.fw_version = ''
+        self.s.hw_version = ''
         self.s.establish_connection(self.win_serial_port)
 
     def close_serial_connection(self, dt):
         if self.s.is_connected():
             self.s.s.close()
         self.clear_motor_registers()
+        self.s.fw_version = ''
+        self.s.hw_version = ''
 
 # PERSISTENT MACHINE VALUES
     def check_presence_of_sb_values_files(self):

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -167,11 +167,7 @@ class RouterMachine(object):
 
     # CREATE/DESTROY SERIAL CONNECTION (for cycle app)
     def reconnect_serial_connection(self):
-        if self.s.is_connected():
-            self.s.s.close()
-        self.clear_motor_registers()
-        self.s.fw_version = ''
-        self.s.hw_version = ''
+        self.close_serial_connection(0)
         self.s.establish_connection(self.win_serial_port)
 
     def close_serial_connection(self, dt):

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -169,11 +169,13 @@ class RouterMachine(object):
     def reconnect_serial_connection(self):
         if self.s.is_connected():
             self.s.s.close()
+        self.clear_motor_registers()
         self.s.establish_connection(self.win_serial_port)
 
     def close_serial_connection(self, dt):
         if self.s.is_connected():
             self.s.s.close()
+        self.clear_motor_registers()
 
 # PERSISTENT MACHINE VALUES
     def check_presence_of_sb_values_files(self):
@@ -957,6 +959,8 @@ class RouterMachine(object):
     handshake_event = None
 
     def tmc_handshake(self):
+
+        self.clear_motor_registers()
 
         if self.s.fw_version and self.state().startswith('Idle'):
 
@@ -2839,11 +2843,34 @@ class RouterMachine(object):
                 time.sleep(0.5)
 
             self.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
-            time.sleep(0.5)
+            time.sleep(1)
             self.tmc_handshake()
-            time.sleep(0.5)
+            time.sleep(1)
             return True
 
         else:
             return False
+
+
+    def clear_motor_registers(self):
+
+        self.TMC_motor[TMC_X1].reset_registers()
+        self.TMC_motor[TMC_X2].reset_registers()
+        self.TMC_motor[TMC_Y1].reset_registers()
+        self.TMC_motor[TMC_Y2].reset_registers()
+        self.TMC_motor[TMC_Z].reset_registers()
+
+
+    def TMC_registers_have_been_read_in(self):
+
+        if not self.TMC_motor[TMC_X1].got_registers: return False
+        if not self.TMC_motor[TMC_X2].got_registers: return False
+        if not self.TMC_motor[TMC_Y1].got_registers: return False
+        if not self.TMC_motor[TMC_Y2].got_registers: return False
+        if not self.TMC_motor[TMC_Z].got_registers: return False
+        return True
+
+
+
+
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -52,11 +52,12 @@ class ZHeadQCConnecting(Screen):
         self.sm = kwargs['sm']
         self.m = kwargs['m']
         self.connecting_label.text = "Connecting to Z Head..."
-        self.current = 26
+        self.current = 25
 
     def on_enter(self):
 
         log("Set Z current to 25 if it is not set already...")
+        self.connecting_label.text = "Connecting to Z Head..."
         self.get_and_set_current()
 
     

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -81,7 +81,6 @@ class ZHeadQCConnecting(Screen):
             Clock.schedule_once(lambda dt: self.get_and_set_current(), 0.5)
             return
 
-        # If current is already set to 22, carry onto QC home
         if not self.m.is_machines_fw_version_equal_to_or_greater_than_version('2.2.8', 'setting current'):
             self.progress_to_next_screen()
             return

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -52,7 +52,7 @@ class ZHeadQCConnecting(Screen):
         self.sm = kwargs['sm']
         self.m = kwargs['m']
         self.connecting_label.text = "Connecting to Z Head..."
-        self.current = 25
+        self.current = 26
 
     def on_enter(self):
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -58,7 +58,6 @@ class ZHeadQCConnecting(Screen):
 
         log("Set Z current to 25 if it is not set already...")
     	self.get_and_set_current()
-        self.progress_to_next_screen()
 
     
     def progress_to_next_screen(self):

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -52,7 +52,7 @@ class ZHeadQCConnecting(Screen):
         self.sm = kwargs['sm']
         self.m = kwargs['m']
         self.connecting_label.text = "Connecting to Z Head..."
-        self.current = 31
+        self.current = 25
 
     def on_enter(self):
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -52,7 +52,7 @@ class ZHeadQCConnecting(Screen):
         self.sm = kwargs['sm']
         self.m = kwargs['m']
         self.connecting_label.text = "Connecting to Z Head..."
-        self.current = 25
+        self.current = 31
 
     def on_enter(self):
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -52,14 +52,12 @@ class ZHeadQCConnecting(Screen):
         self.sm = kwargs['sm']
         self.m = kwargs['m']
         self.connecting_label.text = "Connecting to Z Head..."
-        self.current = 22
+        self.current = 25
 
     def on_enter(self):
 
-     #    log("Set X current to 22 if it is not set already...")
-    	# self.get_and_set_current()
-
-        log("Would set current here, but leave as default for now")
+        log("Set Z current to 25 if it is not set already...")
+    	self.get_and_set_current()
         self.progress_to_next_screen()
 
     
@@ -76,13 +74,13 @@ class ZHeadQCConnecting(Screen):
     		return
 
     	# If current is already set to 22, carry onto QC home
-    	if 	self.m.TMC_motor[TMC_X1].ActiveCurrentScale == self.current or \
+    	if 	self.m.TMC_motor[TMC_Z].ActiveCurrentScale == self.current or \
     		not self.m.is_machines_fw_version_equal_to_or_greater_than_version('2.2.8', 'setting current'):
 
     		self.progress_to_next_screen()
     		return
 
-    	elif self.m.TMC_motor[TMC_X1].ActiveCurrentScale == 0:
+    	elif self.m.TMC_motor[TMC_Z].ActiveCurrentScale == 0:
 
     		Clock.schedule_once(lambda dt: self.get_and_set_current(), 1)
     		return
@@ -90,7 +88,7 @@ class ZHeadQCConnecting(Screen):
     	else:
 			
 			self.connecting_label.text = "Setting current..."
-			if self.m.set_motor_current("X", self.current): Clock.schedule_once(lambda dt: self.progress_to_next_screen(), 0.5)
+			if self.m.set_motor_current("Z", self.current): Clock.schedule_once(lambda dt: self.progress_to_next_screen(), 0.5)
 			else: Clock.schedule_once(lambda dt: self.get_and_set_current(), 1) # If unsuccessful it's because it's not Idle
 
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
@@ -164,7 +164,7 @@ class ZHeadWarrantyChoice(Screen):
             self.sm.get_screen('qcW136').reset_checkboxes()
             self.sm.get_screen('qcW112').reset_checkboxes()
             self.sm.get_screen('qc3').reset_timer()
-
+            self.sm.current = 'qcconnecting'
 
     def toggle_usb_mounted(self):
 

--- a/test/automated_tests/test_router_machine_units.py
+++ b/test/automated_tests/test_router_machine_units.py
@@ -1,0 +1,50 @@
+'''
+Created on 1 Aug 2022
+@author: Letty
+'''
+
+import sys
+sys.path.append('./src')
+
+try: 
+    import unittest
+    import pytest
+    from mock import Mock, MagicMock
+
+except: 
+    print("Can't import mocking packages, are you on a dev machine?")
+
+
+from asmcnc.comms import router_machine
+from asmcnc.comms import localization
+from datetime import datetime
+
+'''
+######################################
+RUN FROM easycut-smartbench FOLDER WITH: 
+python -m pytest --show-capture=no --disable-pytest-warnings test/automated_tests/test_router_machine_units.py
+######################################
+'''
+
+# FIXTURES
+@pytest.fixture
+def m():
+    l = localization.Localization()
+
+    screen_manager = Mock()
+    settings_manager = Mock()
+    job = Mock()
+    m = router_machine.RouterMachine("COM", screen_manager, settings_manager, l, job)
+    m.s.next_poll_time = 0
+    m.s.write_direct = Mock()
+    m.s.s = MagicMock()
+    m.clear_motor_registers = Mock()
+    return m
+
+def test_close_serial_connection(m):
+    m.close_serial_connection(0)
+    m.clear_motor_registers.assert_called()
+
+def test_reconnect_serial_connection(m):
+    m.reconnect_serial_connection()
+    m.clear_motor_registers.assert_called()


### PR DESCRIPTION
- Also ensured that registers and FW/HW versions are cleared/reset when serial is disconnected and reconnected (as Z Head will change) 
- Ensure that "Z Head connecting" screen (which also sets the current) comes up after reconnection called from warranty screen as well as after full QC