### PR TITLE
Stall jig change threshold

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -1529,7 +1529,7 @@ class StallJigScreen(Screen):
 
         log("SB has either completed its move command, or it has detected that a limit has been reached!")
         self.test_passed = self.determine_test_result(expected_pos)
-        self.back_off_and_find_position()
+        if self.test_passed is not None: self.back_off_and_find_position()
 
     ## WORK OUT AND DELIVER TEST RESULTS
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -190,7 +190,7 @@ def log(message):
 
 class StallJigScreen(Screen):
 
-    dev_mode = True
+    dev_mode = False
 
     # ALL NUMBERS ARE DECLARED HERE, SO THAT THEY CAN BE EASILY EDITED AS/WHEN REQUIRED
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -190,7 +190,7 @@ def log(message):
 
 class StallJigScreen(Screen):
 
-    dev_mode = False
+    dev_mode = True
 
     # ALL NUMBERS ARE DECLARED HERE, SO THAT THEY CAN BE EASILY EDITED AS/WHEN REQUIRED
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -266,8 +266,6 @@ class StallJigScreen(Screen):
 
     }
 
-    threshold_index_modifier = 0
-
 
     minimum_threshold_index = {
 
@@ -1635,12 +1633,11 @@ class StallJigScreen(Screen):
 
     def go_to_next_axis(self):
 
-        self.threshold_index_modifier = 0
-
         if self.indices["axis"] + 1 < len(self.axes):
             self.indices["axis"] = self.indices["axis"] + 1
             self.indices["feed"] = 0
             self.indices["threshold"] = 0
+            self.travel_to_stall_pos[self.current_axis()] = None
 
             log("Next feed index: " + str(self.indices["feed"]))
             log("Next threshold index: " + str(self.indices["threshold"]))


### PR DESCRIPTION
- Give user the ability to change the minimum threshold if they want (NB: currently, this will not change the minimum threshold used to set the travel (i.e. the first crash to find stall position))
- Minor bug fix: if axis has already been tested, and is being retested after a previous axis, reset the travel_to_stall_pos to none (this ensures that the next part of the test knows the axis has changed).
- Minor bug fix: If there is no detect or overshoot of position, don't auto-start back off 