### PR TITLE
Stall jig: detect false stalls

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -1244,6 +1244,7 @@ class StallJigScreen(Screen):
         if self.threshold_reached:
 
             self.false_stall_happened = True
+            self.threshold_reached = False
             if self.VERBOSE: log("FALSE STALL DETECTED!! Temporarily increasing threshold")
             self.result_label.text = "FALSE STALL"
             self.result_label.background_color = self.highlight_yellow

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -350,8 +350,8 @@ class StallJigScreen(Screen):
     back_off = {
 
         "X": -430,  #  -400, 
-        "Y": -100,   #  -70,
-        "Z": 80     #  76
+        "Y": -120,   #  -70,
+        "Z": 100     #  76
 
     }
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -1329,7 +1329,8 @@ class StallJigScreen(Screen):
             log("Axis set up")
             self.setting_up_axis_for_test = False
 
-        elif self.false_stall_happened: 
+        elif self.false_stall_happened:
+            self.false_stall_happened = False 
             log("False stall happened - test failed")
             self.colour_current_grid_button(self.fail_orange)
             self.go_to_next_threshold()

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -1064,6 +1064,8 @@ class StallJigScreen(Screen):
 
         self.test_passed = False
         self.threshold_reached = False
+        self.false_stall_happened = False
+        self.expected_limit_found = False
         self.result_label.text = ""
         self.result_label.background_color = [0,0,0,1]
 
@@ -1330,7 +1332,7 @@ class StallJigScreen(Screen):
             self.setting_up_axis_for_test = False
 
         elif self.false_stall_happened:
-            self.false_stall_happened = False 
+            self.false_stall_happened = False
             log("False stall happened - test failed")
             self.colour_current_grid_button(self.fail_orange)
             self.go_to_next_threshold()

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -455,6 +455,7 @@ class StallJigScreen(Screen):
 
     ## COLOURS: 
 
+    false_stall_amber = [245./255, 183./255, 23./255, 1]
     fail_orange = [245./255, 127./255, 23./255, 1]
     pass_green = [0./255, 204./255, 51./255, 1]
     bright_pass_green = [51./255, 255./255, 0./255, 1]
@@ -1249,7 +1250,7 @@ class StallJigScreen(Screen):
             self.threshold_reached = False
             if self.VERBOSE: log("FALSE STALL DETECTED!! Temporarily increasing threshold")
             self.result_label.text = "FALSE STALL"
-            self.result_label.background_color = self.highlight_yellow
+            self.result_label.background_color = self.false_stall_amber
             self.test_status_label.text = "REFIND POS"
             self.m.set_threshold_for_axis(self.current_axis(), 300) # set the threshold high so that it completes the move
             self.poll_to_start_back_off = Clock.schedule_once(lambda dt: self.back_off_and_find_position(), 1)
@@ -1331,10 +1332,10 @@ class StallJigScreen(Screen):
             log("Axis set up")
             self.setting_up_axis_for_test = False
 
-        elif self.false_stall_happened:
+        elif self.false_stall_happened and self.test_passed:
             self.false_stall_happened = False
             log("False stall happened - test failed")
-            self.colour_current_grid_button(self.fail_orange)
+            self.colour_current_grid_button(self.false_stall_amber)
             self.go_to_next_threshold()
 
         elif self.test_passed:

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -190,7 +190,7 @@ def log(message):
 
 class StallJigScreen(Screen):
 
-    dev_mode = True
+    dev_mode = False
 
     # ALL NUMBERS ARE DECLARED HERE, SO THAT THEY CAN BE EASILY EDITED AS/WHEN REQUIRED
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -427,7 +427,6 @@ class StallJigScreen(Screen):
     poll_to_finish_procedure = None           
     data_send_event = None                    
     resume_from_alarm_event = None            
-    threshold_reached = None
     poll_to_deenergize_motors = None
     poll_to_energize_motors = None
     poll_to_reenable_hard_limits_and_go_to_next_test = None
@@ -556,7 +555,6 @@ class StallJigScreen(Screen):
         self.unschedule_event_if_it_exists(self.poll_to_finish_procedure)
         self.unschedule_event_if_it_exists(self.data_send_event)
         self.unschedule_event_if_it_exists(self.resume_from_alarm_event)
-        self.unschedule_event_if_it_exists(self.threshold_reached)
         self.unschedule_event_if_it_exists(self.poll_to_deenergize_motors)
         self.unschedule_event_if_it_exists(self.poll_to_energize_motors)
         self.unschedule_event_if_it_exists(self.poll_to_reenable_hard_limits_and_go_to_next_test)
@@ -1555,6 +1553,7 @@ class StallJigScreen(Screen):
     def test_did_pass(self):
 
         log("TEST PASSED")
+        self.threshold_reached = False
         self.result_label.text = "THRESHOLD REACHED"
         self.result_label.background_color = self.bright_pass_green
         self.test_status_label.text = "PASS"
@@ -1563,6 +1562,7 @@ class StallJigScreen(Screen):
     def test_did_fail(self):
 
         log("TEST FAILED")
+        self.threshold_reached = False
         self.result_label.text = "THRESHOLD NOT REACHED"
         self.result_label.background_color = self.fail_orange
         self.test_status_label.text = "TEST FAILED"

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -190,7 +190,7 @@ def log(message):
 
 class StallJigScreen(Screen):
 
-    dev_mode = False
+    dev_mode = True
 
     # ALL NUMBERS ARE DECLARED HERE, SO THAT THEY CAN BE EASILY EDITED AS/WHEN REQUIRED
 


### PR DESCRIPTION
- If SmartBench stalls on the way back to a limit switch (i.e. when it's not supposed to), register this as a false stall and automatically resume the test. 
- If a false stall is detected, that counts as a test fail, and therefore the result is not logged in the database. 