### PR TITLE
Job recovery redo

### DIFF
--- a/src/asmcnc/apps/shapeCutter_app/screen_manager_shapecutter.py
+++ b/src/asmcnc/apps/shapeCutter_app/screen_manager_shapecutter.py
@@ -995,6 +995,7 @@ class ScreenManagerShapeCutter(object):
         self.jd.job_gcode = self.j.gcode_lines
         self.jd.filename  = self.j.gcode_filename
         self.jd.job_name = self.j.gcode_job_name
+        self.jd.job_recovery_skip_recovery = True # No recovery for shapecutter
         
         def auto_go(dt):
             self.sm.get_screen('go').start_or_pause_button_press()

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -579,7 +579,8 @@ class SerialConnection(object):
                     self.update_machine_runtime()
                     self.sm.current = 'job_feedback'
 
-                self.jd.write_to_recovery_file_after_completion()
+                if not self.jd.job_recovery_skip_recovery:
+                    self.jd.write_to_recovery_file_after_completion()
 
             else:
                 self.check_streaming_started = False
@@ -614,7 +615,8 @@ class SerialConnection(object):
             # g_count represents the number of OKs issued by grbl which are sent when a line enters the line buffer
             # The line buffer has a capacity of 35 lines
             # So the currently executing command is the one 35 lines before the last one received by the buffer
-            self.jd.write_to_recovery_file_after_cancel(self.g_count - 35)
+            if not self.jd.job_recovery_skip_recovery:
+                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35)
 
             # Update time for maintenance reminders
             time.sleep(0.4)

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -285,7 +285,7 @@ class SerialConnection(object):
     # "Push" is for messages from GRBL to provide more general feedback on what Grbl is doing (e.g. status)
 
     VERBOSE_ALL_PUSH_MESSAGES = False
-    VERBOSE_ALL_RESPONSE = True
+    VERBOSE_ALL_RESPONSE = False
     VERBOSE_STATUS = False
 
 

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -579,6 +579,8 @@ class SerialConnection(object):
                     self.update_machine_runtime()
                     self.sm.current = 'job_feedback'
 
+                self.jd.write_to_recovery_file_after_completion()
+
             else:
                 self.check_streaming_started = False
                 self.m.disable_check_mode()
@@ -591,9 +593,6 @@ class SerialConnection(object):
 
         self.jd.job_gcode_running = []
         self.jd.percent_thru_job = 100
-        # Check if job recovery has been completed
-        if self.jd.job_recovery_filepath == self.jd.filename:
-            self.jd.clear_recovery_file()
 
     def cancel_stream(self):
 
@@ -615,7 +614,7 @@ class SerialConnection(object):
             # g_count represents the number of OKs issued by grbl which are sent when a line enters the line buffer
             # The line buffer has a capacity of 35 lines
             # So the currently executing command is the one 35 lines before the last one received by the buffer
-            self.jd.write_to_recovery_file(self.g_count - 35)
+            self.jd.write_to_recovery_file_after_cancel(self.g_count - 35)
 
             # Update time for maintenance reminders
             time.sleep(0.4)

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -84,6 +84,7 @@ class JobData(object):
     job_recovery_selected_line = -1
     job_recovery_gcode = []
     job_recovery_offset = 0 # How many lines the software added to the start of the file
+    job_recovery_from_beginning = False
 
     def __init__(self, **kwargs):
         self.l = kwargs['localization']
@@ -167,6 +168,9 @@ class JobData(object):
         self.feeds_speeds_and_boundaries_string = ''
         self.check_info_string = ''    
         self.comments_string = ''
+
+        self.job_recovery_from_beginning = False
+        self.reset_recovery()
 
     def set_job_filename(self, job_path_and_name):
 

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -423,15 +423,17 @@ class JobData(object):
             # Account for number of lines added in by the software when running file
             cancel_line -= self.job_recovery_offset
 
-            with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
-                job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
+            # If job was cancelled before it started, no need to store recovery info
+            if cancel_line >= 0:
 
-            # Simultaneously update variables
-            self.job_recovery_filepath = self.filename
-            self.job_recovery_cancel_line = cancel_line
-            self.job_recovery_selected_line = -1
-            self.job_recovery_gcode = []
-            self.job_recovery_offset = 0
+                with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
+                    job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
+
+                # Simultaneously update variables
+                self.job_recovery_filepath = self.filename
+                self.job_recovery_cancel_line = cancel_line
+
+            self.reset_recovery()
         
         except:
             print("Could not write recovery info")
@@ -448,9 +450,7 @@ class JobData(object):
             # Simultaneously update variables
             self.job_recovery_filepath = self.filename
             self.job_recovery_cancel_line = cancel_line
-            self.job_recovery_selected_line = -1
-            self.job_recovery_gcode = []
-            self.job_recovery_offset = 0
+            self.reset_recovery()
         
         except:
             print("Could not write recovery info")

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -80,7 +80,7 @@ class JobData(object):
     # Job recovery
     job_recovery_info_filepath = './asmcnc/job/job_recovery.txt'
     job_recovery_filepath = ''
-    job_recovery_cancel_line = 0
+    job_recovery_cancel_line = None
     job_recovery_selected_line = -1
     job_recovery_gcode = []
     job_recovery_offset = 0 # How many lines the software added to the start of the file
@@ -414,11 +414,10 @@ class JobData(object):
             print("Could not read recovery info")
             print(str(traceback.format_exc()))
 
-    def write_to_recovery_file(self, cancel_line):
+    def write_to_recovery_file_after_cancel(self, cancel_line):
         try:
             # Account for number of lines added in by the software when running file
             cancel_line -= self.job_recovery_offset
-            self.job_recovery_offset = 0
 
             with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
                 job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
@@ -434,19 +433,23 @@ class JobData(object):
             print("Could not write recovery info")
             print(str(traceback.format_exc()))
 
-    def clear_recovery_file(self):
+    def write_to_recovery_file_after_completion(self):
         try:
-            open(self.job_recovery_info_filepath, 'w').close()
+            # Cancel on line -1 represents last job completing successfully
+            cancel_line = -1
+
+            with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
+                job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
 
             # Simultaneously update variables
-            self.job_recovery_filepath = ''
-            self.job_recovery_cancel_line = 0
+            self.job_recovery_filepath = self.filename
+            self.job_recovery_cancel_line = cancel_line
             self.job_recovery_selected_line = -1
             self.job_recovery_gcode = []
             self.job_recovery_offset = 0
         
         except:
-            print("Could not clear recovery info")
+            print("Could not write recovery info")
             print(str(traceback.format_exc()))
 
 

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -85,6 +85,7 @@ class JobData(object):
     job_recovery_gcode = []
     job_recovery_offset = 0 # How many lines the software added to the start of the file
     job_recovery_from_beginning = False
+    job_recovery_skip_recovery = False
 
     def __init__(self, **kwargs):
         self.l = kwargs['localization']
@@ -170,6 +171,7 @@ class JobData(object):
         self.comments_string = ''
 
         self.job_recovery_from_beginning = False
+        self.job_recovery_skip_recovery = False
         self.reset_recovery()
 
     def set_job_filename(self, job_path_and_name):

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -177,6 +177,8 @@ class LoadingScreen(Screen):
 
     default_font_size = '30sp'
 
+    skip_check_decision = False
+
     continuing_to_recovery = False
 
     def __init__(self, **kwargs):
@@ -419,6 +421,10 @@ class LoadingScreen(Screen):
                 self.sm.get_screen('homing_decision').return_to_screen = 'job_recovery'
                 self.sm.get_screen('homing_decision').cancel_to_screen = 'job_recovery'
                 self.sm.current = 'homing_decision'
+
+            if self.skip_check_decision:
+                self.skip_check_decision = False
+                self.quit_to_home()
 
             self.progress_value = self.l.get_bold('Job loaded')
             self.warning_body_label.text = (

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -414,6 +414,8 @@ class LoadingScreen(Screen):
         if stage == 'Loaded':
             if self.continuing_to_recovery:
                 self.continuing_to_recovery = False
+                self.jd.checked = False
+                self.sm.get_screen('home').z_datum_reminder_flag = True
                 self.sm.get_screen('homing_decision').return_to_screen = 'job_recovery'
                 self.sm.get_screen('homing_decision').cancel_to_screen = 'job_recovery'
                 self.sm.current = 'homing_decision'

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -176,7 +176,9 @@ class LoadingScreen(Screen):
     usb_status = None
 
     default_font_size = '30sp'
-    
+
+    continuing_to_recovery = False
+
     def __init__(self, **kwargs):
         super(LoadingScreen, self).__init__(**kwargs)
         self.sm=kwargs['screen_manager']
@@ -185,7 +187,7 @@ class LoadingScreen(Screen):
         self.l=kwargs['localization']
 
 
-    def on_enter(self):    
+    def on_pre_enter(self):    
 
         # display file selected in the filename display label
         self.filename_label.text = self.jd.job_name
@@ -410,6 +412,12 @@ class LoadingScreen(Screen):
             self.progress_value = self.l.get_str('Analysing file') + ': ' + str(percentage_progress) + ' %'
 
         if stage == 'Loaded':
+            if self.continuing_to_recovery:
+                self.continuing_to_recovery = False
+                self.sm.get_screen('homing_decision').return_to_screen = 'job_recovery'
+                self.sm.get_screen('homing_decision').cancel_to_screen = 'job_recovery'
+                self.sm.current = 'homing_decision'
+
             self.progress_value = self.l.get_bold('Job loaded')
             self.warning_body_label.text = (
                 self.l.get_bold('WARNING') + '[b]:[/b]\n' + \

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -341,20 +341,6 @@ class HomeScreen(Screen):
             except:
                 log('Unable to preview file')
 
-            # Check if job recovery is available
-            if self.jd.job_recovery_cancel_line > 0 and self.jd.job_recovery_filepath == self.jd.filename:
-                self.job_recovery_button.disabled = False
-                self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job.png"
-
-                # Line -1 being selected represents no selected line
-                if self.jd.job_recovery_selected_line == -1:
-                    self.file_data_label.text += "\n[color=FF0000]Restart from beginning[/color]"
-                else:
-                    self.file_data_label.text += "\n[color=FF0000]From line " + str(self.jd.job_recovery_selected_line) + "[/color]"
-            else:
-                self.job_recovery_button.disabled = True
-                self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job_disabled.png"
-
     def on_pre_enter(self):
 
         if self.jd.job_gcode == []:
@@ -376,10 +362,29 @@ class HomeScreen(Screen):
                 self.gcode_preview_widget.draw_file_in_xy_plane([])
                 self.gcode_preview_widget.get_non_modal_gcode([])
             except:
-                print 'No G-code loaded.'
+                print('No G-code loaded.')
 
             self.gcode_summary_widget.hide_summary()
 
+        # Check if job recovery (or job redo) is available
+        if self.jd.job_recovery_cancel_line != None:
+            self.job_recovery_button.disabled = False
+
+            # Cancel on line -1 represents last job completing successfully
+            if self.jd.job_recovery_cancel_line == -1:
+                self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job_disabled.png"
+
+            else:
+                self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job.png"
+
+                # Line -1 being selected represents no selected line
+                if self.jd.job_recovery_selected_line == -1:
+                    self.file_data_label.text += "\n[color=FF0000]Restart from beginning[/color]"
+                else:
+                    self.file_data_label.text += "\n[color=FF0000]From line " + str(self.jd.job_recovery_selected_line) + "[/color]"
+        else:
+            self.job_recovery_button.disabled = True
+            self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job_disabled.png"
 
     def preview_job_file(self, dt):
 
@@ -389,7 +394,7 @@ class HomeScreen(Screen):
             self.gcode_preview_widget.draw_file_in_xy_plane(self.non_modal_gcode_list)
             log ('< draw_file_in_xy_plane')
         except:
-            print 'Unable to draw gcode'
+            print('Unable to draw gcode')
 
         log('DONE')
 

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -216,7 +216,6 @@ Builder.load_string("""
                                     background_color: hex('#F4433600')
                                     on_press:
                                         root.manager.current = 'recovery_decision'
-                                    disabled: True
                                     BoxLayout:
                                         padding: 0
                                         size: self.parent.size
@@ -367,7 +366,6 @@ class HomeScreen(Screen):
 
         # Check if job recovery (or job redo) is available
         if self.jd.job_recovery_cancel_line != None:
-            self.job_recovery_button.disabled = False
 
             # Cancel on line -1 represents last job completing successfully
             if self.jd.job_recovery_cancel_line == -1:
@@ -383,7 +381,6 @@ class HomeScreen(Screen):
             else:
                 self.file_data_label.text += "\n[color=FF0000]From line " + str(self.jd.job_recovery_selected_line) + "[/color]"
         else:
-            self.job_recovery_button.disabled = True
             self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job_disabled.png"
 
     def preview_job_file(self, dt):

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -328,15 +328,7 @@ class HomeScreen(Screen):
         else: 
             Clock.schedule_once(lambda dt: self.m.set_led_colour('GREEN'), 0.2)
 
-    def on_pre_enter(self):
-
         if self.jd.job_gcode == []:
-
-            self.file_data_label.text = ('[color=333333]' + \
-                self.l.get_str('Load a file') + '...' + '[/color]'
-                )
-            self.job_filename = ''
-  
             self.job_box.range_x[0] = 0
             self.job_box.range_x[1] = 0
             self.job_box.range_y[0] = 0
@@ -354,8 +346,6 @@ class HomeScreen(Screen):
             self.gcode_summary_widget.hide_summary()
 
         else:
-            # File label at the top
-            self.file_data_label.text = "[color=333333]" + self.jd.job_name + "[/color]"    
             self.gcode_summary_widget.display_summary()
 
             # Preview file as drawing
@@ -363,6 +353,19 @@ class HomeScreen(Screen):
                 Clock.schedule_once(self.preview_job_file, 0.05)
             except:
                 log('Unable to preview file')
+
+    def on_pre_enter(self):
+
+        if self.jd.job_gcode == []:
+
+            self.file_data_label.text = ('[color=333333]' + \
+                self.l.get_str('Load a file') + '...' + '[/color]'
+                )
+            self.job_filename = ''
+
+        else:
+            # File label at the top
+            self.file_data_label.text = "[color=333333]" + self.jd.job_name + "[/color]"    
 
         # Check if job recovery (or job redo) is available
         if self.jd.job_recovery_cancel_line != None:

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -328,7 +328,26 @@ class HomeScreen(Screen):
         else: 
             Clock.schedule_once(lambda dt: self.m.set_led_colour('GREEN'), 0.2)
 
+        if self.jd.job_gcode != []:
+
+            self.gcode_summary_widget.display_summary()
+
+            # Preview file as drawing
+            try: 
+                Clock.schedule_once(self.preview_job_file, 0.05)
+            except:
+                log('Unable to preview file')
+
+    def on_pre_enter(self):
+
         if self.jd.job_gcode == []:
+
+            # File label at the top
+            self.file_data_label.text = ('[color=333333]' + \
+                self.l.get_str('Load a file') + '...' + '[/color]'
+                )
+            self.job_filename = ''
+
             self.job_box.range_x[0] = 0
             self.job_box.range_x[1] = 0
             self.job_box.range_y[0] = 0
@@ -344,24 +363,6 @@ class HomeScreen(Screen):
                 print('No G-code loaded.')
 
             self.gcode_summary_widget.hide_summary()
-
-        else:
-            self.gcode_summary_widget.display_summary()
-
-            # Preview file as drawing
-            try: 
-                Clock.schedule_once(self.preview_job_file, 0.05)
-            except:
-                log('Unable to preview file')
-
-    def on_pre_enter(self):
-
-        if self.jd.job_gcode == []:
-
-            self.file_data_label.text = ('[color=333333]' + \
-                self.l.get_str('Load a file') + '...' + '[/color]'
-                )
-            self.job_filename = ''
 
         else:
             # File label at the top

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -328,18 +328,6 @@ class HomeScreen(Screen):
             Clock.schedule_once(lambda dt: self.m.laser_on(), 0.2)
         else: 
             Clock.schedule_once(lambda dt: self.m.set_led_colour('GREEN'), 0.2)
-    
-        # File label at the top
-        if self.jd.job_gcode != []:
-
-            self.file_data_label.text = "[color=333333]" + self.jd.job_name + "[/color]"    
-            self.gcode_summary_widget.display_summary()
-
-            # Preview file as drawing
-            try: 
-                Clock.schedule_once(self.preview_job_file, 0.05)
-            except:
-                log('Unable to preview file')
 
     def on_pre_enter(self):
 
@@ -366,6 +354,17 @@ class HomeScreen(Screen):
 
             self.gcode_summary_widget.hide_summary()
 
+        else:
+            # File label at the top
+            self.file_data_label.text = "[color=333333]" + self.jd.job_name + "[/color]"    
+            self.gcode_summary_widget.display_summary()
+
+            # Preview file as drawing
+            try: 
+                Clock.schedule_once(self.preview_job_file, 0.05)
+            except:
+                log('Unable to preview file')
+
         # Check if job recovery (or job redo) is available
         if self.jd.job_recovery_cancel_line != None:
             self.job_recovery_button.disabled = False
@@ -377,11 +376,12 @@ class HomeScreen(Screen):
             else:
                 self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job.png"
 
-                # Line -1 being selected represents no selected line
-                if self.jd.job_recovery_selected_line == -1:
+            # Line -1 being selected represents no selected line
+            if self.jd.job_recovery_selected_line == -1:
+                if self.jd.job_recovery_from_beginning:
                     self.file_data_label.text += "\n[color=FF0000]Restart from beginning[/color]"
-                else:
-                    self.file_data_label.text += "\n[color=FF0000]From line " + str(self.jd.job_recovery_selected_line) + "[/color]"
+            else:
+                self.file_data_label.text += "\n[color=FF0000]From line " + str(self.jd.job_recovery_selected_line) + "[/color]"
         else:
             self.job_recovery_button.disabled = True
             self.job_recovery_button_image.source = "./asmcnc/skavaUI/img/recover_job_disabled.png"

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -398,7 +398,7 @@ class JobRecoveryScreen(Screen):
         self.m.s.write_command('G90 G0 X%s Y%s' % (self.pos_x, self.pos_y))
 
     def back_to_home(self):
-        self.jd.reset_recovery()
+        self.jd.reset_values()
         self.sm.current = 'home'
 
     def next_screen(self):

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -227,7 +227,7 @@ class NudgeScreen(Screen):
         popup_info.PopupInfo(self.sm, self.l, 700, info)   
 
     def back_to_home(self):
-        self.jd.reset_recovery()
+        self.jd.reset_values()
         self.sm.current = 'home'
 
     def previous_screen(self):
@@ -250,7 +250,8 @@ class NudgeScreen(Screen):
             wait_popup.popup.dismiss()
             if not success:
                 popup_info.PopupError(self.sm, self.l, message)
-                self.jd.reset_recovery()
+                self.jd.reset_values()
+            self.jd.job_recovery_from_beginning = False
             self.sm.current = 'home'
 
         # Give time for wait popup to appear

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -110,7 +110,7 @@ class RecoveryDecisionScreen(Screen):
         # Check if job recovery (or job redo) is available
         if self.jd.job_recovery_cancel_line == None:
             self.job_name_label.text = ''
-            self.completion_label.text = "No file loaded!"
+            self.completion_label.text = "No file available!"
 
             self.repeat_job_button.background_normal = "./asmcnc/skavaUI/img/blank_grey_button.png"
             self.repeat_job_button.background_down = "./asmcnc/skavaUI/img/blank_grey_button.png"

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -129,17 +129,15 @@ class RecoveryDecisionScreen(Screen):
             self.sm.current = 'homing_decision'
 
     def repeat_job(self):
-        self.jd.reset_recovery()
-
         if os.path.isfile(self.jd.job_recovery_filepath):
             self.jd.reset_values()
+            self.jd.job_recovery_from_beginning = True
             self.jd.set_job_filename(self.jd.job_recovery_filepath)
             self.manager.current = 'loading'
 
         else: 
             error_message = self.l.get_str('File selected does not exist!')
             popup_info.PopupError(self.sm, self.l, error_message)
-
 
     def back_to_home(self):
         self.sm.current = 'home'

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -153,6 +153,8 @@ class RecoveryDecisionScreen(Screen):
 
                 if recovering:
                     self.sm.get_screen('loading').continuing_to_recovery = True
+                else:
+                    self.sm.get_screen('loading').skip_check_decision = True
 
                 self.sm.current = 'loading'
 

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -123,17 +123,20 @@ class RecoveryDecisionScreen(Screen):
             self.recover_job_button.background_down = "./asmcnc/skavaUI/img/blank_orange_button.png"
 
     def go_to_recovery(self):
+        # Doing it this way because disabling the button causes visuals errors
         if self.jd.job_recovery_cancel_line != -1:
-            self.sm.get_screen('homing_decision').return_to_screen = 'job_recovery'
-            self.sm.get_screen('homing_decision').cancel_to_screen = 'job_recovery'
-            self.sm.current = 'homing_decision'
+            self.repeat_job(recovering=True)
 
-    def repeat_job(self):
+    def repeat_job(self, recovering=False):
         if os.path.isfile(self.jd.job_recovery_filepath):
             self.jd.reset_values()
             self.jd.job_recovery_from_beginning = True
             self.jd.set_job_filename(self.jd.job_recovery_filepath)
-            self.manager.current = 'loading'
+
+            if recovering:
+                self.sm.get_screen('loading').continuing_to_recovery = True
+
+            self.sm.current = 'loading'
 
         else: 
             error_message = self.l.get_str('File selected does not exist!')


### PR DESCRIPTION
- Completing a job now stores info about the job, so that the job can be quickly repeated even if recovery isn't needed
- Jobs are now loaded through job recovery, so the correct job does not need to be loaded to perform job recovery
- Z datum reminder reset in job recovery (through loading screen)
- Shapecutter job info no longer gets stored in recovery file