### PR TITLE
Up down jig current input

### DIFF
--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -247,13 +247,11 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
-            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
-                self.m.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
                 self.m.jog_absolute_single_axis('Z', -1, self.z_axis_max_speed)
                 Clock.schedule_once(self.start_moving_down, 1)
             else:

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -253,7 +253,7 @@ class ZHeadMechanics(Screen):
     def begin_test(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
-                self.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
+                self.m.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
                 self.m.jog_absolute_single_axis('Z', -1, self.z_axis_max_speed)
                 Clock.schedule_once(self.start_moving_down, 1)
             else:

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -247,6 +247,7 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
+            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -246,13 +246,11 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
-            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
-                self.m.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
                 self.m.jog_absolute_single_axis('Z', -1, self.z_axis_max_speed)
                 Clock.schedule_once(self.start_moving_down, 1)
             else:

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -246,11 +246,13 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
+            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
+                self.m.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
                 self.m.jog_absolute_single_axis('Z', -1, self.z_axis_max_speed)
                 Clock.schedule_once(self.start_moving_down, 1)
             else:

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -247,11 +247,13 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
+            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
+                self.send_command_to_motor("STORE TMC PARAMS IN EEPROM", command = STORE_TMC_PARAMS)
                 self.m.jog_absolute_single_axis('Z', -1, self.z_axis_max_speed)
                 Clock.schedule_once(self.start_moving_down, 1)
             else:

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -247,7 +247,6 @@ class ZHeadMechanics(Screen):
     def on_enter(self):
         if self.test_waiting_to_start:
             self.test_waiting_to_start = False
-            self.m.send_command_to_motor("SET TOFF Z 8", motor = TMC_Z, command = SET_TOFF, value = 8)
             Clock.schedule_once(self.begin_test, 1)
 
     def begin_test(self, dt):

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_manual_move.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_manual_move.py
@@ -13,6 +13,9 @@ Builder.load_string("""
 
     z_move_container:z_move_container
 
+    phase_one_input:phase_one_input
+    phase_two_input:phase_two_input
+
     BoxLayout:
         orientation: 'vertical'
         padding: dp(10)
@@ -32,6 +35,44 @@ Builder.load_string("""
             BoxLayout:
                 orientation: 'vertical'
                 spacing: dp(10)
+
+                BoxLayout:
+                    orientation: 'horizontal'
+                    spacing: dp(10)
+
+                    TextInput:
+                        id: phase_one_input
+                        font_size: dp(25)
+                        input_filter: 'int'
+                        multiline: False
+
+                    Button:
+                        size_hint_x: 2
+                        text: 'Set phase 1 current (Default 25)'
+                        text_size: self.size
+                        halign: 'center'
+                        valign: 'middle'
+                        bold: True
+                        on_press: root.set_phase_one_current()
+
+                BoxLayout:
+                    orientation: 'horizontal'
+                    spacing: dp(10)
+
+                    TextInput:
+                        id: phase_two_input
+                        font_size: dp(25)
+                        input_filter: 'int'
+                        multiline: False
+
+                    Button:
+                        size_hint_x: 2
+                        text: 'Set phase 2 current (Default 13)'
+                        text_size: self.size
+                        halign: 'center'
+                        valign: 'middle'
+                        bold: True
+                        on_press: root.set_phase_two_current()
 
                 Button:
                     text: 'Set power high'
@@ -131,6 +172,14 @@ class ZHeadMechanicsManualMove(Screen):
 
         Clock.schedule_interval(self.update_realtime_labels, 0.1)
 
+
+    def set_phase_one_current(self):
+        if self.phase_one_input.text:
+            self.sm.get_screen('mechanics').phase_one_current = int(self.phase_one_input.text)
+
+    def set_phase_two_current(self):
+        if self.phase_two_input.text:
+            self.sm.get_screen('mechanics').phase_two_current = int(self.phase_two_input.text)
 
     def set_power_high(self):
         self.m.set_motor_current("Z", 25)


### PR DESCRIPTION
Added text inputs to manual move screen to allow user to customise current in both phases of the test. The current is also displayed on the main screen whenever it is changed