### PR TITLE
Enhanced tmc print

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -432,6 +432,7 @@ class StallJigScreen(Screen):
     poll_ready_to_start_moving = None
     populate_and_transfer_logs_event = None
     send_logs_event = None
+    print_registers_just_before_run_tests_starts_event = None
 
     ## DATABASE OBJECTS
 
@@ -565,7 +566,8 @@ class StallJigScreen(Screen):
         self.unschedule_event_if_it_exists(self.poll_to_reenable_hard_limits_and_go_to_next_test)
         self.unschedule_event_if_it_exists(self.poll_ready_to_start_moving)
         self.unschedule_event_if_it_exists(self.populate_and_transfer_logs_event)
-        self.unschedule_event_if_it_exists(self.send_logs_event)        
+        self.unschedule_event_if_it_exists(self.send_logs_event)
+        self.unschedule_event_if_it_exists(self.print_registers_just_before_run_tests_starts_event)     
 
         log("Unschedule all events")
 
@@ -1460,15 +1462,24 @@ class StallJigScreen(Screen):
 
         # go to absolute start position (relative to true home)
         if start_pos_bool:
-            self.move_to_start_pos_event = Clock.schedule_once(lambda dt: self.move_all_axes(self.absolute_start_pos, self.tell_user_that_SB_is_ready_to_run_tests), 0.5)
+            self.move_to_start_pos_event = Clock.schedule_once(lambda dt: self.move_all_axes(self.absolute_start_pos, self.print_registers_just_before_run_tests_starts), 0.5)
             return
 
         self.poll_for_setting_up_axis_for_test = Clock.schedule_once(lambda dt: self.set_up_axis_for_test(), 0.5)
 
+    def print_registers_just_before_run_tests_starts(self, dt):
+
+        if self.smartbench_is_not_ready_for_next_command():
+            if self.VERBOSE: log("Poll to print registers just before running tests")
+            self.print_registers_just_before_run_tests_starts_event = Clock.schedule_once(self.print_registers_just_before_run_tests_starts, 0.5)
+            return
+
+        self.m.tmc_handshake()
+        self.tell_user_that_SB_is_ready_to_run_tests(0)
 
     def tell_user_that_SB_is_ready_to_run_tests(self, dt):
 
-        if self.smartbench_is_not_ready_for_next_command():
+        if self.smartbench_is_not_ready_for_next_command() or not self.TMC_registers_have_been_read_in():
             if self.VERBOSE: log("Poll to tell user that SB is ready")
             self.tell_user_ready_event = Clock.schedule_once(self.tell_user_that_SB_is_ready_to_run_tests, 0.5)
             return

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -1479,7 +1479,7 @@ class StallJigScreen(Screen):
 
     def tell_user_that_SB_is_ready_to_run_tests(self, dt):
 
-        if self.smartbench_is_not_ready_for_next_command() or not self.TMC_registers_have_been_read_in():
+        if self.smartbench_is_not_ready_for_next_command() or not self.m.TMC_registers_have_been_read_in():
             if self.VERBOSE: log("Poll to tell user that SB is ready")
             self.tell_user_ready_event = Clock.schedule_once(self.tell_user_that_SB_is_ready_to_run_tests, 0.5)
             return


### PR DESCRIPTION
- Get and print TMC registers inbetween settings changes, and beginning of stall jig. This is where we normally start to see issues. 

- Tested on dev machine, up to "INSTALL JIGS" part of test (so it does the print, and then that's it :))