### PR TITLE
Final test yellow screens

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -736,7 +736,7 @@ class OvernightTesting(Screen):
     red_cross = "./asmcnc/skavaUI/img/template_cancel.png"
     green_tick = "./asmcnc/skavaUI/img/file_select_select.png"
 
-    mini_run_dev_mode = False
+    mini_run_dev_mode = True
 
     sn_for_db = ''
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -1395,7 +1395,7 @@ class OvernightTesting(Screen):
             self.start_last_rectangle = Clock.schedule_once(self.run_last_rectangle, 3)
             return
 
-        self.self._set_datums_in_xyz_without_leds()
+        self._set_datums_in_xyz_without_leds()
         self.run_event_after_datum_set = Clock.schedule_once(lambda dt: self._stream_overnight_file('five_rectangles'),
                                                              3)
         log("Running last rectangle")

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -736,7 +736,7 @@ class OvernightTesting(Screen):
     red_cross = "./asmcnc/skavaUI/img/template_cancel.png"
     green_tick = "./asmcnc/skavaUI/img/file_select_select.png"
 
-    mini_run_dev_mode = True
+    mini_run_dev_mode = False
 
     sn_for_db = ''
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -730,6 +730,7 @@ class OvernightTesting(Screen):
     start_last_rectangle = None
     run_event_after_datum_set = None
     start_tuning_event = None
+    _stream_overnight_file_event = None
 
     checkbox_inactive = "./asmcnc/skavaUI/img/checkbox_inactive.png"
     red_cross = "./asmcnc/skavaUI/img/template_cancel.png"
@@ -1147,6 +1148,7 @@ class OvernightTesting(Screen):
         self._unschedule_event(self.start_last_rectangle)
         self._unschedule_event(self.run_event_after_datum_set)
         self._unschedule_event(self.poll_for_tuning_completion)
+        self._unschedule_event(self._stream_overnight_file_event)
 
         # also stop measurement running
         self.overnight_running = False
@@ -1369,8 +1371,7 @@ class OvernightTesting(Screen):
             return
 
         self.setup_arrays()
-        self.m.set_workzone_to_pos_xy()
-        self.m.set_jobstart_z()
+        self._set_datums_in_xyz_without_leds()
         self.set_stage("FullyCalibratedTest")
         self.run_event_after_datum_set = Clock.schedule_once(lambda dt: self._stream_overnight_file('spiral_file'), 3)
         log("Running fully calibrated final run...")
@@ -1394,8 +1395,7 @@ class OvernightTesting(Screen):
             self.start_last_rectangle = Clock.schedule_once(self.run_last_rectangle, 3)
             return
 
-        self.m.set_workzone_to_pos_xy()
-        self.m.set_jobstart_z()
+        self.self._set_datums_in_xyz_without_leds()
         self.run_event_after_datum_set = Clock.schedule_once(lambda dt: self._stream_overnight_file('five_rectangles'),
                                                              3)
         log("Running last rectangle")
@@ -1443,13 +1443,16 @@ class OvernightTesting(Screen):
     # FILE STREAMING FUNCTIONS
 
     def _not_ready_to_stream(self):
-        if self.m.state().startswith('Idle') and not self.overnight_running:
+        if self.m.state().startswith('Idle') and not self.overnight_running and not self.m.s.is_sequential_streaming:
             return False
 
         else:
             return True
 
     def _stream_overnight_file(self, filename_end):
+
+        if self._not_ready_to_stream():
+            self._stream_overnight_file_event = Clock.schedule_once(lambda dt: self._stream_overnight_file(filename_end), 2)
 
         self.overnight_running = True
 
@@ -1476,6 +1479,16 @@ class OvernightTesting(Screen):
             return False
 
         return True
+
+    def _set_datums_in_xyz_without_leds(self):
+
+        list_to_stream = [
+                        'G10 L20 P1 X0 Y0',
+                        'G10 L20 P1 Z0',
+                        '$#'
+        ]
+
+        self.m.s.start_sequential_stream(list_to_stream)
 
     ## DATA SEND FUNCTIONS
 


### PR DESCRIPTION
We were seeing intermittent gcode errors in overnight test, between recalibration stage and full calibrated run stage. 

This was caused by setting the datum prior to file streaming, which also had LED commands sent on a clock. These LED commands then interfered with the file stream, causing a gcode error 😳