### PR TITLE
Set different hostnames for pi4 and pi3

### DIFF
--- a/ansible/templates/set-hostname.sh
+++ b/ansible/templates/set-hostname.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-BENCH=`cat /proc/cpuinfo | grep Serial | awk ' {print $3}' | sed 's/^0*//'`
+BENCH_FULL=`cat /proc/cpuinfo | grep Serial | awk ' {print $3}'` 
+
+if [[ $BENCH_FULL == 1* ]];
+then 
+	BENCH=`echo $BENCH_FULL | sed 's/^10*/4/'`
+else
+	BENCH=`echo $BENCH_FULL | sed 's/^0*//'`
+fi
 
 hostname ${BENCH}.yetitool.com
 echo ${BENCH}.yetitool.com > /etc/hostname


### PR DESCRIPTION
If Pi4, serial has leading 100000*..., and Pi 3 has leading 000000*. For pi 4, prepend a 4 onto last 8 digit of SN to differentiate it from pi 3 SNs. 

Consequences: pi4 hostnames will be 9 characters instead of 8. 