### PR TITLE
Split alarm text with newlines

### DIFF
--- a/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
+++ b/src/asmcnc/core_UI/sequence_alarm/alarm_manager.py
@@ -242,7 +242,7 @@ class AlarmSequenceManager(object):
 			self.l.get_str("The N axis was overloaded during a move.").replace("N", self.stall_axis) + \
 			" " + \
 			self.l.get_str("SmartBench has paused the job, to prevent further damage.") + \
-            " " + \
+            "\n\n" + \
             self.l.get_str("Before raising the Z axis, ensure that you release any side-load on the tool by " + \
                            "jogging the X and Y axis a very small amount (e.g. 0.5mm), away from the side of the material.")
 			)

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_1.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_1.py
@@ -165,6 +165,10 @@ class AlarmScreen1(Screen):
 
 	def update_font_size(self, value):
 		if len(value.text) > 330:
-			value.font_size = 19
+			value.font_size = 16
+		elif len(value.text) > 280:
+			value.font_size = 17
+		elif len(value.text) > 270:
+			value.font_size = 18
 		else: 
 			value.font_size = 20


### PR DESCRIPTION
Split text on stall alarm screen into two paragraphs to improve readability

Tested with unit tests for alarm screen