### PR TITLE
Package protect

### DIFF
--- a/src/asmcnc/production/database/payload_publisher.py
+++ b/src/asmcnc/production/database/payload_publisher.py
@@ -19,6 +19,8 @@ CSV_PATH = './asmcnc/production/database/csvs/'
 QUEUE = 'new_factory_data'
 WORKING_DIR = 'C:\\CalibrationReceiver\\CSVS\\'
 
+if os.getcwd().endswith("easycut-smartbench"): 
+    CSV_PATH = './src' + CSV_PATH[1:]
 
 def log(message):
     timestamp = datetime.now()

--- a/tests/automated_unit_tests/comms/test_running_data_measurement.py
+++ b/tests/automated_unit_tests/comms/test_running_data_measurement.py
@@ -22,8 +22,6 @@ from datetime import datetime
 from asmcnc.production.database.payload_publisher import DataPublisher
 from asmcnc.production.database.calibration_database import CalibrationDatabase
 
-# os.chdir('./src')
-
 '''
 ######################################
 RUN FROM easycut-smartbench FOLDER WITH: 


### PR DESCRIPTION
Tested via unit test:

def test_publishing_sample_data(running_data_element):
    running_data_list = [running_data_element]*10
    cdb = CalibrationDatabase()
    cdb._process_running_data(running_data_list, "ys60000")
    publisher = DataPublisher("ys60000")
    response_stall_data = publisher.run_data_send(*cdb.processed_running_data["9"])
    assert response_stall_data
    
Uninstalled pika and paramiko individually to test :) 

also did a test in interactive python from src folder to make sure csv_path was still working normally (had to add the bit that adds the ./src for the unit test to work)