### PR TITLE
Stopped calculating negative percentage

### DIFF
--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -683,7 +683,7 @@ class GoScreen(Screen):
         # % progress    
         if len(self.jd.job_gcode_running) != 0:
             self.jd.percent_thru_job = int(
-                round(((self.m.s.g_count - self.jd.job_recovery_offset) * 1.0 / (len(self.jd.job_gcode_running) - self.jd.job_recovery_offset + 4) * 1.0) * 100.0))
+                round(((self.m.s.g_count - min(0, self.jd.job_recovery_offset)) * 1.0 / (len(self.jd.job_gcode_running) - min(0, self.jd.job_recovery_offset) + 4) * 1.0) * 100.0))
             if self.jd.percent_thru_job > 100: self.jd.percent_thru_job = 100
             self.progress_percentage_label.text = str(self.jd.percent_thru_job) + " %"
 


### PR DESCRIPTION
Fixed bug that would show a negative job progress percentage at the start of a job.

If the recovery offset is calculated as being positive then it is ignored in the percentage calculation. This will at most be 4-5 lines so shouldn't affect the percentage much (and will work more like it does without job recovery)

Tested on windows with arduino