### PR TITLE
Always write to recovery file if enough time has passed

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -619,16 +619,16 @@ class SerialConnection(object):
             Clock.schedule_once(lambda dt: self.m.zUp(), 0.5)
             Clock.schedule_once(lambda dt: self.m.vac_off(), 1)
 
+            # Update time for maintenance reminders
+            time.sleep(0.4)
+            time_taken_seconds = self.update_machine_runtime()
+
             # Write recovery info
             # g_count represents the number of OKs issued by grbl which are sent when a line enters the line buffer
             # The line buffer has a capacity of 35 lines
             # So the currently executing command is the one 35 lines before the last one received by the buffer
             if not self.jd.job_recovery_skip_recovery:
-                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35, self.sm.get_screen('go').time_taken_seconds)
-
-            # Update time for maintenance reminders
-            time.sleep(0.4)
-            self.update_machine_runtime()
+                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35, time_taken_seconds)
             
 
         else:
@@ -676,6 +676,8 @@ class SerialConnection(object):
         self.m.write_z_head_maintenance_settings(self.m.time_since_z_head_lubricated_seconds)
 
         self._reset_counters()
+
+        return time_taken_seconds
         
 
 # PUSH MESSAGE HANDLING

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -624,7 +624,7 @@ class SerialConnection(object):
             # The line buffer has a capacity of 35 lines
             # So the currently executing command is the one 35 lines before the last one received by the buffer
             if not self.jd.job_recovery_skip_recovery:
-                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35)
+                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35, self.sm.get_screen('go').time_taken_seconds)
 
             # Update time for maintenance reminders
             time.sleep(0.4)

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -675,9 +675,12 @@ class SerialConnection(object):
         self.m.time_since_z_head_lubricated_seconds += only_running_time_seconds
         self.m.write_z_head_maintenance_settings(self.m.time_since_z_head_lubricated_seconds)
 
+        # This accounts for the current pause and doesn't include cooldown time
+        time_without_current_pause = self.stream_pause_start_time - self.stream_start_time - self.stream_paused_accumulated_time
+
         self._reset_counters()
 
-        return time_taken_seconds
+        return time_without_current_pause
         
 
 # PUSH MESSAGE HANDLING

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -443,7 +443,7 @@ class JobData(object):
                 write_to_file(cancel_line)
 
             # If cancel line < 0 but enough time has passed, job has probably started, so write line 0
-            elif cancel_time >= 30:
+            elif cancel_time >= 40:
                 write_to_file(1)
                 
             # If job was cancelled before it started, no need to store recovery info

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -422,14 +422,12 @@ class JobData(object):
             print("Could not read recovery info")
             print(str(traceback.format_exc()))
 
-    def write_to_recovery_file_after_cancel(self, cancel_line):
+    def write_to_recovery_file_after_cancel(self, cancel_line, cancel_time):
         try:
             # Account for number of lines added in by the software when running file
             cancel_line -= self.job_recovery_offset
 
-            # If job was cancelled before it started, no need to store recovery info
-            if cancel_line >= 0:
-
+            def write_to_file(cancel_line):
                 with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
                     job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
 
@@ -439,6 +437,15 @@ class JobData(object):
 
                 print("Wrote recovery info")
 
+            # If everything is normal, write recovery info as normal
+            if cancel_line >= 0:
+                write_to_file(cancel_line)
+
+            # If cancel line < 0 but enough time has passed, job has probably started, so write line 0
+            elif cancel_time >= 30:
+                write_to_file(1)
+                
+            # If job was cancelled before it started, no need to store recovery info
             else:
                 print("Job cancelled before start, not writing recovery info")
 

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -423,19 +423,20 @@ class JobData(object):
             print(str(traceback.format_exc()))
 
     def write_to_recovery_file_after_cancel(self, cancel_line, cancel_time):
+
+        def write_to_file(cancel_line):
+            with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
+                job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
+
+            # Simultaneously update variables
+            self.job_recovery_filepath = self.filename
+            self.job_recovery_cancel_line = cancel_line
+
+            print("Wrote recovery info")
+
         try:
             # Account for number of lines added in by the software when running file
             cancel_line -= self.job_recovery_offset
-
-            def write_to_file(cancel_line):
-                with open(self.job_recovery_info_filepath, 'w+') as job_recovery_info_file:
-                    job_recovery_info_file.write(self.filename + "\n" + str(cancel_line))
-
-                # Simultaneously update variables
-                self.job_recovery_filepath = self.filename
-                self.job_recovery_cancel_line = cancel_line
-
-                print("Wrote recovery info")
 
             # If everything is normal, write recovery info as normal
             if cancel_line >= 0:

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -443,7 +443,7 @@ class JobData(object):
                 write_to_file(cancel_line)
 
             # If cancel line < 0 but enough time has passed, job has probably started, so write line 0
-            elif cancel_time >= 40:
+            elif cancel_time >= 30:
                 write_to_file(1)
                 
             # If job was cancelled before it started, no need to store recovery info


### PR DESCRIPTION
When cancelling a job, recovery info is written if more than 30 seconds have passed since the start of the job, even if the cancel line is less than 0. This means that files that calculate the cancel line incorrectly (i.e. file containing G2/G3) will still have recovery info saved.

Tested on rig