### PR TITLE
Making ansible installs compatible with both Pi 3 and Pi 4

### DIFF
--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -14,12 +14,12 @@ apt_pkgs:
 - python-pigpio
 
 pip_pkgs:
-- pika==1.2.0
-- paramiko==2.0.0
-- pigpio==1.78
-- pytz==2022.5
-- influxdb==5.2.0
-- pyserial==3.2.1
+- pika=1.2.0
+- paramiko=2.0.0
+- pigpio=1.78
+- pytz=2022.5
+- influxdb=5.2.0
+- pyserial=3.2.1
 - pyodbc<=4.0.34
 - matplotlib<=2.2.5
 

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,13 +1,13 @@
 apt_pkgs:
 - python-pip
-- proftpd-basic=1.3.7a+dfsg-12+deb11u2
-- avrdude=6.3-20171130+svn1429-2+b1
-- pigpio=1.78-1+rpi1
-- git-repair=1.20200102-2
-- freetds-bin=1.2.3-1
-- freetds-dev=1.2.3-1
-- tdsodbc=1.2.3-1
-- unixodbc-dev=2.3.6-0.1+b1
+- proftpd-basic
+- avrdude
+- pigpio
+- git-repair
+- freetds-bin
+- freetds-dev
+- tdsodbc
+- unixodbc-dev
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -9,6 +9,7 @@ pkgs:
 - freetds-dev
 - tdsodbc
 - mysql-server
+- default-mysql-server
 - libmysqlclient-dev
 - python-mysqldb
 - python-pyodbc

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,17 +1,16 @@
 pkgs:
-- python-pip
+- python2-pip
 - proftpd-basic
 - avrdude
 - pigpio
-- python-pigpio
+- python2-pigpio
 - git-repair
-- python-influxdb
 - freetds-bin
 - freetds-dev
 - tdsodbc
-- python-mysqldb
-- python-pyodbc
-- python-matplotlib
+- python2-mysqldb
+- python2-pyodbc
+- python2-matplotlib
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -9,14 +9,5 @@ apt_pkgs:
 - tdsodbc=1.2.3-1
 - unixodbc-dev=2.3.6-0.1+b1
 
-pip_pkgs:
-- pika==1.2.0
-- pigpio==1.78
-- pytz==2022.5
-- influxdb==5.2.0
-- pyserial==3.2.1
-- pyodbc==4.0.34
-- matplotlib==2.2.5
-
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,14 +1,22 @@
-pkgs:
+apt_pkgs:
 - python-pip
-- proftpd-basic
-- avrdude
-- pigpio
-- python-pigpio
-- git-repair
-- freetds-bin
-- freetds-dev
-- tdsodbc
-- unixodbc-dev
+- proftpd-basic=1.3.7a+dfsg-12+deb11u2
+- avrdude=6.3-20171130+svn1429-2+b1
+- pigpio=1.78-1+rpi1
+- git-repair=1.20200102-2
+- freetds-bin=1.2.3-1
+- freetds-dev=1.2.3-1
+- tdsodbc=1.2.3-1
+- unixodbc-dev=2.3.6-0.1+b1
+
+pip_pkgs:
+- pika==1.2.0
+- pigpio==1.78
+- pytz==2022.5
+- influxdb==5.2.0
+- pyserial==3.2.1
+- pyodbc==4.0.34
+- matplotlib==2.2.5
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,5 +1,4 @@
 apt_pkgs:
-- python-pip
 - proftpd-basic
 - avrdude
 - pigpio

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -8,9 +8,11 @@ pkgs:
 - freetds-bin
 - freetds-dev
 - tdsodbc
-- python2-mysqldb
-- python2-pyodbc
-- python2-matplotlib
+- mysql-server
+- libmysqlclient-dev
+- python-mysqldb
+- python-pyodbc
+- python-matplotlib
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -8,6 +8,7 @@ pkgs:
 - freetds-bin
 - freetds-dev
 - tdsodbc
+- unixodbc-dev
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -13,15 +13,5 @@ apt_pkgs:
 - pigpio
 - python-pigpio
 
-pip_pkgs:
-- pika=1.2.0
-- paramiko=2.0.0
-- pigpio=1.78
-- pytz=2022.5
-- influxdb=5.2.0
-- pyserial=3.2.1
-- pyodbc<=4.0.34
-- matplotlib<=2.2.5
-
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -5,13 +5,13 @@ stretch_pkgs:
 apt_pkgs:
 - proftpd-basic
 - avrdude
-- pigpio
 - git-repair
 - freetds-bin
 - freetds-dev
 - tdsodbc
 - unixodbc-dev
-- python-pigpio=1.78
+- pigpio
+- python-pigpio
 
 pip_pkgs:
 - pika==1.2.0

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,19 +1,13 @@
 pkgs:
-- python2-pip
+- python-pip
 - proftpd-basic
 - avrdude
 - pigpio
-- python2-pigpio
+- python-pigpio
 - git-repair
 - freetds-bin
 - freetds-dev
 - tdsodbc
-- mysql-server
-- default-mysql-server
-- libmysqlclient-dev
-- python-mysqldb
-- python-pyodbc
-- python-matplotlib
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,3 +1,7 @@
+stretch_pkgs:
+- python-pip
+- python-mysqldb
+
 apt_pkgs:
 - proftpd-basic
 - avrdude
@@ -7,6 +11,17 @@ apt_pkgs:
 - freetds-dev
 - tdsodbc
 - unixodbc-dev
+- python-pigpio=1.78
+
+pip_pkgs:
+- pika==1.2.0
+- paramiko==2.0.0
+- pigpio==1.78
+- pytz==2022.5
+- influxdb==5.2.0
+- pyserial==3.2.1
+- pyodbc<=4.0.34
+- matplotlib<=2.2.5
 
 exim_dc_eximconfig_configtype: internet
 exim_dc_localdelivery: mail_spool

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -20,12 +20,6 @@
       state: present
     with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
-  - name: Install pip python packages
-    pip:
-      name: "{{ item }}"
-      state: present
-    with_items: "{{ pip_pkgs }}"
-    ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:
       src: odbcinst.ini
@@ -133,7 +127,44 @@
       state: present
       insertafter: EOF
       line: 'ansible_from_easycut=True'
-  - name: Install paramiko python package on version 2.0.0
+  - name: Pip install paramiko 2.0.0
     pip:
       name: paramiko==2.0.0
+      state: present
     ignore_errors: yes
+  - name: Pip install pika==1.2.0
+    pip:
+      name: pika==1.2.0
+      state: present
+    ignore_errors: yes
+  - name: Pip install pigpio==1.78
+    pip:
+      name: pigpio==1.78
+      state: present
+    ignore_errors: yes
+  - name: Pip install pytz==2022.5
+    pip:
+      name: pytz==2022.5
+      state: present
+    ignore_errors: yes
+  - name: Pip install influxdb==5.2.0
+    pip:
+      name: influxdb==5.2.0
+      state: present
+    ignore_errors: yes
+  - name: Pip install pyserial==3.2.1
+    pip:
+      name: pyserial==3.2.1
+      state: present
+    ignore_errors: yes
+  - name: Pip install pyodbc==4.0.34
+    pip:
+      name: pyodbc==4.0.34
+      state: present
+    ignore_errors: yes
+  - name: Pip install matplotlib==2.2.5
+    pip:
+      name: matplotlib==2.2.5
+      state: present
+    ignore_errors: yes  
+  

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -5,10 +5,6 @@
   roles:
   - geerlingguy.exim
   tasks:
-  - name: Distribution
-    debug: msg="{{ ansible_distribution }}"
-  - name: Distribution version
-    debug: msg="{{ ansible_distribution_version}}"
   - name: Distribution major version
     debug: msg="{{ ansible_distribution_major_version }}"
   - name: Copying the setting hostname script

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -142,41 +142,33 @@
   - name: Pip install paramiko 2.0.0
     pip:
       name: paramiko==2.0.0
-      state: present
     ignore_errors: yes
   - name: Pip install pika==1.2.0
     pip:
       name: pika==1.2.0
-      state: present
     ignore_errors: yes
   - name: Pip install pigpio==1.78
     pip:
       name: pigpio==1.78
-      state: present
     ignore_errors: yes
   - name: Pip install pytz==2022.5
     pip:
       name: pytz==2022.5
-      state: present
     ignore_errors: yes
   - name: Pip install influxdb==5.2.0
     pip:
       name: influxdb==5.2.0
-      state: present
     ignore_errors: yes
   - name: Pip install pyserial==3.2.1
     pip:
       name: pyserial==3.2.1
-      state: present
     ignore_errors: yes
   - name: Pip install pyodbc<=4.0.34
     pip:
       name: pyodbc<=4.0.34
-      state: present
     ignore_errors: yes
   - name: Pip install matplotlib==2.2.5
     pip:
       name: matplotlib<=2.2.5
-      state: present
     ignore_errors: yes  
   

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -20,21 +20,25 @@
     command: /usr/local/bin/set-hostname.sh
     become: yes
     become_user: root
-  - name: Install pip on Debian 9 or 10
+    # Python2 pip and mysqldb are only available on stretch
+  - name: Install packages for Raspbian Stretch
     package:
-      name: python-pip
+      name: "{{ item }}"
       state: present
-    ignore_errors: yes
+    with_items: "{{ stretch_pkgs }}"
     when: ansible_distribution_major_version == '9' or ansible_distribution_major_version == '10'
-  - name: Install apt packages
+    # This might be very very important before the pip run
+  - name: Install apt packages and one python package
     package:
       name: "{{ item }}"
       state: present
     with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
-  - name: Pip install pika==1.2.0
-    pip:
-      name: pika==1.2.0
+  - name: Install pip packages
+    package:
+      name: "{{ item }}"
+      state: present
+    with_items: "{{ pip_pkgs }}"
     ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:
@@ -143,32 +147,37 @@
       state: present
       insertafter: EOF
       line: 'ansible_from_easycut=True'
-  - name: Pip install paramiko 2.0.0
-    pip:
-      name: paramiko==2.0.0
-    ignore_errors: yes
-  - name: Pip install pigpio==1.78
-    pip:
-      name: pigpio==1.78
-    ignore_errors: yes
-  - name: Pip install pytz==2022.5
-    pip:
-      name: pytz==2022.5
-    ignore_errors: yes
-  - name: Pip install influxdb==5.2.0
-    pip:
-      name: influxdb==5.2.0
-    ignore_errors: yes
-  - name: Pip install pyserial==3.2.1
-    pip:
-      name: pyserial==3.2.1
-    ignore_errors: yes
-  - name: Pip install pyodbc<=4.0.34
-    pip:
-      name: pyodbc<=4.0.34
-    ignore_errors: yes
-  - name: Pip install matplotlib==2.2.5
-    pip:
-      name: matplotlib<=2.2.5
-    ignore_errors: yes  
-  
+
+  # - name: Pip install pika==1.2.0
+  #   pip:
+  #     name: pika==1.2.0
+  #   ignore_errors: yes
+  # - name: Pip install paramiko 2.0.0
+  #   pip:
+  #     name: paramiko==2.0.0
+  #   ignore_errors: yes
+  # - name: Pip install pigpio==1.78
+  #   pip:
+  #     name: pigpio==1.78
+  #   ignore_errors: yes
+  # - name: Pip install pytz==2022.5
+  #   pip:
+  #     name: pytz==2022.5
+  #   ignore_errors: yes
+  # - name: Pip install influxdb==5.2.0
+  #   pip:
+  #     name: influxdb==5.2.0
+  #   ignore_errors: yes
+  # - name: Pip install pyserial==3.2.1
+  #   pip:
+  #     name: pyserial==3.2.1
+  #   ignore_errors: yes
+  # - name: Pip install pyodbc<=4.0.34
+  #   pip:
+  #     name: pyodbc<=4.0.34
+  #   ignore_errors: yes
+  # - name: Pip install matplotlib==2.2.5
+  #   pip:
+  #     name: matplotlib<=2.2.5
+  #   ignore_errors: yes  
+  # 

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -26,6 +26,7 @@
         - pika==1.2.0
         - pytz
         - influxdb
+        - pyserial
         - pyodbc
         - matplotlib
         - pigpio

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -157,14 +157,14 @@
       name: pyserial==3.2.1
       state: present
     ignore_errors: yes
-  - name: Pip install pyodbc==4.0.34
+  - name: Pip install pyodbc<=4.0.34
     pip:
-      name: pyodbc==4.0.34
+      name: pyodbc<=4.0.34
       state: present
     ignore_errors: yes
   - name: Pip install matplotlib==2.2.5
     pip:
-      name: matplotlib==2.2.5
+      name: matplotlib<=2.2.5
       state: present
     ignore_errors: yes  
   

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -32,6 +32,10 @@
       state: present
     with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
+  - name: Pip install pika==1.2.0
+    pip:
+      name: pika==1.2.0
+    ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:
       src: odbcinst.ini
@@ -142,12 +146,6 @@
   - name: Pip install paramiko 2.0.0
     pip:
       name: paramiko==2.0.0
-    become: yes
-    become_user: root
-    ignore_errors: yes
-  - name: Pip install pika==1.2.0
-    pip:
-      name: pika==1.2.0
     ignore_errors: yes
   - name: Pip install pigpio==1.78
     pip:

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -5,6 +5,12 @@
   roles:
   - geerlingguy.exim
   tasks:
+  - name: Distribution
+    debug: msg="{{ ansible_distribution }}"
+  - name: Distribution version
+    debug: msg="{{ ansible_distribution_version}}"
+  - name: Distribution major version
+    debug: msg="{{ ansible_distribution_major_version }}"
   - name: Copying the setting hostname script
     template:
       src: set-hostname.sh

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -64,8 +64,14 @@
     ignore_errors: yes
   - name: Pip install matplotlib==2.2.5
     pip:
-      name: matplotlib<=2.2.5
-    ignore_errors: yes 
+      name: matplotlib==2.2.5
+    ignore_errors: yes
+    when: ansible_distribution_major_version == '11'
+  - name: Pip install matplotlib==2.0.0
+    pip:
+      name: matplotlib==2.0.0
+    ignore_errors: yes
+    when: ansible_distribution_major_version == '9'
   - name: Pip install PyMySQL==0.10.1
     pip:
       name: PyMySQL==0.10.1

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -14,23 +14,17 @@
     command: /usr/local/bin/set-hostname.sh
     become: yes
     become_user: root
-  - name: Install packages
+  - name: Install apt packages
     package:
       name: "{{ item }}"
-      state: absent
-    with_items: "{{ pkgs }}"
+      state: present
+    with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
   - name: Install pip python packages
     pip:
-      name: 
-        - pika==1.2.0
-        - pytz
-        - influxdb
-        - pyserial
-        - pyodbc
-        - matplotlib
-        - pigpio
-      state: absent
+      name: "{{ item }}"
+      state: present
+    with_items: "{{ pip_pkgs }}"
     ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -20,13 +20,16 @@
       state: present
     with_items: "{{ pkgs }}"
     ignore_errors: yes
-  - name: Install pika python package on version 1.2.0
+  - name: Install pip python packages
     pip:
-      name: pika==1.2.0
-    ignore_errors: yes
-  - name: Install pytz for timezone info
-    pip:
-      name: pytz
+      name: 
+        - pika==1.2.0
+        - pytz
+        - influxdb
+        - mysqldb
+        - pyodbc
+        - matplotlib
+        - pigpio
     ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -142,6 +142,8 @@
   - name: Pip install paramiko 2.0.0
     pip:
       name: paramiko==2.0.0
+    become: yes
+    become_user: root
     ignore_errors: yes
   - name: Pip install pika==1.2.0
     pip:

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -25,7 +25,7 @@
     with_items: "{{ stretch_pkgs }}"
     when: ansible_distribution_major_version == '9' or ansible_distribution_major_version == '10'
 
-    # This might be very very important before the pip run
+    # This is very important before the pip run
   - name: Install apt packages and one python package
     package:
       name: "{{ item }}"
@@ -62,11 +62,6 @@
     pip:
       name: pyodbc<=4.0.34
     ignore_errors: yes
-  # - name: Pip install matplotlib==2.2.5
-  #   pip:
-  #     name: matplotlib==2.2.5
-  #   ignore_errors: yes
-  #   when: ansible_distribution_major_version == '11'
   - name: Pip install numpy==1.16.6
     pip:
       name: numpy==1.16.6
@@ -75,7 +70,6 @@
     pip:
       name: matplotlib==2.2.5
     ignore_errors: yes
-    # when: ansible_distribution_major_version == '9'
   - name: Pip install PyMySQL==0.10.1
     pip:
       name: PyMySQL==0.10.1
@@ -197,6 +191,3 @@
       state: present
       insertafter: EOF
       line: 'ansible_from_easycut=True'
-
-
-  

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -67,9 +67,9 @@
       name: matplotlib==2.2.5
     ignore_errors: yes
     when: ansible_distribution_major_version == '11'
-  - name: Pip install matplotlib==2.0.0
+  - name: Pip install matplotlib
     pip:
-      name: matplotlib==2.0.0
+      name: matplotlib
     ignore_errors: yes
     when: ansible_distribution_major_version == '9'
   - name: Pip install PyMySQL==0.10.1

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -26,7 +26,6 @@
         - pika==1.2.0
         - pytz
         - influxdb
-        - MySQL-python
         - pyodbc
         - matplotlib
         - pigpio

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -20,6 +20,12 @@
     command: /usr/local/bin/set-hostname.sh
     become: yes
     become_user: root
+  - name: Install pip on Debian 9 or 10
+    package:
+      name: python-pip
+      state: present
+    ignore_errors: yes
+    when: ansible_distribution_major_version == '9' or ansible_distribution_major_version == '10'
   - name: Install apt packages
     package:
       name: "{{ item }}"

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -62,16 +62,18 @@
     pip:
       name: pyodbc<=4.0.34
     ignore_errors: yes
-  - name: Pip install matplotlib==2.2.5
+  # - name: Pip install matplotlib==2.2.5
+  #   pip:
+  #     name: matplotlib==2.2.5
+  #   ignore_errors: yes
+  #   when: ansible_distribution_major_version == '11'
+  - name: Pip install matplotlib and numpy (dependency)
     pip:
-      name: matplotlib==2.2.5
+      name: 
+        - numpy==1.16.6
+        - matplotlib==2.2.5
     ignore_errors: yes
-    when: ansible_distribution_major_version == '11'
-  - name: Pip install matplotlib
-    pip:
-      name: matplotlib
-    ignore_errors: yes
-    when: ansible_distribution_major_version == '9'
+    # when: ansible_distribution_major_version == '9'
   - name: Pip install PyMySQL==0.10.1
     pip:
       name: PyMySQL==0.10.1

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -16,6 +16,7 @@
     command: /usr/local/bin/set-hostname.sh
     become: yes
     become_user: root
+
     # Python2 pip and mysqldb are only available on stretch
   - name: Install packages for Raspbian Stretch
     package:
@@ -23,6 +24,7 @@
       state: present
     with_items: "{{ stretch_pkgs }}"
     when: ansible_distribution_major_version == '9' or ansible_distribution_major_version == '10'
+
     # This might be very very important before the pip run
   - name: Install apt packages and one python package
     package:
@@ -31,6 +33,7 @@
     with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
 
+  # Install python2 pip packages
   - name: Pip install pika==1.2.0
     pip:
       name: pika==1.2.0
@@ -62,14 +65,13 @@
   - name: Pip install matplotlib==2.2.5
     pip:
       name: matplotlib<=2.2.5
-    ignore_errors: yes
+    ignore_errors: yes 
+  - name: Pip install PyMySQL==0.10.1
+    pip:
+      name: PyMySQL==0.10.1
+    ignore_errors: yes 
+    when: ansible_distribution_major_version == '11'
 
-  # - name: Install pip packages
-  #   package:
-  #     name: "{{ item }}"
-  #     state: present
-  #   with_items: "{{ pip_pkgs }}"
-  #   ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:
       src: odbcinst.ini
@@ -154,12 +156,20 @@
       state: present
       insertafter: 'wiring'
       line: '  reset = 17;'
-  - name: Add bluetooth line if it does not exist to use ttyAMA0 port
+  - name: Disable bluetooth on Pi3 to use ttyAMA0 port
     lineinfile:
       name: /boot/config.txt
       state: present
       insertafter: 'enable_uart=1'
       line: 'dtoverlay=pi3-disable-bt'
+    when: ansible_distribution_major_version == '9'
+  - name: Disable bluetooth on Pi4 to use ttyAMA0 port
+    lineinfile:
+      name: /boot/config.txt
+      state: present
+      insertafter: 'enable_uart=1'
+      line: 'dtoverlay=disable-bt'
+    when: ansible_distribution_major_version == '11'
   - name: Update GPU memory
     lineinfile: 
       name: /boot/config.txt

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -30,12 +30,46 @@
       state: present
     with_items: "{{ apt_pkgs }}"
     ignore_errors: yes
-  - name: Install pip packages
-    package:
-      name: "{{ item }}"
-      state: present
-    with_items: "{{ pip_pkgs }}"
+
+  - name: Pip install pika==1.2.0
+    pip:
+      name: pika==1.2.0
     ignore_errors: yes
+  - name: Pip install paramiko 2.0.0
+    pip:
+      name: paramiko==2.0.0
+    ignore_errors: yes
+  - name: Pip install pigpio==1.78
+    pip:
+      name: pigpio==1.78
+    ignore_errors: yes
+  - name: Pip install pytz==2022.5
+    pip:
+      name: pytz==2022.5
+    ignore_errors: yes
+  - name: Pip install influxdb==5.2.0
+    pip:
+      name: influxdb==5.2.0
+    ignore_errors: yes
+  - name: Pip install pyserial==3.2.1
+    pip:
+      name: pyserial==3.2.1
+    ignore_errors: yes
+  - name: Pip install pyodbc<=4.0.34
+    pip:
+      name: pyodbc<=4.0.34
+    ignore_errors: yes
+  - name: Pip install matplotlib==2.2.5
+    pip:
+      name: matplotlib<=2.2.5
+    ignore_errors: yes
+
+  # - name: Install pip packages
+  #   package:
+  #     name: "{{ item }}"
+  #     state: present
+  #   with_items: "{{ pip_pkgs }}"
+  #   ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:
       src: odbcinst.ini
@@ -144,36 +178,5 @@
       insertafter: EOF
       line: 'ansible_from_easycut=True'
 
-  # - name: Pip install pika==1.2.0
-  #   pip:
-  #     name: pika==1.2.0
-  #   ignore_errors: yes
-  # - name: Pip install paramiko 2.0.0
-  #   pip:
-  #     name: paramiko==2.0.0
-  #   ignore_errors: yes
-  # - name: Pip install pigpio==1.78
-  #   pip:
-  #     name: pigpio==1.78
-  #   ignore_errors: yes
-  # - name: Pip install pytz==2022.5
-  #   pip:
-  #     name: pytz==2022.5
-  #   ignore_errors: yes
-  # - name: Pip install influxdb==5.2.0
-  #   pip:
-  #     name: influxdb==5.2.0
-  #   ignore_errors: yes
-  # - name: Pip install pyserial==3.2.1
-  #   pip:
-  #     name: pyserial==3.2.1
-  #   ignore_errors: yes
-  # - name: Pip install pyodbc<=4.0.34
-  #   pip:
-  #     name: pyodbc<=4.0.34
-  #   ignore_errors: yes
-  # - name: Pip install matplotlib==2.2.5
-  #   pip:
-  #     name: matplotlib<=2.2.5
-  #   ignore_errors: yes  
-  # 
+
+  

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -26,7 +26,7 @@
         - pika==1.2.0
         - pytz
         - influxdb
-        - mysqldb
+        - MySQL-python
         - pyodbc
         - matplotlib
         - pigpio

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -17,7 +17,7 @@
   - name: Install packages
     package:
       name: "{{ item }}"
-      state: present
+      state: absent
     with_items: "{{ pkgs }}"
     ignore_errors: yes
   - name: Install pip python packages
@@ -30,6 +30,7 @@
         - pyodbc
         - matplotlib
         - pigpio
+      state: absent
     ignore_errors: yes
   - name: Copying the odbcinst ini script
     template:

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -67,11 +67,13 @@
   #     name: matplotlib==2.2.5
   #   ignore_errors: yes
   #   when: ansible_distribution_major_version == '11'
-  - name: Pip install matplotlib and numpy (dependency)
+  - name: Pip install numpy==1.16.6
     pip:
-      name: 
-        - numpy==1.16.6
-        - matplotlib==2.2.5
+      name: numpy==1.16.6
+    ignore_errors: yes
+  - name: Pip install matplotlib==2.2.5
+    pip:
+      name: matplotlib==2.2.5
     ignore_errors: yes
     # when: ansible_distribution_major_version == '9'
   - name: Pip install PyMySQL==0.10.1


### PR DESCRIPTION
- I know that python-pigpio is installed twice (once with the auto package installer, once with pip). This is important - the auto package installer needs to find pip for python 2 on the pi 4 system, otherwise the specified pip package installer doesn't work. I'm not really sure why. 
-- It is possible to configure ansible to know what path to look for, but these are in different places on pi 3 and 4 so
- matplotlib and numpy install a bit weirdly and differently on each system - this very specific configuration of installing numpy and then mpl means we can keep versions consistent across platforms :) 
- have tried to specify versions where possible and where important. 

Tested on virgin Pi 4 and Pi 3 with factory SD card

NB: PACKAGE INSTALL COULD TAKE A WHILE DURING NEXT SW UPDATE IN FIELD