### PR TITLE
Make calibration app Y length neutral

### DIFF
--- a/src/asmcnc/calibration_app/screen_backlash.py
+++ b/src/asmcnc/calibration_app/screen_backlash.py
@@ -327,7 +327,7 @@ class BacklashScreenClass(Screen):
 
     def screen_y_1(self):
         self.m.jog_absolute_single_axis('X',-660, 9999)
-        self.m.jog_absolute_single_axis('Y', -2320, 9999)
+        self.m.jog_absolute_single_axis('Y', round(0.9 * self.m.y_min_jog_abs_limit), 9999)
         self.m.jog_relative('Y',-10,9999)
         self.m.jog_relative('Y',10,9999)
         self.sub_screen_count = 0

--- a/src/asmcnc/calibration_app/screen_distance_1_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_1_y.py
@@ -301,6 +301,9 @@ class DistanceScreen1yClass(Screen):
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
 
+        self.initial_y_cal_move = round(0.8 * (abs(self.m.y_max_jog_abs_limit - self.m.y_min_jog_abs_limit)))
+        self.expected_user_entry = round(0.08 * (abs(self.m.y_max_jog_abs_limit - self.m.y_min_jog_abs_limit)))
+
     def on_pre_enter(self):
         self.title_label.text = '[color=000000]Y Distance:[/color]'
         self.user_instructions_text.text = '\n\nPlease wait while the machine moves to the next measurement point...'                      
@@ -315,7 +318,7 @@ class DistanceScreen1yClass(Screen):
 
     def initial_move_y(self):
         self.m.jog_absolute_single_axis('X',-660,9999)    # machine moves on screen enter       
-        self.m.jog_absolute_single_axis('Y',-2320,9999)
+        self.m.jog_absolute_single_axis('Y', round(0.9 * self.m.y_min_jog_abs_limit), 9999)
         self.m.jog_relative('Y',-10,9999)
         self.m.jog_relative('Y',10,9999)
 

--- a/src/asmcnc/calibration_app/screen_distance_3_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_3_y.py
@@ -298,6 +298,8 @@ class DistanceScreen3yClass(Screen):
         self.sm=kwargs['screen_manager']
         self.m=kwargs['machine']
 
+        self.initial_y_cal_move = round(0.8 * (abs(self.m.y_max_jog_abs_limit - self.m.y_min_jog_abs_limit)))
+
     def on_pre_enter(self):
         self.nudge_counter = 0
         self.value_input.text = ''

--- a/src/asmcnc/calibration_app/screen_measurement.py
+++ b/src/asmcnc/calibration_app/screen_measurement.py
@@ -237,7 +237,7 @@ class MeasurementScreenClass(Screen):
         
     def screen_y_1(self):
         self.m.jog_absolute_single_axis('X',-660, 9999)
-        self.m.jog_absolute_single_axis('Y', -2320, 9999)
+        self.m.jog_absolute_single_axis('Y', round(0.9 * self.m.y_min_jog_abs_limit), 9999)
         self.instruction_top.text = '[color=000000][b]Y measurement:[/b] Lift the X beam and position the tape body at the maximum end of the bench [b](1)[/b], threading underneath the X beam [b](2)[/b]. ' \
                             'Tape end should be hooked at the home end [b](3)[/b], so that the lowest measurement number is at the home end [b](3)[/b].[/color]'
         self.instruction_left.text = ''


### PR DESCRIPTION
Removed all instances of hardcoded Y length values that are accessible to the user and replaced them with values based on grbl setting 131.

Tested on windows