### PR TITLE
Skip file load in job recovery if file is already loaded

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -619,6 +619,9 @@ class SerialConnection(object):
             Clock.schedule_once(lambda dt: self.m.zUp(), 0.5)
             Clock.schedule_once(lambda dt: self.m.vac_off(), 1)
 
+            # Store cancel line, as g_count is reset in update_machine_runtime
+            cancel_line = self.g_count - 35
+
             # Update time for maintenance reminders
             time.sleep(0.4)
             time_taken_seconds = self.update_machine_runtime()
@@ -628,7 +631,7 @@ class SerialConnection(object):
             # The line buffer has a capacity of 35 lines
             # So the currently executing command is the one 35 lines before the last one received by the buffer
             if not self.jd.job_recovery_skip_recovery:
-                self.jd.write_to_recovery_file_after_cancel(self.g_count - 35, time_taken_seconds)
+                self.jd.write_to_recovery_file_after_cancel(cancel_line, time_taken_seconds)
             
 
         else:

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -154,16 +154,30 @@ class RecoveryDecisionScreen(Screen):
     def repeat_job(self, recovering=False):
         if self.jd.job_recovery_cancel_line != None:
             if os.path.isfile(self.jd.job_recovery_filepath):
-                self.jd.reset_values()
-                self.jd.job_recovery_from_beginning = True
-                self.jd.set_job_filename(self.jd.job_recovery_filepath)
+                # Only load file if it's not already loaded
+                if self.jd.job_recovery_filepath != self.jd.filename:
+                    self.jd.reset_values()
+                    self.jd.job_recovery_from_beginning = True
+                    self.jd.set_job_filename(self.jd.job_recovery_filepath)
 
-                if recovering:
-                    self.sm.get_screen('loading').continuing_to_recovery = True
+                    if recovering:
+                        self.sm.get_screen('loading').continuing_to_recovery = True
+                    else:
+                        self.sm.get_screen('loading').skip_check_decision = True
+
+                    self.sm.current = 'loading'
+
                 else:
-                    self.sm.get_screen('loading').skip_check_decision = True
+                    self.sm.get_screen('home').z_datum_reminder_flag = True
+                    self.jd.reset_recovery()
 
-                self.sm.current = 'loading'
+                    if recovering:
+                        self.sm.get_screen('homing_decision').return_to_screen = 'job_recovery'
+                        self.sm.get_screen('homing_decision').cancel_to_screen = 'job_recovery'
+                        self.sm.current = 'homing_decision'
+                    else:
+                        self.jd.job_recovery_from_beginning = True
+                        self.back_to_home()
 
             else: 
                 error_message = self.l.get_str('File selected does not exist!')


### PR DESCRIPTION
When a file is being loaded from the job recovery decision screen, the file load is skipped if the file is already loaded.

(This also includes a fix to my last change which included a call to the update_machine_runtime function before the cancellation line is recorded, which resulted in line 0 always being saved)

Tested on windows