### PR TITLE
Move relative commands don't need to be sent as jogs in cal app

### DIFF
--- a/src/asmcnc/calibration_app/screen_backlash.py
+++ b/src/asmcnc/calibration_app/screen_backlash.py
@@ -370,8 +370,8 @@ class BacklashScreenClass(Screen):
     
     def test(self):    
         
-        jog_relative_to_stream = ['$J=G91 ' + self.axis + str(self.backlash_move_distance) + ' F9999',
-                                  '$J=G91 ' + self.axis + str(-1*self.backlash_move_distance) + ' F9999'
+        jog_relative_to_stream = ['G91 ' + self.axis + str(self.backlash_move_distance) + ' F6000',
+                                  'G91 ' + self.axis + str(-1*self.backlash_move_distance) + ' F6000'
                                   ]
         self.m.s.start_sequential_stream(jog_relative_to_stream)
         


### PR DESCRIPTION
The $J caused an error when sent with sequential streaming, now that a pause has been added when $ commands are sent. 

Tested on rig