### PR TITLE
Make holding scroll button scroll indefinitely

### DIFF
--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -85,7 +85,8 @@ Builder.load_string("""
 
                             Button:
                                 background_color: [0,0,0,0]
-                                on_press: root.scroll_up()
+                                on_press: root.start_scrolling_up()
+                                on_release: root.stop_scrolling_up()
                                 BoxLayout:
                                     padding: 0
                                     size: self.parent.size
@@ -99,7 +100,8 @@ Builder.load_string("""
 
                             Button:
                                 background_color: [0,0,0,0]
-                                on_press: root.scroll_down()
+                                on_press: root.start_scrolling_down()
+                                on_release: root.stop_scrolling_down()
                                 BoxLayout:
                                     padding: 0
                                     size: self.parent.size
@@ -329,15 +331,53 @@ class JobRecoveryScreen(Screen):
             self.display_list[self.selected_line_index + 6] = "[color=FF0000]" + self.display_list[self.selected_line_index + 6] + "[/color]"
             self.update_display()
 
-    def scroll_up(self):
+    def start_scrolling_up(self):
+        self.scrolling_up = True
+
+        # Do one scroll immediately
         if self.selected_line_index > 0:
             self.selected_line_index -= 1
             self.update_display()
 
-    def scroll_down(self):
+        # Start scrolling after a delay
+        self.scroll_up_event = Clock.schedule_once(self.scroll_up, 0.5)
+
+    def scroll_up(self, dt=0):
+        if self.scrolling_up:
+            if self.selected_line_index > 0:
+                self.selected_line_index -= 1
+                self.update_display()
+
+                # Keep scrolling until button released
+                self.scroll_up_event = Clock.schedule_once(self.scroll_up, 0.03)
+
+    def stop_scrolling_up(self):
+        self.scrolling_up = False
+        Clock.unschedule(self.scroll_up_event)
+
+    def start_scrolling_down(self):
+        self.scrolling_down = True
+
+        # Do one scroll immediately
         if self.selected_line_index < self.initial_line_index:
             self.selected_line_index += 1
             self.update_display()
+
+        # Start scrolling after a delay
+        self.scroll_down_event = Clock.schedule_once(self.scroll_down, 0.5)
+
+    def scroll_down(self, dt=0):
+        if self.scrolling_down:
+            if self.selected_line_index < self.initial_line_index:
+                self.selected_line_index += 1
+                self.update_display()
+
+                # Keep scrolling until button released
+                self.scroll_down_event = Clock.schedule_once(self.scroll_down, 0.03)
+
+    def stop_scrolling_down(self):
+        self.scrolling_down = False
+        Clock.unschedule(self.scroll_down_event)
 
     def jump_to_line(self, instance, value):
         if value:

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -299,6 +299,9 @@ class JobRecoveryScreen(Screen):
     selected_line_index = 0
     display_list = []
 
+    scroll_up_event = None
+    scroll_down_event = None
+
     def __init__(self, **kwargs):
         super(JobRecoveryScreen, self).__init__(**kwargs)
 
@@ -354,7 +357,8 @@ class JobRecoveryScreen(Screen):
 
     def stop_scrolling_up(self):
         self.scrolling_up = False
-        Clock.unschedule(self.scroll_up_event)
+        if self.scroll_up_event:
+            Clock.unschedule(self.scroll_up_event)
 
     def start_scrolling_down(self):
         self.scrolling_down = True
@@ -379,7 +383,8 @@ class JobRecoveryScreen(Screen):
 
     def stop_scrolling_down(self):
         self.scrolling_down = False
-        Clock.unschedule(self.scroll_down_event)
+        if self.scroll_down_event:
+            Clock.unschedule(self.scroll_down_event)
 
     def jump_to_line(self, instance, value):
         if value:

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -85,8 +85,12 @@ Builder.load_string("""
 
                             Button:
                                 background_color: [0,0,0,0]
-                                on_press: root.start_scrolling_up()
-                                on_release: root.stop_scrolling_up()
+                                on_press:
+                                    root.start_scrolling_up()
+                                    self.background_color = hex('#F44336FF')
+                                on_release:
+                                    self.background_color = hex('#F4433600')
+                                    root.stop_scrolling_up()
                                 BoxLayout:
                                     padding: 0
                                     size: self.parent.size
@@ -100,8 +104,12 @@ Builder.load_string("""
 
                             Button:
                                 background_color: [0,0,0,0]
-                                on_press: root.start_scrolling_down()
-                                on_release: root.stop_scrolling_down()
+                                on_press:
+                                    root.start_scrolling_down()
+                                    self.background_color = hex('#F44336FF')
+                                on_release:
+                                    root.stop_scrolling_down()
+                                    self.background_color = hex('#F4433600')
                                 BoxLayout:
                                     padding: 0
                                     size: self.parent.size

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -335,21 +335,22 @@ class JobRecoveryScreen(Screen):
         self.scrolling_up = True
 
         # Do one scroll immediately
-        if self.selected_line_index > 0:
-            self.selected_line_index -= 1
-            self.update_display()
+        self.do_scroll_up()
 
         # Start scrolling after a delay
         self.scroll_up_event = Clock.schedule_once(self.scroll_up, 0.5)
 
+    def do_scroll_up(self):
+        if self.selected_line_index > 0:
+            self.selected_line_index -= 1
+            self.update_display()
+
     def scroll_up(self, dt=0):
         if self.scrolling_up:
-            if self.selected_line_index > 0:
-                self.selected_line_index -= 1
-                self.update_display()
+            self.do_scroll_up()
 
-                # Keep scrolling until button released
-                self.scroll_up_event = Clock.schedule_once(self.scroll_up, 0.03)
+            # Keep scrolling until button released
+            self.scroll_up_event = Clock.schedule_once(self.scroll_up, 0.03)
 
     def stop_scrolling_up(self):
         self.scrolling_up = False
@@ -359,21 +360,22 @@ class JobRecoveryScreen(Screen):
         self.scrolling_down = True
 
         # Do one scroll immediately
-        if self.selected_line_index < self.initial_line_index:
-            self.selected_line_index += 1
-            self.update_display()
+        self.do_scroll_down()
 
         # Start scrolling after a delay
         self.scroll_down_event = Clock.schedule_once(self.scroll_down, 0.5)
 
+    def do_scroll_down(self):
+        if self.selected_line_index < self.initial_line_index:
+            self.selected_line_index += 1
+            self.update_display()
+
     def scroll_down(self, dt=0):
         if self.scrolling_down:
-            if self.selected_line_index < self.initial_line_index:
-                self.selected_line_index += 1
-                self.update_display()
+            self.do_scroll_down()
 
-                # Keep scrolling until button released
-                self.scroll_down_event = Clock.schedule_once(self.scroll_down, 0.03)
+            # Keep scrolling until button released
+            self.scroll_down_event = Clock.schedule_once(self.scroll_down, 0.03)
 
     def stop_scrolling_down(self):
         self.scrolling_down = False


### PR DESCRIPTION
Holding down the gcode scroll button on job recovery line selection screen now scrolls continuously after a short delay

Tested on windows by spamming buttons a lot