### PR TITLE
whitespace is stripped in user input anyway, but operators will still delete it if it's there so also strip from when branch put into textbox

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -296,7 +296,7 @@ class BetaTestingScreen(Screen):
         self.set = kwargs['settings']
         self.l = kwargs['localization']
 
-        self.user_branch.text = (self.set.sw_branch).strip('*')
+        self.user_branch.text = (self.set.sw_branch).strip('* ')
         self.beta_version.text = self.set.latest_sw_beta
 
         self.usb_stick = usb_storage.USB_storage(self.systemtools_sm.sm, self.l)


### PR DESCRIPTION
Tested on rig