### PR TITLE
Up down jig popups

### DIFF
--- a/src/asmcnc/production/z_head_mechanics_jig/popup_z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/popup_z_head_mechanics.py
@@ -1,0 +1,109 @@
+from kivy.uix.popup import Popup
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.widget import Widget
+from kivy.uix.label import Label
+from kivy.uix.button import  Button
+from kivy.uix.image import Image
+
+class PopupCalibrate(Widget):
+
+    def __init__(self, screen_manager, localization):
+        
+        self.sm = screen_manager
+        self.l = localization
+
+        description = "Remove the belt, then press 'Calibrate' to continue"
+        title_string = "Calibration"
+        calibrate_string = "Calibrate"
+        cancel_string = "Cancel"
+
+        def do_calibrate(*args):
+            self.sm.get_screen('mechanics').calibrate_motor()
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+
+        ok_button = Button(text=calibrate_string, markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        ok_button.bold = True
+        cancel_button = Button(text=cancel_string, markup = True)
+        cancel_button.background_normal = ''
+        cancel_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+        cancel_button.bold = True
+
+        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[0,10,0,0])
+        btn_layout.add_widget(cancel_button)
+        btn_layout.add_widget(ok_button)
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(btn_layout)
+        
+        popup = Popup(title=title_string,
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(540, 400),
+                      auto_dismiss= False
+                      )
+
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
+        popup.separator_height = '4dp'
+
+        ok_button.bind(on_press=do_calibrate)
+        ok_button.bind(on_press=popup.dismiss)
+        cancel_button.bind(on_press=popup.dismiss)
+
+        popup.open()
+
+
+class PopupPhaseTwo(Widget):
+
+    def __init__(self, screen_manager, localization):
+        
+        self.sm = screen_manager
+        self.l = localization
+
+        description = "Press 'Continue' to proceed to fast run"
+        title_string = "Phase Two"
+        ok_string = "Continue"
+
+        def proceed_to_phase_two(*args):
+            self.sm.get_screen('mechanics').phase_two()
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+
+        ok_button = Button(text=ok_string, markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        ok_button.bold = True
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(ok_button)
+        
+        popup = Popup(title=title_string,
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(540, 400),
+                      auto_dismiss= False
+                      )
+
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
+        popup.separator_height = '4dp'
+
+        ok_button.bind(on_press=proceed_to_phase_two)
+        ok_button.bind(on_press=popup.dismiss)
+
+        popup.open()

--- a/src/asmcnc/production/z_head_mechanics_jig/popup_z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/popup_z_head_mechanics.py
@@ -69,7 +69,7 @@ class PopupPhaseTwo(Widget):
         self.sm = screen_manager
         self.l = localization
 
-        description = "Press 'Continue' to proceed to fast run"
+        description = "Press 'Continue' to proceed to fast run. Watch and listen for a stall throughout."
         title_string = "Phase Two"
         ok_string = "Continue"
 

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -1,15 +1,10 @@
 from kivy.uix.screenmanager import Screen
 from kivy.lang import Builder
 from kivy.clock import Clock
-from kivy.uix.popup import Popup
-from kivy.uix.boxlayout import BoxLayout
-from kivy.uix.widget import Widget
-from kivy.uix.label import Label
-from kivy.uix.button import  Button
-from kivy.uix.image import Image
 
 from asmcnc.comms.yeti_grbl_protocol.c_defines import *
 from asmcnc.skavaUI import popup_info
+from asmcnc.production.z_head_mechanics_jig.popup_z_head_mechanics import *
 
 import matplotlib
 matplotlib.use('Agg')
@@ -205,110 +200,6 @@ Builder.load_string("""
             opacity: 0
 
 """)
-
-
-class PopupCalibrate(Widget):
-
-    def __init__(self, screen_manager, localization):
-        
-        self.sm = screen_manager
-        self.l = localization
-
-        description = "Remove the belt, then press 'Calibrate' to continue"
-        title_string = "Calibration"
-        calibrate_string = "Calibrate"
-        cancel_string = "Cancel"
-
-        def do_calibrate(*args):
-            self.sm.get_screen('mechanics').calibrate_motor()
-        
-        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
-        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
-
-        ok_button = Button(text=calibrate_string, markup = True)
-        ok_button.background_normal = ''
-        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
-        ok_button.bold = True
-        cancel_button = Button(text=cancel_string, markup = True)
-        cancel_button.background_normal = ''
-        cancel_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
-        cancel_button.bold = True
-
-        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[0,10,0,0])
-        btn_layout.add_widget(cancel_button)
-        btn_layout.add_widget(ok_button)
-        
-        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
-        layout_plan.add_widget(img)
-        layout_plan.add_widget(label)
-        layout_plan.add_widget(btn_layout)
-        
-        popup = Popup(title=title_string,
-                      title_color=[0, 0, 0, 1],
-                      title_font= 'Roboto-Bold',
-                      title_size = '20sp',
-                      content=layout_plan,
-                      size_hint=(None, None),
-                      size=(540, 400),
-                      auto_dismiss= False
-                      )
-
-        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
-        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
-        popup.separator_height = '4dp'
-
-        ok_button.bind(on_press=do_calibrate)
-        ok_button.bind(on_press=popup.dismiss)
-        cancel_button.bind(on_press=popup.dismiss)
-
-        popup.open()
-
-
-class PopupPhaseTwo(Widget):
-
-    def __init__(self, screen_manager, localization):
-        
-        self.sm = screen_manager
-        self.l = localization
-
-        description = "Press 'Continue' to proceed to fast run"
-        title_string = "Phase Two"
-        ok_string = "Continue"
-
-        def proceed_to_phase_two(*args):
-            self.sm.get_screen('mechanics').phase_two()
-        
-        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
-        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
-
-        ok_button = Button(text=ok_string, markup = True)
-        ok_button.background_normal = ''
-        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
-        ok_button.bold = True
-        
-        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
-        layout_plan.add_widget(img)
-        layout_plan.add_widget(label)
-        layout_plan.add_widget(ok_button)
-        
-        popup = Popup(title=title_string,
-                      title_color=[0, 0, 0, 1],
-                      title_font= 'Roboto-Bold',
-                      title_size = '20sp',
-                      content=layout_plan,
-                      size_hint=(None, None),
-                      size=(540, 400),
-                      auto_dismiss= False
-                      )
-
-        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
-        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
-        popup.separator_height = '4dp'
-
-        ok_button.bind(on_press=proceed_to_phase_two)
-        ok_button.bind(on_press=popup.dismiss)
-
-        popup.open()
 
 
 class ZHeadMechanics(Screen):

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -228,9 +228,11 @@ class PopupCalibrate(Widget):
         ok_button = Button(text=calibrate_string, markup = True)
         ok_button.background_normal = ''
         ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        ok_button.bold = True
         cancel_button = Button(text=cancel_string, markup = True)
         cancel_button.background_normal = ''
         cancel_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+        cancel_button.bold = True
 
         btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[0,10,0,0])
         btn_layout.add_widget(cancel_button)
@@ -260,6 +262,54 @@ class PopupCalibrate(Widget):
         cancel_button.bind(on_press=popup.dismiss)
 
         popup.open()
+
+
+class PopupPhaseTwo(Widget):
+
+    def __init__(self, screen_manager, localization):
+        
+        self.sm = screen_manager
+        self.l = localization
+
+        description = "Press 'Continue' to proceed to fast run"
+        title_string = "Phase Two"
+        ok_string = "Continue"
+
+        def proceed_to_phase_two(*args):
+            self.sm.get_screen('mechanics').phase_two()
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+
+        ok_button = Button(text=ok_string, markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        ok_button.bold = True
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(ok_button)
+        
+        popup = Popup(title=title_string,
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(540, 400),
+                      auto_dismiss= False
+                      )
+
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
+        popup.separator_height = '4dp'
+
+        ok_button.bind(on_press=proceed_to_phase_two)
+        ok_button.bind(on_press=popup.dismiss)
+
+        popup.open()
+
 
 class ZHeadMechanics(Screen):
 
@@ -339,7 +389,7 @@ class ZHeadMechanics(Screen):
     def record_up_values(self, dt):
         if self.test_running:
             if self.m.state().startswith('Idle'):
-                self.phase_two()
+                PopupPhaseTwo(self.sm, self.l)
             else:
                 if self.m.s.sg_z_motor_axis != -999:
                     self.sg_values_up.append(self.m.s.sg_z_motor_axis)

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -1,6 +1,12 @@
 from kivy.uix.screenmanager import Screen
 from kivy.lang import Builder
 from kivy.clock import Clock
+from kivy.uix.popup import Popup
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.widget import Widget
+from kivy.uix.label import Label
+from kivy.uix.button import  Button
+from kivy.uix.image import Image
 
 from asmcnc.comms.yeti_grbl_protocol.c_defines import *
 from asmcnc.skavaUI import popup_info
@@ -47,7 +53,7 @@ Builder.load_string("""
                     font_size: dp(20)
                     background_color: hex('#FF9900FF')
                     background_normal: ''
-                    on_press: root.calibrate_motor()
+                    on_press: root.show_calibration_popup()
 
                 Button:
                     id: begin_test_button
@@ -200,6 +206,60 @@ Builder.load_string("""
 
 """)
 
+
+class PopupCalibrate(Widget):
+
+    def __init__(self, screen_manager, localization):
+        
+        self.sm = screen_manager
+        self.l = localization
+
+        description = "Remove the belt, then press 'Calibrate' to continue"
+        title_string = "Calibration"
+        calibrate_string = "Calibrate"
+        cancel_string = "Cancel"
+
+        def do_calibrate(*args):
+            self.sm.get_screen('mechanics').calibrate_motor()
+        
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/info_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=1.5, text_size=(480, None), halign='center', valign='middle', text=description, color=[0,0,0,1], padding=[0,0], markup = True)
+
+        ok_button = Button(text=calibrate_string, markup = True)
+        ok_button.background_normal = ''
+        ok_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        cancel_button = Button(text=cancel_string, markup = True)
+        cancel_button.background_normal = ''
+        cancel_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+
+        btn_layout = BoxLayout(orientation='horizontal', spacing=10, padding=[0,10,0,0])
+        btn_layout.add_widget(cancel_button)
+        btn_layout.add_widget(ok_button)
+        
+        layout_plan = BoxLayout(orientation='vertical', spacing=10, padding=[20,10,20,10])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(btn_layout)
+        
+        popup = Popup(title=title_string,
+                      title_color=[0, 0, 0, 1],
+                      title_font= 'Roboto-Bold',
+                      title_size = '20sp',
+                      content=layout_plan,
+                      size_hint=(None, None),
+                      size=(540, 400),
+                      auto_dismiss= False
+                      )
+
+        popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+        popup.separator_color = [249 / 255., 206 / 255., 29 / 255., 1.]
+        popup.separator_height = '4dp'
+
+        ok_button.bind(on_press=do_calibrate)
+        ok_button.bind(on_press=popup.dismiss)
+        cancel_button.bind(on_press=popup.dismiss)
+
+        popup.open()
 
 class ZHeadMechanics(Screen):
 
@@ -357,6 +417,9 @@ class ZHeadMechanics(Screen):
         self.z_pos_values_down = []
         self.z_pos_values_up = []
 
+
+    def show_calibration_popup(self):
+        PopupCalibrate(self.sm, self.l)
 
     def calibrate_motor(self):
         self.load_graph.opacity = 0


### PR DESCRIPTION
Up down jig has two new popups:

- When calibrate button is pressed, a popup is shown to tell user to remove the belt before calibration
- When phase one ends, a popup is shown that warns the user before phase two starts

![image](https://user-images.githubusercontent.com/75572055/207980266-48744ffd-8e7d-4f50-809d-e381091eb87b.png)

![image](https://user-images.githubusercontent.com/75572055/207980648-dae4564f-65df-47cf-87bb-181401ff1d8f.png)
