### PR TITLE
Reset currents only if Idle

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -88,8 +88,12 @@ Builder.load_string("""
                                 on_press: root.home()
         
                             Button:
-                                text: 'Reset'
+                                text: 'Reset I'
                                 on_press: root.reset_currents()
+
+                            Button:
+                                text: 'GRBL Reset'
+                                on_press: root.grbl_reset()
 
                             Label: 
                                 id: protocol_status
@@ -244,12 +248,16 @@ class CurrentAdjustment(Screen):
 
     def on_leave(self):
         self.m.s.FINAL_TEST = False
-        self.reset_currents()
-        self.raw_sg_toggle_button.state = 'normal'
-        self.toggle_raw_sg_values()
         if self.update_protocol_status_label_event: Clock.unschedule(self.update_protocol_status_label_event)
 
     def back_to_fac_settings(self):
+        if not self.m.state().startswith("Idle"):
+            PopupWarning(self.systemtools_sm.sm,  self.l, "SB not Idle!! Can't reset currents!")
+            return
+
+        self.raw_sg_toggle_button.state = 'normal'
+        self.toggle_raw_sg_values()
+        self.reset_currents()
         self.systemtools_sm.open_factory_settings_screen()
 
     def home(self):
@@ -312,12 +320,24 @@ class CurrentAdjustment(Screen):
 
 
     def reset_currents(self):
+        
+        if not self.m.state().startswith("Idle"):
+            PopupWarning(self.systemtools_sm.sm,  self.l, "SB not Idle!! Can't reset currents!")
+            return False
+
         self.wait_popup_for_reset_currents = PopupWait(self.systemtools_sm.sm,  self.l)
-        self.x1_current_adjustment_widget.reset_current()
-        self.x2_current_adjustment_widget.reset_current()
-        self.y1_current_adjustment_widget.reset_current()
-        self.y2_current_adjustment_widget.reset_current()
-        self.z_current_adjustment_widget.reset_current()
+
+        if  self.x1_current_adjustment_widget.reset_current() and \
+            self.x2_current_adjustment_widget.reset_current() and \
+            self.y1_current_adjustment_widget.reset_current() and \
+            self.y2_current_adjustment_widget.reset_current() and \
+            self.z_current_adjustment_widget.reset_current():
+
+            return True
+
+        else: 
+            return False
+
         self.wait_while_currents_reset()
 
     def wait_while_currents_reset(self, dt=0):
@@ -354,12 +374,14 @@ class CurrentAdjustment(Screen):
         else: 
             Clock.schedule_once(self.wait_while_values_stored_and_read_back_in, 0.2)
 
-
     def update_protocol_status_label(self, dt=0):
 
         if self.m.s.write_protocol_buffer: 
             self.protocol_status.text = "Writing..."
         else:
             self.protocol_status.text = ""
+
+    def grbl_reset(self):
+        self.m.reset_from_alarm()
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -327,11 +327,11 @@ class CurrentAdjustment(Screen):
 
         self.wait_popup_for_reset_currents = PopupWait(self.systemtools_sm.sm,  self.l)
 
-        if  self.x1_current_adjustment_widget.reset_current() and \
+        if  (self.x1_current_adjustment_widget.reset_current() and \
             self.x2_current_adjustment_widget.reset_current() and \
             self.y1_current_adjustment_widget.reset_current() and \
             self.y2_current_adjustment_widget.reset_current() and \
-            self.z_current_adjustment_widget.reset_current():
+            self.z_current_adjustment_widget.reset_current()):
 
             return True
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -327,16 +327,12 @@ class CurrentAdjustment(Screen):
 
         self.wait_popup_for_reset_currents = PopupWait(self.systemtools_sm.sm,  self.l)
 
-        if  (self.x1_current_adjustment_widget.reset_current() and \
-            self.x2_current_adjustment_widget.reset_current() and \
-            self.y1_current_adjustment_widget.reset_current() and \
-            self.y2_current_adjustment_widget.reset_current() and \
-            self.z_current_adjustment_widget.reset_current()):
-
-            return True
-
-        else: 
-            return False
+        if  not self.x1_current_adjustment_widget.reset_current() or \
+            not self.x2_current_adjustment_widget.reset_current() or \
+            not self.y1_current_adjustment_widget.reset_current() or \
+            not self.y2_current_adjustment_widget.reset_current() or \
+            not self.z_current_adjustment_widget.reset_current():
+            PopupWarning(self.systemtools_sm.sm,  self.l, "Issue resetting currents!")
 
         self.wait_while_currents_reset()
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -378,6 +378,6 @@ class CurrentAdjustment(Screen):
             self.protocol_status.text = ""
 
     def grbl_reset(self):
-        self.m.reset_from_alarm()
+        self.m.resume_from_alarm()
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -88,7 +88,7 @@ Builder.load_string("""
                                 on_press: root.home()
         
                             Button:
-                                text: 'Reset I'
+                                text: 'Reset Currents'
                                 on_press: root.reset_currents()
 
                             Button:

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
@@ -83,9 +83,9 @@ class CurrentAdjustmentWidget(Widget):
         self.set_current(self.current_current-1)
 
     def reset_current(self):
-        self.current_current = self.m.TMC_motor[self.motor].ActiveCurrentScale
-        self.m.set_motor_current(self.motor_name_dict[self.motor], self.current_current)
-        self.current_current_label.text = str(self.current_current)
+        if self.m.set_motor_current(self.motor_name_dict[self.motor], self.m.TMC_motor[self.motor].ActiveCurrentScale):
+            self.current_current = self.m.TMC_motor[self.motor].ActiveCurrentScale
+            self.current_current_label.text = str(self.current_current)
 
     def on_focus(self, instance, value):
         if not value:

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
@@ -86,6 +86,9 @@ class CurrentAdjustmentWidget(Widget):
         if self.m.set_motor_current(self.motor_name_dict[self.motor], self.m.TMC_motor[self.motor].ActiveCurrentScale):
             self.current_current = self.m.TMC_motor[self.motor].ActiveCurrentScale
             self.current_current_label.text = str(self.current_current)
+            return True
+
+        return False
 
     def on_focus(self, instance, value):
         if not value:


### PR DESCRIPTION
- Ensure that currents are only reset when: 
    - User presses Reset currents button
    - User presses Factory settings button
- Currents are NOT reset if there is an alarm/stop bar/grbl error, but that's fine because it will return to the screen. 
- Change reset_current function to only update labels if the current setting has been successful 
- Add a grbl reset button to the screen