### PR TITLE
Needed to patch store tmc values popup on threshold setting screen

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -2,6 +2,7 @@ from kivy.uix.screenmanager import Screen
 from kivy.lang import Builder
 
 from asmcnc.apps.systemTools_app.screens.popup_system import PopupConfirmStoreCurrentValues
+from asmcnc.skavaUI.popup_info import PopupWait
 
 Builder.load_string("""
 <SetThresholdsScreen>:
@@ -87,7 +88,22 @@ class SetThresholdsScreen(Screen):
         self.m.set_threshold_for_axis(axis, int(value))
 
     def store_parameters(self):
-        PopupConfirmStoreCurrentValues(self.m, self.systemtools_sm.sm, self.l)
+        PopupConfirmStoreCurrentValues(self.m, self.systemtools_sm.sm, self.l, self)
 
     def back_to_fac_settings(self):
         self.systemtools_sm.open_factory_settings_screen()
+
+    def store_values_and_wait_for_handshake(self):
+        self.wait_popup_for_tmc_read_in = PopupWait(self.systemtools_sm.sm,  self.l)
+        Clock.schedule_once(self.do_tmc_value_store, 0.2)
+
+    def do_tmc_value_store(self, dt=0):
+        self.m.store_tmc_params_in_eeprom_and_handshake()
+        self.wait_while_values_stored_and_read_back_in()
+
+    def wait_while_values_stored_and_read_back_in(self, dt=0):
+        if self.m.TMC_registers_have_been_read_in(): 
+            self.wait_popup_for_tmc_read_in.popup.dismiss()
+            self.wait_popup_for_tmc_read_in = None
+        else: 
+            Clock.schedule_once(self.wait_while_values_stored_and_read_back_in, 0.2)

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -3,6 +3,7 @@ from kivy.lang import Builder
 
 from asmcnc.apps.systemTools_app.screens.popup_system import PopupConfirmStoreCurrentValues
 from asmcnc.skavaUI.popup_info import PopupWait
+from kivy.clock import Clock
 
 Builder.load_string("""
 <SetThresholdsScreen>:


### PR DESCRIPTION
## Bug
When modifying the current adjustment screen, and the popup for storing TMC values, I didn't realise that the threshold setting screen used the same popup. As a result, the mods didn't go into the other screen! 

I've added the additional argument and functions to get it to work. 

It could probably do with a little bit of refactoring, but I'm under time pressure and need to finish setting thresholds on the Y rack cutter so that will need to happen another time :) 

(I've also checked that those are the only two screens using this popup currently) 
