### PR TITLE
Show threshold values on set threshold screen

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -17,6 +17,10 @@ Builder.load_string("""
     y_stored_threshold:y_stored_threshold
     z_stored_threshold:z_stored_threshold
 
+    x_set_threshold:x_set_threshold
+    y_set_threshold:y_set_threshold
+    z_set_threshold:z_set_threshold
+
     BoxLayout:
         orientation: 'vertical'
 
@@ -28,7 +32,7 @@ Builder.load_string("""
 
             GridLayout:
                 size_hint_y: 1.5
-                cols: 5
+                cols: 7
                 rows: 3
                 spacing: dp(10)
 
@@ -52,6 +56,13 @@ Builder.load_string("""
                     text: '?'
 
                 Label:
+                    text: 'Set:'
+
+                Label:
+                    id: x_set_threshold
+                    text: ''
+
+                Label:
                     text: 'Y:'
 
                 TextInput:
@@ -71,6 +82,13 @@ Builder.load_string("""
                     text: '?'
 
                 Label:
+                    text: 'Set:'
+
+                Label:
+                    id: y_set_threshold
+                    text: ''
+
+                Label:
                     text: 'Z:'
 
                 TextInput:
@@ -88,6 +106,13 @@ Builder.load_string("""
                 Label:
                     id: z_stored_threshold
                     text: '?'
+
+                Label:
+                    text: 'Set:'
+
+                Label:
+                    id: z_set_threshold
+                    text: ''
 
             BoxLayout:
                 orientation: 'vertical'
@@ -113,6 +138,7 @@ class SetThresholdsScreen(Screen):
 
     def on_enter(self):
         self.show_thresholds()
+        self.update_set_thresholds()
 
     def show_thresholds(self):
         self.x_threshold_input.text = str(self.m.TMC_motor[TMC_X1].stallGuardAlarmThreshold)
@@ -124,8 +150,14 @@ class SetThresholdsScreen(Screen):
         self.y_stored_threshold.text = str(self.m.TMC_motor[TMC_Y1].stallGuardAlarmThreshold)
         self.z_stored_threshold.text = str(self.m.TMC_motor[TMC_Z].stallGuardAlarmThreshold)
 
+    def update_set_thresholds(self):
+        self.x_set_threshold.text = str(self.m.TMC_motor[TMC_X1].stallGuardAlarmThreshold)
+        self.y_set_threshold.text = str(self.m.TMC_motor[TMC_Y1].stallGuardAlarmThreshold)
+        self.z_set_threshold.text = str(self.m.TMC_motor[TMC_Z].stallGuardAlarmThreshold)
+
     def set_threshold(self, axis, value):
         self.m.set_threshold_for_axis(axis, int(value))
+        self.update_set_thresholds()
 
     def store_parameters(self):
         PopupConfirmStoreCurrentValues(self.m, self.systemtools_sm.sm, self.l, self)

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -49,7 +49,7 @@ Builder.load_string("""
 
                 Label:
                     id: x_stored_threshold
-                    text: ''
+                    text: '?'
 
                 Label:
                     text: 'Y:'
@@ -68,7 +68,7 @@ Builder.load_string("""
 
                 Label:
                     id: y_stored_threshold
-                    text: ''
+                    text: '?'
 
                 Label:
                     text: 'Z:'
@@ -87,7 +87,7 @@ Builder.load_string("""
 
                 Label:
                     id: z_stored_threshold
-                    text: ''
+                    text: '?'
 
             BoxLayout:
                 orientation: 'vertical'

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -4,6 +4,7 @@ from kivy.lang import Builder
 from asmcnc.apps.systemTools_app.screens.popup_system import PopupConfirmStoreCurrentValues
 from asmcnc.skavaUI.popup_info import PopupWait
 from kivy.clock import Clock
+from asmcnc.comms.yeti_grbl_protocol.c_defines import *
 
 Builder.load_string("""
 <SetThresholdsScreen>:
@@ -11,6 +12,10 @@ Builder.load_string("""
     x_threshold_input:x_threshold_input
     y_threshold_input:y_threshold_input
     z_threshold_input:z_threshold_input
+
+    x_stored_threshold:x_stored_threshold
+    y_stored_threshold:y_stored_threshold
+    z_stored_threshold:z_stored_threshold
 
     BoxLayout:
         orientation: 'vertical'
@@ -23,7 +28,7 @@ Builder.load_string("""
 
             GridLayout:
                 size_hint_y: 1.5
-                cols: 3
+                cols: 5
                 rows: 3
                 spacing: dp(10)
 
@@ -40,6 +45,13 @@ Builder.load_string("""
                     on_press: root.set_threshold('X', x_threshold_input.text)
 
                 Label:
+                    text: 'Stored:'
+
+                Label:
+                    id: x_stored_threshold
+                    text: ''
+
+                Label:
                     text: 'Y:'
 
                 TextInput:
@@ -52,6 +64,13 @@ Builder.load_string("""
                     on_press: root.set_threshold('Y', y_threshold_input.text)
 
                 Label:
+                    text: 'Stored:'
+
+                Label:
+                    id: y_stored_threshold
+                    text: ''
+
+                Label:
                     text: 'Z:'
 
                 TextInput:
@@ -62,6 +81,13 @@ Builder.load_string("""
                 Button:
                     text: 'Set'
                     on_press: root.set_threshold('Z', z_threshold_input.text)
+
+                Label:
+                    text: 'Stored:'
+
+                Label:
+                    id: z_stored_threshold
+                    text: ''
 
             BoxLayout:
                 orientation: 'vertical'
@@ -85,6 +111,19 @@ class SetThresholdsScreen(Screen):
         self.m = kwargs['m']
         self.l = kwargs['l']
 
+    def on_enter(self):
+        self.show_thresholds()
+
+    def show_thresholds(self):
+        self.x_threshold_input.text = str(self.m.TMC_motor[TMC_X1].stallGuardAlarmThreshold)
+        self.y_threshold_input.text = str(self.m.TMC_motor[TMC_Y1].stallGuardAlarmThreshold)
+        self.z_threshold_input.text = str(self.m.TMC_motor[TMC_Z].stallGuardAlarmThreshold)
+
+    def update_stored_thresholds(self):
+        self.x_stored_threshold.text = str(self.m.TMC_motor[TMC_X1].stallGuardAlarmThreshold)
+        self.y_stored_threshold.text = str(self.m.TMC_motor[TMC_Y1].stallGuardAlarmThreshold)
+        self.z_stored_threshold.text = str(self.m.TMC_motor[TMC_Z].stallGuardAlarmThreshold)
+
     def set_threshold(self, axis, value):
         self.m.set_threshold_for_axis(axis, int(value))
 
@@ -106,5 +145,7 @@ class SetThresholdsScreen(Screen):
         if self.m.TMC_registers_have_been_read_in(): 
             self.wait_popup_for_tmc_read_in.popup.dismiss()
             self.wait_popup_for_tmc_read_in = None
+            self.show_thresholds()
+            self.update_stored_thresholds()
         else: 
             Clock.schedule_once(self.wait_while_values_stored_and_read_back_in, 0.2)


### PR DESCRIPTION
Shows labels for currently set (and stored if known) threshold values, as reported by TMC registers on set threshold screen. Helps Az with testing. 

Tested on rig