### PR TITLE
Auto set setting 51

### DIFF
--- a/src/asmcnc/apps/maintenance_app/screen_maintenance.py
+++ b/src/asmcnc/apps/maintenance_app/screen_maintenance.py
@@ -581,7 +581,10 @@ class MaintenanceScreenClass(Screen):
         # Only show SC2 options if machine supports it
         self.spindle_settings_widget.spindle_brand.values = self.spindle_settings_widget.brand_list_sc1
         try:
-            if os.path.exists('/home/pi/proplus.txt') and self.m.s.setting_51:
+            # Check if $51 exists
+            self.m.s.setting_51
+            # Check if PRO+ is activated
+            if os.path.exists('/home/pi/proplus.txt'):
                 self.spindle_settings_widget.spindle_brand.values = self.spindle_settings_widget.brand_list_sc2
         except:
             pass

--- a/src/asmcnc/apps/maintenance_app/screen_maintenance.py
+++ b/src/asmcnc/apps/maintenance_app/screen_maintenance.py
@@ -5,6 +5,8 @@ Tabbed maintenance screen, for setting the laser datum; monitoring brush life.
 @author: Letty
 '''
 
+import os
+
 from kivy.lang import Builder
 from kivy.uix.screenmanager import ScreenManager, Screen
 from kivy.metrics import MetricsBase
@@ -575,6 +577,14 @@ class MaintenanceScreenClass(Screen):
         self.spindle_settings_widget.spindle_cooldown_time.text = str(self.m.spindle_cooldown_time_seconds)
         self.spindle_settings_widget.spindle_cooldown_speed.text = str(self.m.spindle_cooldown_rpm)
         self.spindle_settings_widget.rpm_override = self.m.spindle_cooldown_rpm_override
+
+        # Only show SC2 options if machine supports it
+        self.spindle_settings_widget.spindle_brand.values = self.spindle_settings_widget.brand_list_sc1
+        try:
+            if os.path.exists('/home/pi/proplus.txt') and self.m.s.setting_51:
+                self.spindle_settings_widget.spindle_brand.values = self.spindle_settings_widget.brand_list_sc2
+        except:
+            pass
 
         # Z MISC
         self.touchplate_offset_widget.touchplate_offset.text = str(self.m.z_touch_plate_thickness)

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_save.py
@@ -201,6 +201,12 @@ class SpindleSaveWidget(Widget):
             self.m.write_spindle_cooldown_settings(brand, voltage, digital, time, speed) and \
             self.m.write_stylus_settings(self.sm.current_screen.spindle_settings_widget.stylus_switch.active):
 
+            if self.m.is_machines_fw_version_equal_to_or_greater_than_version('2.2.8', 'Set $51 based on selected spindle'):
+                if "SC2" in brand:
+                    self.m.write_dollar_51_setting(1)
+                else:
+                    self.m.write_dollar_51_setting(0)
+
             saved_success = self.l.get_str("Settings saved!")
             popup_info.PopupMiniInfo(self.sm, self.l, saved_success)
 

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
@@ -173,7 +173,7 @@ Builder.load_string("""
                 text_size: self.size
                 multiline: False
                 color: 0,0,0,1
-                values: root.brand_list
+                values: root.brand_list_sc1
                 option_cls: Factory.get("SpindleSpinner")
                 background_normal: './asmcnc/apps/maintenance_app/img/brand_dropdown.png'
                 on_text: root.autofill_rpm_time()

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
@@ -214,7 +214,8 @@ Builder.load_string("""
 
 class SpindleSettingsWidget(Widget):
 
-    brand_list = [' YETI SC1 digital 230V', ' YETI SC1 digital 110V', ' YETI SC2 digital 230V', ' YETI SC2 digital 110V', ' AMB digital 230V', ' AMB manual 230V', ' AMB manual 110V']
+    brand_list_sc1 = [' YETI SC1 digital 230V', ' YETI SC1 digital 110V', ' AMB digital 230V', ' AMB manual 230V', ' AMB manual 110V']
+    brand_list_sc2 = [' YETI SC2 digital 230V', ' YETI SC2 digital 110V'] + brand_list_sc1
 
     def __init__(self, **kwargs):
     

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -692,6 +692,13 @@ class RouterMachine(object):
                             ]
         self.s.start_sequential_stream(dollar_50_setting, reset_grbl_after_stream=True)
 
+    def write_dollar_51_setting(self, value):
+        dollar_51_setting = [
+                            '$51=' + str(value),
+                            '$$'
+                            ]
+        self.s.start_sequential_stream(dollar_51_setting, reset_grbl_after_stream=True)
+
     def write_dollar_54_setting(self, value):
         dollar_54_setting = [
                             '$54=' + str(value),


### PR DESCRIPTION
On the spindle cooldown settings tab in the maintenance app, selecting a spindle from the dropdown and saving now sets the $51 setting depening on whether or not the spindle is SC2. Additionally, the option to select an SC2 spindle is only given when the PRO+ unlock file and setting 51 both exist.

$51 command is sent every time, regardless of whether it needs changing or not - Boris confirmed that this is fine, as EEPROM wear happens: 'Only when writing different value. This applies to most EEPROMs in the market.
Atmega EEPROM "has an endurance of at least 100,000 write/erase cycles" (from datasheet)
"Write" means wirting "0" in one bit,  "Erase" means write "1"s to all bits in the byte or multiple bytes
Meaning that writing $51=1 when $51 is 0 will cause mupltiple bytes erase and rewrite.'

Tested on rig