### PR TITLE
Maintenance brush times feedback

### DIFF
--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -88,7 +88,7 @@ class BrushSaveWidget(Widget):
 
         # Machine must be idle if a spindle brush reset is attempted
         if not self.m.state().startswith('Idle'):
-            popup_info.PopupError(self.sm, self.l, self.l.get_str("Please ensure the machine is idle before attempting to save."))
+            popup_info.PopupError(self.sm, self.l, self.l.get_str("There was a problem saving your settings."))
             return
 
         # TIME FOR DATA VALIDATION
@@ -207,7 +207,7 @@ class BrushSaveWidget(Widget):
                 if self.brush_reset_test_count == 5:
                     self.m.s.write_command('M5')
                     self.wait_popup.popup.dismiss()
-                    popup_info.PopupError(self.sm, self.l, self.l.get_str("Could not reset brush timer! Please try again."))
+                    popup_info.PopupError(self.sm, self.l, self.l.get_str("There was a problem saving your settings."))
                 else:
                     self.attempt_reset()
             else:

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -115,23 +115,8 @@ class BrushSaveWidget(Widget):
                 popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
                 return
 
-            # Brush life for SC2
-            try:
-                # Don't allow saving non 0 brush use values
-                if self.m.s.setting_51 and use != 0:
-                    # throw popup, return without saving
-                    brush_use_validation_error = (
-                            self.l.get_str("The number of hours the brushes have been used for should be 0.") + \
-                            "\n\n" + \
-                            self.l.get_str("Please enter a new value.")
-                        )
 
-                    popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
-                    return
-            except:
-                pass
-
-            # Brush life for SC1
+            # Brush life
             if lifetime >= 100*3600 and lifetime <= 999*3600: pass # all good, carry on
             else: 
                 # throw popup, return without saving

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -115,8 +115,23 @@ class BrushSaveWidget(Widget):
                 popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
                 return
 
+            # Brush life for SC2
+            try:
+                # Don't allow saving non 0 brush use values
+                if self.m.s.setting_51 and use != 0:
+                    # throw popup, return without saving
+                    brush_use_validation_error = (
+                            self.l.get_str("The number of hours the brushes have been used for should be 0.") + \
+                            "\n\n" + \
+                            self.l.get_str("Please enter a new value.")
+                        )
 
-            # Brush life
+                    popup_info.PopupError(self.sm, self.l, brush_use_validation_error)
+                    return
+            except:
+                pass
+
+            # Brush life for SC1
             if lifetime >= 100*3600 and lifetime <= 999*3600: pass # all good, carry on
             else: 
                 # throw popup, return without saving

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -179,7 +179,7 @@ class BrushUseWidget(Widget):
                 return
             except:
                 pass
-        popup_info.PopupError(self.sm, self.l, self.l.get_str("Could not get info - spindle not plugged in!"))
+        popup_info.PopupError(self.sm, self.l, self.l.get_str("Error!"))
 
     def reset_to_0(self):
         self.brush_use.text = '0'

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -152,12 +152,14 @@ class BrushUseWidget(Widget):
     def restore(self):
         try:
             if self.m.s.setting_51:
+                self.brush_use.disabled = True
                 self.m.s.write_command('M3 S0')
                 Clock.schedule_once(self.get_restore_info, 0.1)
                 self.wait_popup = popup_info.PopupWait(self.sm, self.l)
                 return
         except:
             pass
+        self.brush_use.disabled = False
         self.brush_use.text = str(int(self.m.spindle_brush_use_seconds/3600)) # convert back to hrs for user
         self.sm.get_screen('maintenance').brush_monitor_widget.update_percentage()
 


### PR DESCRIPTION
Some changes to PRO+ maintenance brush times based on feedback:

- Don't show settings saved popup if reset didn't work
- Don't allow user to input brush use values for SC2 - can only use reset or restore buttons to change input values
- Change new error messages to existing localised ones while we wait for finalised localised ones