### PR TITLE
Syntax bug fix in prep_triple_axes_calibration

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2876,8 +2876,7 @@ class RouterMachine(object):
 
         if not self.run_calibration: return
 
-        if not self.state().startswith('Idle') or self.s.write_protocol_buffer or True:
-            log("Resched prep triple axes cal")
+        if not self.state().startswith('Idle') or self.s.write_protocol_buffer:
             Clock.schedule_once(lambda dt: self.prep_triple_axes_calibration(), 0.1)
             return
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2876,8 +2876,8 @@ class RouterMachine(object):
 
         if not self.run_calibration: return
 
-        if not self.state().startswith('Idle') or self.s.write_protocol_buffer:
-            Clock.schedule_once(lambda dt: self.prep_triple_axes_calibration(axis), 0.1)
+        if not self.state().startswith('Idle') or self.s.write_protocol_buffer or True:
+            Clock.schedule_once(lambda dt: self.prep_triple_axes_calibration(), 0.1)
             return
 
         self.calibration_tuning_fail_info = ''

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -2877,6 +2877,7 @@ class RouterMachine(object):
         if not self.run_calibration: return
 
         if not self.state().startswith('Idle') or self.s.write_protocol_buffer or True:
+            log("Resched prep triple axes cal")
             Clock.schedule_once(lambda dt: self.prep_triple_axes_calibration(), 0.1)
             return
 

--- a/tests/automated_unit_tests/comms/test_router_machine_tuning_and_calibration.py
+++ b/tests/automated_unit_tests/comms/test_router_machine_tuning_and_calibration.py
@@ -158,6 +158,3 @@ def test_are_sg_values_in_range_after_calibration_fails_as_expected(m):
 
 
 
-
-
-


### PR DESCRIPTION
Tested on dev machine by adding True flag to force it into clock schedule condition, and checked with logs. Then removed test code & confirmed that homing sequence was working normally again :) 