### PR TITLE
scrape_last_feed_command and get_is_constant_feed_rate for YetiPilot

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1428,6 +1428,11 @@ class RouterMachine(object):
 # SPEED AND FEED GETTERS
     def feed_rate(self): return int(self.s.feed_rate)
 
+    def get_is_constant_feed_rate(self, feed_override_percentage, feed_rate, current_line_number):
+        last_modal_feed_rate = self.jd.scrape_last_feed_command(self.job_gcode_running, current_line_number)
+        constant_feed_target = last_modal_feed_rate * feed_override_percentage / 100
+        return abs(constant_feed_target - feed_rate) < 50, last_modal_feed_rate
+
     def spindle_speed(self): 
         if self.spindle_voltage == 110: 
             # if not self.spindle_digital or not self.fw_can_operate_digital_spindle(): # this is only relevant much later on

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1428,10 +1428,9 @@ class RouterMachine(object):
 # SPEED AND FEED GETTERS
     def feed_rate(self): return int(self.s.feed_rate)
 
-    def get_is_constant_feed_rate(self, feed_override_percentage, feed_rate, current_line_number):
-        last_modal_feed_rate = self.jd.scrape_last_feed_command(self.job_gcode_running, current_line_number)
+    def get_is_constant_feed_rate(self, last_modal_feed_rate, feed_override_percentage, current_feed_rate):
         constant_feed_target = last_modal_feed_rate * feed_override_percentage / 100
-        return abs(constant_feed_target - feed_rate) < 50, last_modal_feed_rate
+        return abs(constant_feed_target - current_feed_rate) < 50, last_modal_feed_rate
 
     def spindle_speed(self): 
         if self.spindle_voltage == 110: 

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -166,6 +166,14 @@ class JobData(object):
         else:
             self.job_name = self.filename.split("/")[-1]
 
+
+    def scrape_last_feed_command(self, job_gcode_object, index): 
+
+        feedrate_line = next((s for s in reversed(job_gcode_object[:index]) if 'F' in s), None)
+        if feedrate_line:
+            feedrate = re.match('\d+',feedrate_line[feedrate_line.find("F")+1:]).group()
+
+
     def generate_job_data(self, raw_gcode):
 
         self.job_gcode_raw = map(remove_newlines, raw_gcode)

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -169,9 +169,16 @@ class JobData(object):
 
     def scrape_last_feed_command(self, job_gcode_object, index): 
 
-        feedrate_line = next((s for s in reversed(job_gcode_object[:index]) if 'F' in s), None)
-        if feedrate_line:
-            feedrate = re.match('\d+',feedrate_line[feedrate_line.find("F")+1:]).group()
+        try:
+
+            feedrate_line = next((s for s in reversed(job_gcode_object[:index]) if 'F' in s), None)
+            if feedrate_line:
+                feedrate = re.match('\d+',feedrate_line[feedrate_line.find("F")+1:]).group()
+
+            return int(feedrate)
+
+        except: 
+            return 0
 
 
     def generate_job_data(self, raw_gcode):

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -172,7 +172,7 @@ class JobData(object):
         try:
             feedrate_line = next((s for s in reversed(job_gcode_object[:index]) if 'F' in s), None)
             if feedrate_line:
-                feedrate = re.match('\d+(\.\d+)?$',feedrate_line[feedrate_line.find("F")+1:]).group()
+                feedrate = re.match('\d+(\.\d+)?',feedrate_line[feedrate_line.find("F")+1:]).group()
 
             return float(feedrate)
 

--- a/src/asmcnc/job/job_data.py
+++ b/src/asmcnc/job/job_data.py
@@ -170,12 +170,11 @@ class JobData(object):
     def scrape_last_feed_command(self, job_gcode_object, index): 
 
         try:
-
             feedrate_line = next((s for s in reversed(job_gcode_object[:index]) if 'F' in s), None)
             if feedrate_line:
-                feedrate = re.match('\d+',feedrate_line[feedrate_line.find("F")+1:]).group()
+                feedrate = re.match('\d+(\.\d+)?$',feedrate_line[feedrate_line.find("F")+1:]).group()
 
-            return int(feedrate)
+            return float(feedrate)
 
         except: 
             return 0

--- a/tests/automated_unit_tests/comms/test_router_machine_units.py
+++ b/tests/automated_unit_tests/comms/test_router_machine_units.py
@@ -14,7 +14,6 @@ try:
 except: 
     print("Can't import mocking packages, are you on a dev machine?")
 
-
 from asmcnc.comms import router_machine
 from asmcnc.comms import localization
 from datetime import datetime
@@ -37,8 +36,8 @@ def m():
 
     screen_manager = Mock()
     settings_manager = Mock()
-    job = Mock()
-    m = router_machine.RouterMachine("COM", screen_manager, settings_manager, l, job)
+    jd = Mock()
+    m = router_machine.RouterMachine("COM", screen_manager, settings_manager, l, jd)
     m.s.next_poll_time = 0
     m.s.write_direct = Mock()
     m.s.s = MagicMock()
@@ -376,3 +375,29 @@ def test_do_next_task_in_sequence_when_not_ready(m):
     m.setup_homing_funcs_list()
     m.do_next_task_in_sequence()
     assert m.homing_seq_events[0].get_callback() == m.do_next_task_in_sequence
+
+# FEED RATE TESTS
+
+def test_get_is_constant_feed_rate_accel(m):
+    feed_override_percentage = 100
+    feed_rate = 6000
+    last_feed_rate = 8000
+    val, last = m.get_is_constant_feed_rate(last_feed_rate, feed_override_percentage, feed_rate)
+    assert last == last_feed_rate
+    assert not val
+
+def test_get_is_constant_feed_rate_decel(m):
+    feed_override_percentage = 100
+    feed_rate = 6000
+    last_feed_rate = 4000
+    val, last = m.get_is_constant_feed_rate(last_feed_rate, feed_override_percentage, feed_rate)
+    assert last == last_feed_rate
+    assert not val
+
+def test_get_is_constant_feed_rate_true_within_range(m):
+    feed_override_percentage = 100
+    feed_rate = 6000
+    last_feed_rate = 6010
+    val, last = m.get_is_constant_feed_rate(last_feed_rate, feed_override_percentage, feed_rate)
+    assert last == last_feed_rate
+    assert val

--- a/tests/automated_unit_tests/job/test_job_data_units.py
+++ b/tests/automated_unit_tests/job/test_job_data_units.py
@@ -27,7 +27,6 @@ python -m pytest --show-capture=no --disable-pytest-warnings tests/automated_uni
 ######################################
 '''
 
-
 # FIXTURES
 @pytest.fixture
 def jd():
@@ -39,8 +38,7 @@ def jd():
 def test_get_jd(jd):
     jd.reset_values()
 
-
-def test_scrape_last_feed_command(jd):
+def test_scrape_last_feed_command_float(jd):
     index = 6
     job_gcode_object = [
         "G91X0F1000",
@@ -50,4 +48,63 @@ def test_scrape_last_feed_command(jd):
         "X2.259Y2.259Z-0.240F796.74",
         "X2.259Y2.259Z-0.240F824.88"
     ]
-    assert jd.scrape_last_feed_command(job_gcode_object, index) == 824
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 824.88
+
+def test_scrape_last_feed_command_int_mid_job(jd):
+    index = 2
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "X6.776Y6.776Z-0.720F769.25",
+        "X2.259Y2.259Z-0.240F796.74",
+        "X2.259Y2.259Z-0.240F824.88"
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 8000
+
+def test_scrape_last_end_of_job(jd):
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "X6.776Y6.776Z-0.720F769.25",
+        "CUY",
+        "X2.259Y2.259Z-0.240F796.74",
+        "X2.259Y2.259Z-0.240F824.88"
+    ]
+    index = len(job_gcode_object)
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 824.88
+
+def test_scrape_last_feed_command_start_of_job(jd):
+    index = 0
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "X6.776Y6.776Z-0.720F769.25",
+        "CUY",
+        "X2.259Y2.259Z-0.240F796.74",
+        "X2.259Y2.259Z-0.240F824.88"
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 0
+
+def test_scrape_last_feed_command_no_feeds(jd):
+    index = 3
+    job_gcode_object = [
+        "G91",
+        "G1",
+        "G90",
+        "G0"
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 0
+
+def test_scrape_last_feed_command_no_obj(jd):
+    index = 3
+    job_gcode_object = []
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 0
+
+def test_scrape_last_feed_command_no_F(jd):
+    index = 3
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "X6.776Y6.776Z-0.720F",
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 0

--- a/tests/automated_unit_tests/job/test_job_data_units.py
+++ b/tests/automated_unit_tests/job/test_job_data_units.py
@@ -77,11 +77,7 @@ def test_scrape_last_feed_command_start_of_job(jd):
     index = 0
     job_gcode_object = [
         "G91X0F1000",
-        "G1X0F8000",
-        "X6.776Y6.776Z-0.720F769.25",
-        "CUY",
-        "X2.259Y2.259Z-0.240F796.74",
-        "X2.259Y2.259Z-0.240F824.88"
+        "G1X0F8000"
     ]
     assert jd.scrape_last_feed_command(job_gcode_object, index) == 0
 
@@ -108,3 +104,19 @@ def test_scrape_last_feed_command_no_F(jd):
         "X6.776Y6.776Z-0.720F",
     ]
     assert jd.scrape_last_feed_command(job_gcode_object, index) == 0
+
+def test_scrape_last_feed_command_feed_start_of_line(jd):
+    index = 3
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "F6000X6.776Y6.776Z-0.720",
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 6000
+
+def test_scrape_last_feed_command_feed_mid_line(jd):
+    index = 1
+    job_gcode_object = [
+        "G91F1000X0",
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 1000

--- a/tests/automated_unit_tests/job/test_job_data_units.py
+++ b/tests/automated_unit_tests/job/test_job_data_units.py
@@ -1,0 +1,53 @@
+'''
+Created on 22 Feb 2023
+@author: Letty
+'''
+
+import sys, os
+sys.path.append('./src')
+
+try: 
+    import unittest
+    import pytest
+    from mock import Mock, MagicMock
+
+except: 
+    print("Can't import mocking packages, are you on a dev machine?")
+
+from asmcnc.job import job_data
+from asmcnc.comms import localization
+from datetime import datetime
+
+from kivy.clock import Clock
+
+'''
+######################################
+RUN FROM easycut-smartbench FOLDER WITH: 
+python -m pytest --show-capture=no --disable-pytest-warnings tests/automated_unit_tests/job/test_job_data_units.py
+######################################
+'''
+
+
+# FIXTURES
+@pytest.fixture
+def jd():
+    l = localization.Localization()
+    settings_manager = Mock()
+    jd = job_data.JobData(localization = l, settings_manager = settings_manager)
+    return jd
+
+def test_get_jd(jd):
+    jd.reset_values()
+
+
+def test_scrape_last_feed_command(jd):
+    index = 6
+    job_gcode_object = [
+        "G91X0F1000",
+        "G1X0F8000",
+        "X6.776Y6.776Z-0.720F769.25",
+        "CUY",
+        "X2.259Y2.259Z-0.240F796.74",
+        "X2.259Y2.259Z-0.240F824.88"
+    ]
+    assert jd.scrape_last_feed_command(job_gcode_object, index) == 824


### PR DESCRIPTION
- Slight refactor of functions pulled from YP branch:
    - Used a variation of Dennis's code for scraping feedrate (this scrapes a float rather than an int)
    - ensured args were passed to functions to keep them more general, and allow ease of testing
    - moved functions out of YP into other parts of the codebase where they can be used more generally (e.g. the feedrate scrape can by called by job recovery in future) 
    - moved location of scrape_last_feed_command in job data module in the hope that it's less likely to create merge conflict with job recovery later on

- Unit tests to ensure that functionality is good and working as expected :)

Tested via unit test, and by running main.py on computer