### PR TITLE
Read in line number from status

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -672,6 +672,9 @@ class SerialConnection(object):
 
     m_state = 'Unknown'
 
+    # Line number
+    grbl_ln = 0
+
     # Machine co-ordinates
     m_x = '0.0'
     m_y = '0.0'
@@ -834,8 +837,12 @@ class SerialConnection(object):
 
             for part in status_parts:
 
+                # Get line number first so that all other data is in relation to this
+                if part.startswith('Ln:'):
+                    self.grbl_ln = part[3:]
+
                 # Get machine's position (may not be displayed, depending on mask)
-                if part.startswith('MPos:'):
+                elif part.startswith('MPos:'):
                     pos = part[5:].split(',')
                     try:
                         float(pos[0])

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -672,9 +672,6 @@ class SerialConnection(object):
 
     m_state = 'Unknown'
 
-    # Line number
-    grbl_ln = 0
-
     # Machine co-ordinates
     m_x = '0.0'
     m_y = '0.0'
@@ -694,6 +691,9 @@ class SerialConnection(object):
     g28_x = '0.0'
     g28_y = '0.0'
     g28_z = '0.0'
+
+    # Line number
+    grbl_ln = None
 
     # Feeds and speeds
     spindle_speed = 0
@@ -837,12 +837,8 @@ class SerialConnection(object):
 
             for part in status_parts:
 
-                # Get line number first so that all other data is in relation to this
-                if part.startswith('Ln:'):
-                    self.grbl_ln = part[3:]
-
                 # Get machine's position (may not be displayed, depending on mask)
-                elif part.startswith('MPos:'):
+                if part.startswith('MPos:'):
                     pos = part[5:].split(',')
                     try:
                         float(pos[0])
@@ -909,6 +905,19 @@ class SerialConnection(object):
                     # print if change flagged
                     if self.print_buffer_status == True:
                         self.print_buffer_status = False
+
+                # Get line number first so that all other data is in relation to this
+                elif part.startswith('Ln:'):
+                    value = part[3:]
+
+                    try: 
+                        int(value)
+
+                    except: 
+                        log("ERROR status parse: Line number invalid: " + message)
+                        return
+
+                    self.grbl_ln = int(value)
 
                 # Get limit switch states: Pn:PxXyYZ
                 elif part.startswith('Pn:'):

--- a/tests/automated_unit_tests/comms/test_serial_connection_process_grbl_push.py
+++ b/tests/automated_unit_tests/comms/test_serial_connection_process_grbl_push.py
@@ -390,3 +390,37 @@ def test_feed_override_read_in_fails_if_bad(sc):
     assert sc.motor_driver_temp != 1
     assert sc.pcb_temp != 2
 
+## TEST LINE NUMBER READ IN
+
+def construct_status_with_line_numbers(l=None):
+
+    # Use this to construct the test status passed out by mock serial object
+    status = "<Idle|MPos:0.000,0.000,0.000|Bf:35,255"
+
+    if l: 
+        line_appendage = "|Ln:" + str(l)
+        status+=line_appendage
+
+    status += "|FS:0,0|Ld:0|TC:1,2>"
+
+    return status
+
+def test_line_number_read_in(sc):
+    status = construct_status_with_line_numbers(123)
+    sc.process_grbl_push(status)
+    assert sc.grbl_ln == 123
+    assert_status_end_processed(sc)
+
+def test_line_number_read_in_when_nonsense(sc):
+    status = construct_status_with_line_numbers("nonsense")
+    sc.process_grbl_push(status)
+    assert sc.grbl_ln == None
+    assert sc.motor_driver_temp != 1
+    assert sc.pcb_temp != 2
+
+def test_line_number_read_in_when_no_number(sc):
+    status = construct_status_with_line_numbers()
+    sc.process_grbl_push(status)
+    assert sc.grbl_ln == None
+    assert_status_end_processed(sc)
+


### PR DESCRIPTION
- Put it in to read the line number after it reads in the buffer block, just because this matches the order it'll run in the for loop/matches the order that grbl reads it out
- Unit tests for possible cases

Have set the default line number value to None, but maybe it should be set to 0? Depends on usage.
Also thought about whether it needs resetting between jobs, but this also depends on usage, so have left it. 
Could also overwrite grbl_ln with "None" if no Ln block is present in the status? Again, depends on usage. 

Tested via unit test
Tested on rig with branch line_readin_test (which has dynamic_line_numbers branch merged into it, so that line numbers would be present)
Tested on rig as just this branch :)