### PR TITLE
Maintenance brush times new feedback

### DIFF
--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -205,7 +205,11 @@ class BrushSaveWidget(Widget):
             Clock.schedule_once(check_info, 0.3)
 
         def check_info(dt):
-            if self.m.s.spindle_brush_run_time_seconds != 0:
+            if self.m.s.digital_spindle_ld_qdA == -999:
+                self.m.s.write_command('M5')
+                self.wait_popup.popup.dismiss()
+                popup_info.PopupError(self.sm, self.l, self.l.get_str("Error!"))
+            elif self.m.s.spindle_brush_run_time_seconds != 0:
                 if self.brush_reset_test_count == 5:
                     self.m.s.write_command('M5')
                     self.wait_popup.popup.dismiss()

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -205,6 +205,7 @@ class BrushSaveWidget(Widget):
             Clock.schedule_once(check_info, 0.3)
 
         def check_info(dt):
+            # Value of -999 represents disconnected spindle
             if self.m.s.digital_spindle_ld_qdA == -999:
                 self.m.s.write_command('M5')
                 self.wait_popup.popup.dismiss()

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -202,7 +202,7 @@ class BrushSaveWidget(Widget):
 
         def read_info(dt):
             self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")
-            Clock.schedule_once(check_info, 0.3)
+            Clock.schedule_once(check_info, 0.5)
 
         def check_info(dt):
             # Value of -999 represents disconnected spindle

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -165,7 +165,7 @@ class BrushUseWidget(Widget):
 
     def get_restore_info(self, dt):
         self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")
-        Clock.schedule_once(self.read_restore_info, 0.3)
+        Clock.schedule_once(self.read_restore_info, 0.5)
 
     def read_restore_info(self, dt):
         self.m.s.write_command('M5')

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -170,6 +170,7 @@ class BrushUseWidget(Widget):
     def read_restore_info(self, dt):
         self.m.s.write_command('M5')
         self.wait_popup.popup.dismiss()
+        # Value of -999 represents disconnected spindle
         if self.m.s.digital_spindle_ld_qdA != -999:
             try: # Just in case of weird errors
                 self.brush_use.text = str(int(self.m.s.spindle_brush_run_time_seconds/3600))

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -170,9 +170,7 @@ class BrushUseWidget(Widget):
     def read_restore_info(self, dt):
         self.m.s.write_command('M5')
         self.wait_popup.popup.dismiss()
-        # If info was not obtained successfully, spindle production year will equal 99
-        # Update this code if the year is 2099
-        if self.m.s.spindle_production_year != 99:
+        if self.m.s.digital_spindle_ld_qdA != -999:
             try: # Just in case of weird errors
                 self.brush_use.text = str(int(self.m.s.spindle_brush_run_time_seconds/3600))
                 self.sm.get_screen('maintenance').brush_monitor_widget.update_percentage()


### PR DESCRIPTION
When checking whether get digital spindle info has been successful, ld_qda is now used instead of spindle production year, as ld_qda updates to an error value when spindle is disconnected whereas production year does not.

Additionally lengthened delay between writing protocol and checking values, to improve consistency.

Tested on rig and signed off by Benji