### PR TITLE
Sc2 retain written brush use

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -653,7 +653,7 @@ class SerialConnection(object):
         ## UPDATE MAINTENANCE TRACKING
 
         # Add time taken in seconds to brush use: 
-        if self.m.stylus_router_choice == 'router':
+        if self.m.stylus_router_choice == 'router' and self.m.get_dollar_setting(51):
             self.m.spindle_brush_use_seconds += only_running_time_seconds
             self.m.write_spindle_brush_values(self.m.spindle_brush_use_seconds, self.m.spindle_brush_lifetime_seconds)
 

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -653,7 +653,7 @@ class SerialConnection(object):
         ## UPDATE MAINTENANCE TRACKING
 
         # Add time taken in seconds to brush use: 
-        if self.m.stylus_router_choice == 'router' and self.m.get_dollar_setting(51):
+        if self.m.stylus_router_choice == 'router' and not self.m.get_dollar_setting(51):
             self.m.spindle_brush_use_seconds += only_running_time_seconds
             self.m.write_spindle_brush_values(self.m.spindle_brush_use_seconds, self.m.spindle_brush_lifetime_seconds)
 


### PR DESCRIPTION
When a job is stopped, brush use values are no longer written if setting 51 is enabled

Tested on windows