### PR TITLE
Maintenance brush times poll info

### DIFF
--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -213,7 +213,7 @@ class BrushSaveWidget(Widget):
             else: # Keep trying for a few seconds
                 Clock.schedule_once(wait_for_successful_read, 0.3)
 
-        def check_info(dt):
+        def check_info():
             # Value of -999 represents disconnected spindle
             if self.m.s.digital_spindle_ld_qdA == -999:
                 self.m.s.write_command('M5')

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -202,7 +202,16 @@ class BrushSaveWidget(Widget):
 
         def read_info(dt):
             self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")
-            Clock.schedule_once(check_info, 0.5)
+            self.check_info_count = 0
+            Clock.schedule_once(wait_for_successful_read, 0.3)
+
+        def wait_for_successful_read(dt):
+            self.check_info_count += 1
+            # Value of -999 represents disconnected spindle - if detected then stop waiting
+            if (self.m.s.digital_spindle_ld_qdA != -999) or (self.check_info_count > 10):
+                check_info()
+            else: # Keep trying for a few seconds
+                Clock.schedule_once(wait_for_successful_read, 0.3)
 
         def check_info(dt):
             # Value of -999 represents disconnected spindle


### PR DESCRIPTION
When getting info, rather than waiting a fixed period of time and checking what has been received, instead poll the response repeatedly for 3 seconds before deciding that spindle is disconnected, to improve consistency.

Tested on rig