### PR TITLE
Stop auto resume after unpause

### DIFF
--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -655,6 +655,11 @@ class GoScreen(Screen):
             else:
                 self.m.resume_after_a_stream_pause()
                 self.start_or_pause_button_image.source = "./asmcnc/skavaUI/img/pause.png"
+
+                # Job resumed, send event
+                self.database.send_event(0, 'Job resumed', 'Resumed job: ' + self.jd.job_name, 4)
+
+                self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         else:
             self._start_running_job()
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -605,7 +605,7 @@ class GoScreen(Screen):
 
     def reset_go_screen_prior_to_job_start(self):
 
-        print "RESET GO SCREEN FIRES"
+        print("RESET GO SCREEN FIRES")
 
         # Update images
         self.start_or_pause_button_image.source = "./asmcnc/skavaUI/img/go.png"
@@ -649,7 +649,11 @@ class GoScreen(Screen):
 
         log('start/pause button pressed')
         if self.is_job_started_already:
-            self._pause_job()
+            if not self.m.is_machine_paused:
+                self._pause_job()
+            else:
+                self.m.resume_after_a_stream_pause()
+                self.start_or_pause_button_image.source = "./asmcnc/skavaUI/img/pause.png"
         else:
             self._start_running_job()
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -651,6 +651,7 @@ class GoScreen(Screen):
         if self.is_job_started_already:
             if not self.m.is_machine_paused:
                 self._pause_job()
+                self.start_or_pause_button_image.source = "./asmcnc/skavaUI/img/go.png"
             else:
                 self.m.resume_after_a_stream_pause()
                 self.start_or_pause_button_image.source = "./asmcnc/skavaUI/img/pause.png"

--- a/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
+++ b/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
@@ -221,8 +221,6 @@ class StopOrResumeDecisionScreen(Screen):
         if self.reason_for_pause == 'yetipilot_low_feed':
             self.sm.get_screen('go').yp_widget.disable_yeti_pilot()
 
-        self.sm.get_screen('go').start_or_pause_button_image.source = "./asmcnc/skavaUI/img/go.png"
-
         # Job resumed, send event
         self.db.send_event(0, 'Job resumed', 'Resumed job: ' + self.jd.job_name, 4)
 

--- a/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
+++ b/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
@@ -221,8 +221,4 @@ class StopOrResumeDecisionScreen(Screen):
         if self.reason_for_pause == 'yetipilot_low_feed':
             self.sm.get_screen('go').yp_widget.disable_yeti_pilot()
 
-        # Job resumed, send event
-        self.db.send_event(0, 'Job resumed', 'Resumed job: ' + self.jd.job_name, 4)
-
-        self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         self.sm.current = self.return_screen

--- a/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
+++ b/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
@@ -221,7 +221,7 @@ class StopOrResumeDecisionScreen(Screen):
         if self.reason_for_pause == 'yetipilot_low_feed':
             self.sm.get_screen('go').yp_widget.disable_yeti_pilot()
 
-        self.m.resume_after_a_stream_pause()
+        self.sm.get_screen('go').start_or_pause_button_image.source = "./asmcnc/skavaUI/img/go.png"
 
         # Job resumed, send event
         self.db.send_event(0, 'Job resumed', 'Resumed job: ' + self.jd.job_name, 4)


### PR DESCRIPTION
When resuming a job after a pause, the job no longer automatically resumes, and instead the user is now required to press the resume button on the go screen to allow them time to adjust settings.

Tested on rig