### PR TITLE
Yp settings toggle actual disabling

### DIFF
--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -317,8 +317,8 @@ class PopupYetiPilotSettings(Widget):
 
         def switch_version(state, instance=None):
             if state: 
-                # instance.active=True
-                # instance.disabled=True
+                instance.active=True
+                instance.disabled=True
                 return
 
             self.yp.standard_profiles = not version
@@ -348,7 +348,7 @@ class PopupYetiPilotSettings(Widget):
 
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
             checkbox_func =partial(switch_version, version)
-            label_radio_container.add_widget(CheckBox(group=str(version), color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -327,7 +327,7 @@ class PopupYetiPilotSettings(Widget):
                           )
         def make_option(version_text, version):
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
-            label_radio_container.add_widget(CheckBox(group="settings", color=blue, on_press=switch_version, active=version, disabled=version, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -316,7 +316,7 @@ class PopupYetiPilotSettings(Widget):
         # Profile radio buttons
 
         def switch_version(state, instance=None):
-            if instance.active: 
+            if state: 
                 instance.active=True
                 instance.disabled=True
                 return

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -327,7 +327,7 @@ class PopupYetiPilotSettings(Widget):
                           )
         def make_option(version_text, version):
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=True)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -313,8 +313,8 @@ class PopupYetiPilotSettings(Widget):
         def switch_version(*args):
             self.yp.standard_profiles = not version
             unschedule_clocks()
-            PopupYetiPilotSettings(self.sm, self.l, self.m, self.db, self.yp, version= not version, closing_func=closing_func)
             popup.dismiss()
+            PopupYetiPilotSettings(self.sm, self.l, self.m, self.db, self.yp, version= not version, closing_func=closing_func)
 
         radio_button_width = 40
         pad_width = 40      
@@ -327,7 +327,7 @@ class PopupYetiPilotSettings(Widget):
                           )
         def make_option(version_text, version):
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
-            label_radio_container.add_widget(CheckBox(group="settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -317,6 +317,8 @@ class PopupYetiPilotSettings(Widget):
 
         def switch_version(state, instance=None):
             if state: 
+                # instance.active=True
+                # instance.disabled=True
                 return
 
             self.yp.standard_profiles = not version
@@ -346,7 +348,7 @@ class PopupYetiPilotSettings(Widget):
 
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
             checkbox_func =partial(switch_version, version)
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group=str(version), color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -336,16 +336,6 @@ class PopupYetiPilotSettings(Widget):
                             padding=[pad_width, 0]
                           )
         def make_option(version_text, version):
-
-
-            # def make_buttons(self, container, slider, val):
-            #     btn_str = str(val) if val < 0 else "+" + str(val)
-            #     button_adjust_func = partial(self.button_adjust_slider, val)
-            #     container.add_widget(PowerAdjustButtons(text=btn_str, on_press=button_adjust_func, color=dark_grey))
-
-            # def button_adjust_slider(self, val, instance=None):
-            #     if 400 <= self.power_slider.value + val <= 1000: self.power_slider.value+=val
-
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
             checkbox_func =partial(switch_version, version)
             label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -338,7 +338,7 @@ class PopupYetiPilotSettings(Widget):
         def make_option(version_text, version):
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
             checkbox_func =partial(switch_version, version)
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -310,7 +310,8 @@ class PopupYetiPilotSettings(Widget):
 
         # Profile radio buttons
 
-        def switch_version(*args):
+        def switch_version(instance=None):
+            if instance.active: return
             self.yp.standard_profiles = not version
             unschedule_clocks()
             popup.dismiss()
@@ -327,7 +328,7 @@ class PopupYetiPilotSettings(Widget):
                           )
         def make_option(version_text, version):
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=True)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -318,7 +318,6 @@ class PopupYetiPilotSettings(Widget):
         def switch_version(state, instance=None):
             if state: 
                 instance.active=True
-                instance.disabled=True
                 return
 
             self.yp.standard_profiles = not version

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -20,8 +20,13 @@ from kivy.metrics import dp
 from kivy.uix.spinner import Spinner
 from kivy.clock import Clock
 from kivy.uix.checkbox import CheckBox
+
+from functools import partial
+
 from asmcnc.core_UI.job_go.widgets.widget_load_slider import LoadSliderWidget
 from asmcnc.skavaUI import widget_speed_override
+
+
 
 Builder.load_string("""
 
@@ -310,8 +315,10 @@ class PopupYetiPilotSettings(Widget):
 
         # Profile radio buttons
 
-        def switch_version(instance=None):
-            if instance.active: return
+        def switch_version(state, instance=None):
+            if state: 
+                return
+
             self.yp.standard_profiles = not version
             unschedule_clocks()
             popup.dismiss()
@@ -327,8 +334,19 @@ class PopupYetiPilotSettings(Widget):
                             padding=[pad_width, 0]
                           )
         def make_option(version_text, version):
+
+
+            # def make_buttons(self, container, slider, val):
+            #     btn_str = str(val) if val < 0 else "+" + str(val)
+            #     button_adjust_func = partial(self.button_adjust_slider, val)
+            #     container.add_widget(PowerAdjustButtons(text=btn_str, on_press=button_adjust_func, color=dark_grey))
+
+            # def button_adjust_slider(self, val, instance=None):
+            #     if 400 <= self.power_slider.value + val <= 1000: self.power_slider.value+=val
+
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=switch_version, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            checkbox_func =partial(switch_version, version)
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -316,7 +316,7 @@ class PopupYetiPilotSettings(Widget):
         # Profile radio buttons
 
         def switch_version(state, instance=None):
-            if state: 
+            if instance.active: 
                 instance.active=True
                 instance.disabled=True
                 return
@@ -348,7 +348,7 @@ class PopupYetiPilotSettings(Widget):
 
             label_radio_container = GridLayout(cols=2, rows=1, cols_minimum={0: dp(radio_button_width), 1: dp(text_width)})
             checkbox_func =partial(switch_version, version)
-            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version)) #, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
+            label_radio_container.add_widget(CheckBox(group="yp_settings", color=blue, on_press=checkbox_func, active=version, disabled=version, background_radio_disabled_down="atlas://data/images/defaulttheme/checkbox_radio_on"))
             label_radio_container.add_widget(Label(text=version_text, color=dark_grey, markup=True, halign='left', text_size=(text_width, None)))
             radio_BL.add_widget(label_radio_container)
 


### PR DESCRIPTION
For whatever reason, "disabling" the active toggle with standard kivy args doesn't seem to work on the rig (even though the graphic default is to be greyed out - very weird). 

Have set up the function to take in the "version" arg and then respond based on that. 

Tested on rig