### PR TITLE
General tracking of x/y/z change, as generally useful

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -690,6 +690,11 @@ class SerialConnection(object):
     m_y = '0.0'
     m_z = '0.0'
 
+    # Track co-ordinate change in each axis
+    x_change = False
+    y_change = False
+    z_change = False
+
     # Work co-ordinates
     w_x = '0.0'
     w_y = '0.0'
@@ -861,6 +866,10 @@ class SerialConnection(object):
                     except:
                         log("ERROR status parse: Position invalid: " + message)
                         return
+
+                    self.x_change = self.m_x != pos[0]
+                    self.y_change = self.m_y != pos[1]
+                    self.z_change = self.m_z != pos[2]
 
                     self.m_x = pos[0]
                     self.m_y = pos[1]

--- a/tests/automated_unit_tests/comms/test_serial_connection_process_grbl_push.py
+++ b/tests/automated_unit_tests/comms/test_serial_connection_process_grbl_push.py
@@ -178,6 +178,64 @@ def test_temp_sg_array_append_4_drivers(m):
     m.s.process_grbl_push(status)
     assert m.temp_sg_array[0] == four_driver_list
 
+
+## TEST MACHINE COORD VALUE CHANGE
+## --------------------------------
+
+def default_pos_values(serial_comms):
+    serial_comms.x_change = False
+    serial_comms.y_change = False
+    serial_comms.z_change = False
+    serial_comms.m_x = '0.000'
+    serial_comms.m_y = '0.000'
+    serial_comms.m_z = '0.000'
+
+def test_value_change_x(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:4.000,0.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert sc.x_change
+    assert not sc.y_change
+    assert not sc.z_change
+
+def test_value_change_y(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:0.000,6.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert not sc.x_change
+    assert sc.y_change
+    assert not sc.z_change
+
+def test_value_change_z(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:0.000,0.000,6.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert not sc.x_change
+    assert not sc.y_change
+    assert sc.z_change
+
+def test_value_no_change_x(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:0.000,7.000,8.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert not sc.x_change
+    assert sc.y_change
+    assert sc.z_change
+
+def test_value_no_change_y(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:5.000,0.000,6.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert sc.x_change
+    assert not sc.y_change
+    assert sc.z_change
+
+def test_value_no_change_z(sc):
+    default_pos_values(sc)
+    sc.process_grbl_push("<Idle|MPos:2.000,6.000,0.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert sc.x_change
+    assert sc.y_change
+    assert not sc.z_change
+    sc.process_grbl_push("<Idle|MPos:2.000,6.000,8.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert sc.z_change
+    sc.process_grbl_push("<Idle|MPos:2.000,6.000,8.000|Bf:35,255|FS:0,0|Pn:PxXyYZ>")
+    assert not sc.z_change
+
 ## TEST PIN VALUES READ IN PROPERLY 
 ## --------------------------------
 


### PR DESCRIPTION
Put this in instead of moving_in_z, as I can think of a few times when I would have used this in the past if I had thought of it. 

Tested with unit tests and running SW on rig. 