### PR TITLE
Adjust go screen container to show up to two lines of text for selected profile

### DIFF
--- a/src/asmcnc/core_UI/job_go/widgets/widget_yeti_pilot.py
+++ b/src/asmcnc/core_UI/job_go/widgets/widget_yeti_pilot.py
@@ -20,7 +20,7 @@ Builder.load_string("""
         orientation: 'horizontal'
         size: self.parent.size
         pos: self.parent.pos
-        padding: [10,8]
+        padding: [10,8,10,8]
 
         
         BoxLayout:
@@ -30,7 +30,7 @@ Builder.load_string("""
 
             Label:
                 id: yetipilot_two_tone
-                size_hint_y: 0.6
+                size_hint_y: 0.5
                 markup: True
                 halign: 'center'
                 text_size: self.size
@@ -40,7 +40,7 @@ Builder.load_string("""
 
             BoxLayout: 
                 id: bl
-                size_hint_y: 0.4
+                size_hint_y: 0.5
                 padding: [14.09649122,0]
 
                 ToggleButton:
@@ -63,7 +63,7 @@ Builder.load_string("""
 
         BoxLayout:
             padding: [0,0]
-            size_hint_x: 0.05
+            size_hint_x: 0.025
             
             BoxLayout:
                 size_hint_x: None
@@ -78,11 +78,11 @@ Builder.load_string("""
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 0.6
-            padding: [0,0]
-            spacing: 10
+            padding: [2,0,5,0]
+            spacing: 0
             Label: 
                 id: profile_label
-                size_hint_y: 0.6
+                size_hint_y: 0.4
                 color: hex('#333333ff')
                 markup: True
                 halign: 'left'
@@ -93,12 +93,12 @@ Builder.load_string("""
 
             Label:
                 id: profile_selection
-                size_hint_y: 0.4
+                size_hint_y: 0.6
                 color: hex('#333333ff')
                 markup: True
                 halign: 'left'
                 text_size: self.size
-                font_size: '15sp'
+                font_size: '14sp'
                 valign: "middle"
 
         BoxLayout: 

--- a/tests/manual_tests/visual_screen_tests/go_screen_sc2_overload_test.py
+++ b/tests/manual_tests/visual_screen_tests/go_screen_sc2_overload_test.py
@@ -44,7 +44,7 @@ Cmport = 'COM3'
 
 class ScreenTest(App):
 
-    lang_idx = 6
+    lang_idx = 0
 
     # 0 - English (y)
     # 1 - Italian (y)

--- a/tests/manual_tests/visual_screen_tests/go_screen_sc2_overload_test.py
+++ b/tests/manual_tests/visual_screen_tests/go_screen_sc2_overload_test.py
@@ -44,7 +44,7 @@ Cmport = 'COM3'
 
 class ScreenTest(App):
 
-    lang_idx = 0
+    lang_idx = 6
 
     # 0 - English (y)
     # 1 - Italian (y)


### PR DESCRIPTION
Tested with go_screen_sc2_overload_test.py
Verified on rig