### PR TITLE
Override command stabilisiation 

### DIFF
--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -131,11 +131,11 @@ class FeedOverride(Widget):
             if self.disable_buttons():
                 self.feed_override_percentage += 5
                 self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.25)
+                self.m.feed_override_up_1(final_percentage=self.feed_override_percentage)
+                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.06)
+                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.12)
+                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.18)
+                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.24)
                 Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
                 Clock.schedule_once(self.enable_buttons, self.enable_button_time)
                 
@@ -151,11 +151,11 @@ class FeedOverride(Widget):
             if self.disable_buttons():
                 self.feed_override_percentage -= 5
                 self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.25)
+                self.m.feed_override_down_1(final_percentage=self.feed_override_percentage)
+                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.06)
+                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.12)
+                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.18)
+                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.24)
                 Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
                 Clock.schedule_once(self.enable_buttons, self.enable_button_time)
 

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -132,11 +132,11 @@ class SpeedOverride(Widget):
             if self.disable_buttons():
                 self.speed_override_percentage += 5
                 self.speed_rate_label.text = str(self.speed_override_percentage) + "%"
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.25)
+                self.m.speed_override_up_1(final_percentage=self.speed_override_percentage)
+                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.06)
+                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.12)
+                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.18)
+                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.24)
                 Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
                 Clock.schedule_once(self.enable_buttons, self.enable_button_time)
         
@@ -151,11 +151,11 @@ class SpeedOverride(Widget):
             if self.disable_buttons():
                 self.speed_override_percentage -= 5
                 self.speed_rate_label.text = str(self.speed_override_percentage) + "%"
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.25)
+                self.m.speed_override_down_1(final_percentage=self.speed_override_percentage)
+                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.06)
+                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.12)
+                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.18)
+                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.24)
                 Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
                 Clock.schedule_once(self.enable_buttons, self.enable_button_time)
 


### PR DESCRIPTION
- Don't delay the first override command
- Wait 0.06s instead of 0.05s between sending commands

0.06 was found to be most reliable when developing yetipilot.