### PR TITLE
Update override logic

### DIFF
--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -129,8 +129,6 @@ class FeedOverride(Widget):
         if self.feed_override_percentage >= 200 or self.push >= 2:
             return
 
-        self.push += 1
-
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.feed_override_up_1(), 0.06 * i)
 
@@ -146,8 +144,6 @@ class FeedOverride(Widget):
     def feed_down(self):
         if self.feed_override_percentage <= 10 or self.push >= 2:
             return
-
-        self.push += 1
 
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.feed_override_down_1(), 0.06 * i)

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -110,7 +110,7 @@ class FeedOverride(Widget):
     feed_override_percentage = NumericProperty()
     feed_rate_label = ObjectProperty()
 
-    enable_button_time = 0.3
+    enable_button_time = 0.36
 
     def __init__(self, **kwargs):
         super(FeedOverride, self).__init__(**kwargs)

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -125,7 +125,7 @@ class FeedOverride(Widget):
         self.feed_rate_label.text = str(self.m.s.feed_override_percentage) + '%'
 
     def feed_up(self):
-        if self.feed_override_percentage >= 200:
+        if self.m.s.feed_override_percentage >= 200:
             return
 
         self.disable_buttons()
@@ -142,7 +142,7 @@ class FeedOverride(Widget):
         Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
 
     def feed_down(self):
-        if self.feed_override_percentage <= 10:
+        if self.m.s.feed_override_percentage <= 10:
             return
 
         self.disable_buttons()

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -126,38 +126,34 @@ class FeedOverride(Widget):
         self.feed_rate_label.text = str(self.m.s.feed_override_percentage) + '%'
 
     def feed_up(self):
-        self.push =+ 1
-        if self.feed_override_percentage < 200 and self.push < 2:
-            if self.disable_buttons():
-                self.feed_override_percentage += 5
-                self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.feed_override_up_1(final_percentage=self.feed_override_percentage), 0.25)
-                Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
-                Clock.schedule_once(self.enable_buttons, self.enable_button_time)
+        if self.feed_override_percentage >= 200 or self.push >= 2:
+            return
+
+        self.push += 1
+
+        for i in range(5):
+            Clock.schedule_once(lambda dt: self.m.feed_override_up_1(), 0.06 * i)
+
+        Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
+        Clock.schedule_once(self.enable_buttons, self.enable_button_time)
                 
     def feed_norm(self):
         self.feed_override_percentage = 100
         self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
         self.m.feed_override_reset()
         Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
-                
+
     def feed_down(self):
-        self.push =+ 1 
-        if self.feed_override_percentage > 10 and self.push < 2:
-            if self.disable_buttons():
-                self.feed_override_percentage -= 5
-                self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.feed_override_down_1(final_percentage=self.feed_override_percentage), 0.25)
-                Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
-                Clock.schedule_once(self.enable_buttons, self.enable_button_time)
+        if self.feed_override_percentage <= 10 or self.push >= 2:
+            return
+
+        self.push += 1
+
+        for i in range(5):
+            Clock.schedule_once(lambda dt: self.m.feed_override_down_1(), 0.06 * i)
+
+        Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
+        Clock.schedule_once(self.enable_buttons, self.enable_button_time)
 
     def disable_buttons(self):
         self.down_5.disabled = True

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -111,7 +111,6 @@ class FeedOverride(Widget):
     feed_rate_label = ObjectProperty()
 
     enable_button_time = 0.3
-    push = 0
 
     def __init__(self, **kwargs):
         super(FeedOverride, self).__init__(**kwargs)
@@ -129,6 +128,8 @@ class FeedOverride(Widget):
         if self.feed_override_percentage >= 200:
             return
 
+        self.disable_buttons()
+
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.feed_override_up_1(), 0.06 * i)
 
@@ -144,6 +145,8 @@ class FeedOverride(Widget):
     def feed_down(self):
         if self.feed_override_percentage <= 10:
             return
+
+        self.disable_buttons()
 
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.feed_override_down_1(), 0.06 * i)
@@ -163,7 +166,6 @@ class FeedOverride(Widget):
         self.up_5.disabled = False
         self.sm.get_screen('go').speedOverride.down_5.disabled = False
         self.sm.get_screen('go').speedOverride.up_5.disabled = False
-        self.push = 0
 
     def set_widget_visibility(self, visible):
         self.up_5.disabled = not visible

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -126,7 +126,7 @@ class FeedOverride(Widget):
         self.feed_rate_label.text = str(self.m.s.feed_override_percentage) + '%'
 
     def feed_up(self):
-        if self.feed_override_percentage >= 200 or self.push >= 2:
+        if self.feed_override_percentage >= 200:
             return
 
         for i in range(5):
@@ -142,7 +142,7 @@ class FeedOverride(Widget):
         Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
 
     def feed_down(self):
-        if self.feed_override_percentage <= 10 or self.push >= 2:
+        if self.feed_override_percentage <= 10:
             return
 
         for i in range(5):

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -137,9 +137,8 @@ class FeedOverride(Widget):
         Clock.schedule_once(self.enable_buttons, self.enable_button_time)
                 
     def feed_norm(self):
-        self.feed_override_percentage = 100
-        self.feed_rate_label.text = str(self.feed_override_percentage) + '%'
         self.m.feed_override_reset()
+        self.update_feed_percentage_override_label()
         Clock.schedule_once(lambda dt: self.db.send_feed_rate_info(), 1)
 
     def feed_down(self):

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -111,7 +111,6 @@ class SpeedOverride(Widget):
     speed_rate_label = ObjectProperty()
 
     enable_button_time = 0.3
-    push = 0
 
     def __init__(self, **kwargs):
         super(SpeedOverride, self).__init__(**kwargs)
@@ -130,6 +129,8 @@ class SpeedOverride(Widget):
         if self.speed_override_percentage >= 200:
             return
 
+        self.disable_buttons()
+
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.speed_override_up_1(), 0.06 * i)
 
@@ -144,6 +145,8 @@ class SpeedOverride(Widget):
     def speed_down(self):
         if self.speed_override_percentage <= 10:
             return
+
+        self.disable_buttons()
 
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.speed_override_down_1(), 0.06 * i)
@@ -175,8 +178,6 @@ class SpeedOverride(Widget):
                 self.sm.get_screen('go').feedOverride.up_5.disabled = False
         except:
             pass
-
-        self.push = 0
 
     def set_widget_visibility(self, visible):
         self.up_5.disabled = not visible

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -126,7 +126,7 @@ class SpeedOverride(Widget):
         self.speed_rate_label.text = str(self.m.s.speed_override_percentage) + '%'
 
     def speed_up(self):
-        if self.speed_override_percentage >= 200:
+        if self.m.s.speed_override_percentage >= 200:
             return
 
         self.disable_buttons()
@@ -143,7 +143,7 @@ class SpeedOverride(Widget):
         Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
                 
     def speed_down(self):
-        if self.speed_override_percentage <= 10:
+        if self.m.s.speed_override_percentage <= 10:
             return
 
         self.disable_buttons()

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -127,7 +127,7 @@ class SpeedOverride(Widget):
         self.speed_rate_label.text = str(self.m.s.speed_override_percentage) + '%'
 
     def speed_up(self):
-        if self.speed_override_percentage >= 200 or self.push >= 2:
+        if self.speed_override_percentage >= 200:
             return
 
         for i in range(5):
@@ -142,7 +142,7 @@ class SpeedOverride(Widget):
         Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
                 
     def speed_down(self):
-        if self.speed_override_percentage <= 10 or self.push >= 2:
+        if self.speed_override_percentage <= 10:
             return
 
         for i in range(5):

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -130,8 +130,6 @@ class SpeedOverride(Widget):
         if self.speed_override_percentage >= 200 or self.push >= 2:
             return
 
-        self.push += 1
-
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.speed_override_up_1(), 0.06 * i)
 
@@ -146,8 +144,6 @@ class SpeedOverride(Widget):
     def speed_down(self):
         if self.speed_override_percentage <= 10 or self.push >= 2:
             return
-
-        self.push += 1
 
         for i in range(5):
             Clock.schedule_once(lambda dt: self.m.speed_override_down_1(), 0.06 * i)

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -110,7 +110,7 @@ class SpeedOverride(Widget):
     speed_override_percentage = NumericProperty()
     speed_rate_label = ObjectProperty()
 
-    enable_button_time = 0.3
+    enable_button_time = 0.36
 
     def __init__(self, **kwargs):
         super(SpeedOverride, self).__init__(**kwargs)

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -127,18 +127,16 @@ class SpeedOverride(Widget):
         self.speed_rate_label.text = str(self.m.s.speed_override_percentage) + '%'
 
     def speed_up(self):
-        self.push =+ 1 
-        if self.speed_override_percentage < 200 and self.push < 2:
-            if self.disable_buttons():
-                self.speed_override_percentage += 5
-                self.speed_rate_label.text = str(self.speed_override_percentage) + "%"
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.speed_override_up_1(final_percentage=self.speed_override_percentage), 0.25)
-                Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
-                Clock.schedule_once(self.enable_buttons, self.enable_button_time)
+        if self.speed_override_percentage >= 200 or self.push >= 2:
+            return
+
+        self.push += 1
+
+        for i in range(5):
+            Clock.schedule_once(lambda dt: self.m.speed_override_up_1(), 0.06 * i)
+
+        Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
+        Clock.schedule_once(self.enable_buttons, self.enable_button_time)
         
     def speed_norm(self):
         self.m.speed_override_reset()
@@ -146,18 +144,16 @@ class SpeedOverride(Widget):
         Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
                 
     def speed_down(self):
-        self.push =+ 1 
-        if self.speed_override_percentage > 10 and self.push < 2:          
-            if self.disable_buttons():
-                self.speed_override_percentage -= 5
-                self.speed_rate_label.text = str(self.speed_override_percentage) + "%"
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.05) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.1) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.15) 
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.2)
-                Clock.schedule_once(lambda dt: self.m.speed_override_down_1(final_percentage=self.speed_override_percentage), 0.25)
-                Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
-                Clock.schedule_once(self.enable_buttons, self.enable_button_time)
+        if self.speed_override_percentage <= 10 or self.push >= 2:
+            return
+
+        self.push += 1
+
+        for i in range(5):
+            Clock.schedule_once(lambda dt: self.m.speed_override_down_1(), 0.06 * i)
+
+        Clock.schedule_once(lambda dt: self.db.send_spindle_speed_info(), 1)
+        Clock.schedule_once(self.enable_buttons, self.enable_button_time)
 
     def disable_buttons(self):
         self.down_5.disabled = True


### PR DESCRIPTION
- Read percentages exclusively from Ov status part (ensures no mismatch)
- 0.06s delay instead of 0.05s