### PR TITLE
Change exit job recovery buttons to not unload job

### DIFF
--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -468,7 +468,8 @@ class JobRecoveryScreen(Screen):
         self.m.s.write_command('G90 G0 X%s Y%s' % (self.pos_x, self.pos_y))
 
     def back_to_home(self):
-        self.jd.reset_values()
+        self.jd.reset_recovery()
+        self.jd.job_recovery_from_beginning = True
         self.sm.current = 'home'
 
     def next_screen(self):

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -227,7 +227,8 @@ class NudgeScreen(Screen):
         popup_info.PopupBigInfo(self.sm, self.l, 780, info)
 
     def back_to_home(self):
-        self.jd.reset_values()
+        self.jd.reset_recovery()
+        self.jd.job_recovery_from_beginning = True
         self.sm.current = 'home'
 
     def previous_screen(self):
@@ -250,8 +251,10 @@ class NudgeScreen(Screen):
             wait_popup.popup.dismiss()
             if not success:
                 popup_info.PopupError(self.sm, self.l, message)
-                self.jd.reset_values()
-            self.jd.job_recovery_from_beginning = False
+                self.jd.reset_recovery()
+                self.jd.job_recovery_from_beginning = True
+            else:
+                self.jd.job_recovery_from_beginning = False
             self.sm.current = 'home'
 
         # Give time for wait popup to appear


### PR DESCRIPTION
Exiting job recovery without completing it now keeps the job loaded, and shows the "Restart from beginning" message.

Tested on windows