### PR TITLE
Upgrade screens data bug

### DIFF
--- a/src/asmcnc/apps/upgrade_app/screen_upgrade.py
+++ b/src/asmcnc/apps/upgrade_app/screen_upgrade.py
@@ -184,7 +184,7 @@ class UpgradeScreen(Screen):
         self.hide_error_message()
         self.show_verifying()
         self.m.s.write_command('M3 S0')
-        Clock.schedule_once(self.get_restore_info, 0.1)
+        Clock.schedule_once(self.get_restore_info, 1)
 
     def get_restore_info(self, dt):
         self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")

--- a/src/asmcnc/apps/upgrade_app/screen_upgrade.py
+++ b/src/asmcnc/apps/upgrade_app/screen_upgrade.py
@@ -184,7 +184,7 @@ class UpgradeScreen(Screen):
         self.hide_error_message()
         self.show_verifying()
         self.m.s.write_command('M3 S0')
-        Clock.schedule_once(self.get_restore_info, 1)
+        Clock.schedule_once(self.get_restore_info, 0.2)
 
     def get_restore_info(self, dt):
         self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")

--- a/src/asmcnc/apps/upgrade_app/screen_upgrade.py
+++ b/src/asmcnc/apps/upgrade_app/screen_upgrade.py
@@ -184,7 +184,7 @@ class UpgradeScreen(Screen):
         self.hide_error_message()
         self.show_verifying()
         self.m.s.write_command('M3 S0')
-        Clock.schedule_once(self.get_restore_info, 0.2)
+        Clock.schedule_once(self.get_restore_info, 0.3)
 
     def get_restore_info(self, dt):
         self.m.s.write_protocol(self.m.p.GetDigitalSpindleInfo(), "GET DIGITAL SPINDLE INFO")

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -471,8 +471,8 @@ class LobbyScreen(Screen):
 
     def on_pre_enter(self):
         # Hide upgrade app if older than V1.3, and only if it has not been hidden already
-        if not ("V1.3" in self.m.smartbench_model()) and not self.upgrade_app_hidden:
-        # if not self.upgrade_app_hidden:
+        # if not ("V1.3" in self.m.smartbench_model()) and not self.upgrade_app_hidden:
+        if not self.upgrade_app_hidden:
             self.upgrade_app_container.parent.remove_widget(self.upgrade_app_container)
             self.upgrade_app_hidden = True
 

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -471,8 +471,8 @@ class LobbyScreen(Screen):
 
     def on_pre_enter(self):
         # Hide upgrade app if older than V1.3, and only if it has not been hidden already
-        # if not ("V1.3" in self.m.smartbench_model()) and not self.upgrade_app_hidden:
-        if not self.upgrade_app_hidden:
+        if not ("V1.3" in self.m.smartbench_model()) and not self.upgrade_app_hidden:
+        # if not self.upgrade_app_hidden:
             self.upgrade_app_container.parent.remove_widget(self.upgrade_app_container)
             self.upgrade_app_hidden = True
 


### PR DESCRIPTION
Increased time between enabling spindle motor and sending get info protocol in the upgrade app, to improve consistency of info retrieval.

Tested on rig