### PR TITLE
Job recovery stop lowering z

### DIFF
--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -492,7 +492,11 @@ class JobRecoveryScreen(Screen):
     def go_xy(self):
         # Pick min out of safe z height and limit_switch_safety_distance, in case positive value is calculated, which causes errors
         z_safe_height = min(self.m.z_wco() + self.sm.get_screen('home').job_box.range_z[1], -self.m.limit_switch_safety_distance)
-        self.m.s.write_command('G53 G0 Z%s F750' % z_safe_height)
+
+        # If Z is below safe height, then raise it up
+        if self.m.mpos_z() < z_safe_height:
+            self.m.s.write_command('G53 G0 Z%s F750' % z_safe_height)
+
         self.m.s.write_command('G90 G0 X%s Y%s' % (self.pos_x, self.pos_y))
 
     def back_to_home(self):

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -243,7 +243,10 @@ class NudgeScreen(Screen):
         # Raise Z to safe range in case user tries to move the tool after nudging into the groove
         # Pick min out of safe z height and limit_switch_safety_distance, in case positive value is calculated, which causes errors
         z_safe_height = min(self.m.z_wco() + self.sm.get_screen('home').job_box.range_z[1], -self.m.limit_switch_safety_distance)
-        self.m.s.write_command('G53 G0 Z%s F750' % z_safe_height)
+
+        # If Z is below safe height, then raise it up
+        if self.m.mpos_z() < z_safe_height:
+            self.m.s.write_command('G53 G0 Z%s F750' % z_safe_height)
 
     def previous_screen(self):
         self.sm.current = 'job_recovery'

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -205,7 +205,8 @@ class NudgeScreen(Screen):
         self.z_move_container.add_widget(widget_z_move_nudge.ZMoveNudge(machine=self.m, screen_manager=self.sm, job=self.jd))
 
         # XY move widget
-        self.xy_move_container.add_widget(widget_xy_move_recovery.XYMoveRecovery(machine=self.m, screen_manager=self.sm))
+        self.xy_move_widget = widget_xy_move_recovery.XYMoveRecovery(machine=self.m, screen_manager=self.sm)
+        self.xy_move_container.add_widget(self.xy_move_widget)
 
         # Nudge speed widget
         self.nudge_speed_widget = widget_nudge_speed.NudgeSpeed(machine=self.m, screen_manager=self.sm)

--- a/src/asmcnc/skavaUI/widget_z_move_nudge.py
+++ b/src/asmcnc/skavaUI/widget_z_move_nudge.py
@@ -100,7 +100,7 @@ class ZMoveNudge(Widget):
         self.m.set_led_colour('WHITE')
 
         feed_speed = self.sm.get_screen('nudge').nudge_speed_widget.feedSpeedJogZ
-        self.jogMode = self.sm.get_screen('nudge').nudge_speed_widget.jogMode
+        self.jogMode = self.sm.get_screen('nudge').xy_move_widget.jogMode
         
         if self.jogMode == 'free':
             if case == 'Z-': self.m.jog_absolute_single_axis('Z', 


### PR DESCRIPTION
When Z axis is supposed to raise to safe height on nudge screen entry and exit, the current position is checked to avoid lowering the Z axis unexpectedly. Additionally includes a bugfix for the nudge screen Z move widget, where I had forgotten to make it take the jog mode from the XY widget after I had moved the button

Tested on rig