### PR TITLE
Set up functions for checking and setting use_yp

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -74,6 +74,16 @@ class SerialConnection(object):
         if self.s: self.s.close()
         log('Serial connection destructor')
 
+    def is_use_yp(self):
+        if self.yp:
+            return self.yp.use_yp
+        else: 
+            return False
+
+    def set_use_yp(self, val):
+        if self.yp:
+            self.yp.use_yp = val
+
     def get_serial_screen(self, serial_error):
 
         try:
@@ -378,7 +388,7 @@ class SerialConnection(object):
                 # Job streaming: stuff buffer
                 if (self.is_job_streaming and not self.m.is_machine_paused and not "Alarm" in self.m.state()):
 
-                    if self.yp.use_yp and self.m.has_spindle_health_check_passed() and self.m.is_using_sc2():
+                    if self.is_use_yp() and self.m.has_spindle_health_check_passed() and self.m.is_using_sc2():
 
                         if self.digital_spindle_ld_qdA >= 0 \
                                 and self.grbl_ln is not None \
@@ -438,7 +448,7 @@ class SerialConnection(object):
         log('Checking job...')
 
         self.m.enable_check_mode()
-        self.yp.use_yp = False
+        self.set_use_yp(False)
 
         def check_job_inner_function():
             # Check that check mode has been enabled before running:
@@ -632,7 +642,7 @@ class SerialConnection(object):
         self.is_job_streaming = False
         self.is_stream_lines_remaining = False
         self.m.set_pause(False)
-        self.yp.use_yp = False
+        self.set_use_yp(False)
 
         if self.NOT_SKELETON_STUFF:
 
@@ -670,7 +680,7 @@ class SerialConnection(object):
         self.is_stream_lines_remaining = False
         self.m.set_pause(False)
         self.jd.job_gcode_running = []
-        self.yp.use_yp = False
+        self.set_use_yp(False)
         self.jd.grbl_mode_tracker = []
         self.grbl_ln = None
 

--- a/tests/automated_unit_tests/comms/test_serial_connection_streaming_units.py
+++ b/tests/automated_unit_tests/comms/test_serial_connection_streaming_units.py
@@ -541,3 +541,75 @@ def test_remove_from_g_mode_tracker_at_job_start(sc):
                                 (0,7,9),
                                 (1,7,9),
     ]
+
+
+# Test YP impartiality
+## If serial comms is run from any production jigs, they don't use or need yp
+## it's important that serial comms can still run even if yp == None. 
+
+def test_yp_is_use_yp_when_yp_none(sc):
+    sc.yp = None
+    assert not sc.is_use_yp()
+
+def test_yp_is_use_yp_when_yp_not_none(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = True
+    assert sc.is_use_yp()
+
+def test_yp_set_use_yp_false(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = True
+    sc.set_use_yp(False)
+    assert not sc.yp.use_yp
+
+def test_yp_set_use_yp_true(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = False
+    sc.set_use_yp(True)
+    assert sc.yp.use_yp
+
+def test_yp_grbl_scanner_when_yp_none(sc):
+    # pass this: if (self.is_job_streaming and not self.m.is_machine_paused and not "Alarm" in self.m.state()):
+    sc.is_job_streaming = True
+    sc.m.is_machine_paused = False
+    sc.m.state = Mock(return_value="Idle")
+
+    sc.g_count = 0 # prevent end_stream from running
+    sc.l_count = 1 # prevent end_stream from running
+
+    sc.yp = None
+    sc.grbl_scanner(run_grbl_scanner_once=True)
+
+def test_yp_check_job_yp_is_none(sc):
+    sc.yp = None
+    sc.check_job([])
+
+def test_yp_check_job_yp_exists(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = True
+    sc.check_job([])
+    assert not sc.yp.use_yp
+
+def test_yp_end_stream_is_none(sc):
+    sc.yp = None
+    sc.update_machine_runtime = Mock()
+    sc.end_stream()
+
+def test_yp_cancel_stream_is_none(sc):
+    sc.yp = None
+    sc.update_machine_runtime = Mock()
+    sc.cancel_stream()
+
+def test_yp_end_stream_exists(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = True
+    sc.update_machine_runtime = Mock()
+    sc.end_stream()
+    assert not sc.yp.use_yp
+
+def test_yp_cancel_stream_exists(sc):
+    sc.yp = Mock()
+    sc.yp.use_yp = True
+    sc.update_machine_runtime = Mock()
+    sc.cancel_stream()
+    assert not sc.yp.use_yp


### PR DESCRIPTION
When I tried to test a fix for ZHQC, I was getting a failure from streaming the calibration files because the jigs have not been set up to use yp. 

Rather than adding yp module to apps that don't need it, I pulled out the instances of checking and setting use_yp into functions that check whether yp exists in the first place. 

Tested with unit tests.

Tested on rig; also made test branch `use_yp_test_none` for testing standard functions without yp, but it fell over before running the job (due to other screens not being able to reference yp through serial comms).

Merged this into the new branch for debugging ZHQC, and tested on that; this merge fixed the issue. 