### PR TITLE
Increase default currents to high values, and add in current change for Y axis

### DIFF
--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -838,7 +838,7 @@ class ZHeadPCBSetUp(Screen):
                 if int(self.m.TMC_motor[motor].standStillCurrentScale) != int(expected_current):
                     outcome_current_correct = False
 
-            def check_temp_coeff(motor, expected_coeff)
+            def check_temp_coeff(motor, expected_coeff):
                 if int(self.m.TMC_motor[motor].temperatureCoefficient) != int(expected_coeff):
                     outcome_screen.thermal_coefficients_correct = False
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -304,7 +304,6 @@ Builder.load_string("""
                             Label:
                                 id: recommended_z_current_label
                                 size_hint_x: 0.8
-                                text: "25"
                                 text_size: self.size
                                 markup: 'True'
                                 halign: 'left'
@@ -330,7 +329,6 @@ Builder.load_string("""
                             TextInput:
                                 id: other_z_current_textinput
                                 size_hint_x: 0.4
-                                text: "25"
                                 input_filter: "int"
                                 multiline: False
                                 font_size: "22sp"
@@ -444,6 +442,7 @@ class ZHeadPCBSetUp(Screen):
     number_of_drivers = 4
 
     x_current = str(single_stack_dual_driver_x_current)
+    y_current = str(default_y_current)
     z_current = str(default_z_current)
 
     x_thermal_coefficient = str(default_x_thermal_coefficient)
@@ -528,6 +527,7 @@ class ZHeadPCBSetUp(Screen):
         self.recommended_z_current_checkbox.state = "normal"
         self.other_z_current_checkbox.state = "normal"
 
+        self.recommended_z_current_label.text = str(self.default_z_current)
         self.other_z_current_textinput.text = str(self.z_current)
         self.z_current = self.set_value_to_update_to(self.recommended_z_current_label, self.recommended_z_current_checkbox)
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -832,17 +832,17 @@ class ZHeadPCBSetUp(Screen):
             # CHECK REGISTERS
             outcome_screen = self.sm.get_screen("qcpcbsetupoutcome")
 
-            outcome_screen.x_current_correct = self.check_current(TMC_X1, self.x_current)
-            outcome_screen.x_current_correct = self.check_current(TMC_X2, self.x_current)
-            outcome_screen.y_current_correct = self.check_current(TMC_Y1, self.y_current)
-            outcome_screen.y_current_correct = self.check_current(TMC_Y2, self.y_current)
-            outcome_screen.z_current_correct = self.check_current(TMC_Z, self.z_current)
+            outcome_screen.x_current_correct*=self.check_current(TMC_X1, self.x_current)
+            outcome_screen.x_current_correct*=self.check_current(TMC_X2, self.x_current)
+            outcome_screen.y_current_correct*=self.check_current(TMC_Y1, self.y_current)
+            outcome_screen.y_current_correct*=self.check_current(TMC_Y2, self.y_current)
+            outcome_screen.z_current_correct*=self.check_current(TMC_Z, self.z_current)
 
-            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_X1, self.x_thermal_coefficient)
-            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_X2, self.x_thermal_coefficient)
-            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Y1, self.y_thermal_coefficient)
-            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Y2, self.y_thermal_coefficient)
-            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Z, self.z_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct*=self.check_temp_coeff(TMC_X1, self.x_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct*=self.check_temp_coeff(TMC_X2, self.x_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct*=self.check_temp_coeff(TMC_Y1, self.y_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct*=self.check_temp_coeff(TMC_Y2, self.y_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct*=self.check_temp_coeff(TMC_Z, self.z_thermal_coefficient)
 
             self.progress_to_next_screen()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -431,9 +431,10 @@ class ZHeadPCBSetUp(Screen):
     single_stack_single_driver_x_current = 26
     double_stack_single_driver_x_current = 26
     single_stack_dual_driver_x_current = 13
-    double_stack_dual_driver_x_current = 20
+    double_stack_dual_driver_x_current = 27
 
-    default_z_current = 25
+    default_z_current = 31
+    default_y_current = 28
 
     default_x_thermal_coefficient = 5000
     default_y_thermal_coefficient = 5000

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -834,9 +834,9 @@ class ZHeadPCBSetUp(Screen):
 
             def check_current(motor, expected_current, outcome_current_correct):
                 if int(self.m.TMC_motor[motor].ActiveCurrentScale) != int(expected_current):
-                    outcome_current_correct = False
+                    outcome_screen.outcome_current_correct = False
                 if int(self.m.TMC_motor[motor].standStillCurrentScale) != int(expected_current):
-                    outcome_current_correct = False
+                    outcome_screen.outcome_current_correct = False
 
             def check_temp_coeff(motor, expected_coeff):
                 if int(self.m.TMC_motor[motor].temperatureCoefficient) != int(expected_coeff):

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -830,24 +830,29 @@ class ZHeadPCBSetUp(Screen):
             self.ok_button.text = "Checking registers..."
 
             # CHECK REGISTERS
-            if int(self.m.TMC_motor[TMC_X1].ActiveCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
-            if int(self.m.TMC_motor[TMC_X2].ActiveCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
-            if int(self.m.TMC_motor[TMC_X1].standStillCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
-            if int(self.m.TMC_motor[TMC_X2].standStillCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
+            outcome_screen = self.sm.get_screen("qcpcbsetupoutcome")
 
-            if int(self.m.TMC_motor[TMC_Y1].ActiveCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
-            if int(self.m.TMC_motor[TMC_Y2].ActiveCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
-            if int(self.m.TMC_motor[TMC_Y1].standStillCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
-            if int(self.m.TMC_motor[TMC_Y2].standStillCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
+            def check_current(motor, expected_current, outcome_current_correct):
+                if int(self.m.TMC_motor[motor].ActiveCurrentScale) != int(expected_current):
+                    outcome_current_correct = False
+                if int(self.m.TMC_motor[motor].standStillCurrentScale) != int(expected_current):
+                    outcome_current_correct = False
 
-            if int(self.m.TMC_motor[TMC_Z].ActiveCurrentScale) != int(self.z_current): self.sm.get_screen("qcpcbsetupoutcome").z_current_correct = False
-            if int(self.m.TMC_motor[TMC_Z].standStillCurrentScale) != int(self.z_current): self.sm.get_screen("qcpcbsetupoutcome").z_current_correct = False
+            def check_temp_coeff(motor, expected_coeff)
+                if int(self.m.TMC_motor[motor].temperatureCoefficient) != int(expected_coeff):
+                    outcome_screen.thermal_coefficients_correct = False
 
-            if int(self.m.TMC_motor[TMC_X1].temperatureCoefficient) != int(self.x_thermal_coefficient): self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
-            if int(self.m.TMC_motor[TMC_X2].temperatureCoefficient) != int(self.x_thermal_coefficient): self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
-            if int(self.m.TMC_motor[TMC_Y1].temperatureCoefficient) != int(self.y_thermal_coefficient): self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
-            if int(self.m.TMC_motor[TMC_Y2].temperatureCoefficient) != int(self.y_thermal_coefficient): self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
-            if int(self.m.TMC_motor[TMC_Z].temperatureCoefficient) != int(self.z_thermal_coefficient): self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
+            check_current(TMC_X1, self.x_current, outcome_screen.x_current_correct)
+            check_current(TMC_X2, self.x_current, outcome_screen.x_current_correct)
+            check_current(TMC_Y1, self.y_current, outcome_screen.y_current_correct)
+            check_current(TMC_Y2, self.y_current, outcome_screen.y_current_correct)
+            check_current(TMC_Z, self.z_current, outcome_screen.z_current_correct)
+
+            check_temp_coeff(TMC_X1, self.x_thermal_coefficient)
+            check_temp_coeff(TMC_X2, self.x_thermal_coefficient)
+            check_temp_coeff(TMC_Y1, self.y_thermal_coefficient)
+            check_temp_coeff(TMC_Y2, self.y_thermal_coefficient)
+            check_temp_coeff(TMC_Z, self.z_thermal_coefficient)
 
             self.progress_to_next_screen()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -832,31 +832,35 @@ class ZHeadPCBSetUp(Screen):
             # CHECK REGISTERS
             outcome_screen = self.sm.get_screen("qcpcbsetupoutcome")
 
-            def check_current(motor, expected_current, outcome_current_correct):
-                if int(self.m.TMC_motor[motor].ActiveCurrentScale) != int(expected_current):
-                    outcome_screen.outcome_current_correct = False
-                if int(self.m.TMC_motor[motor].standStillCurrentScale) != int(expected_current):
-                    outcome_screen.outcome_current_correct = False
+            outcome_screen.x_current_correct = self.check_current(TMC_X1, self.x_current)
+            outcome_screen.x_current_correct = self.check_current(TMC_X2, self.x_current)
+            outcome_screen.y_current_correct = self.check_current(TMC_Y1, self.y_current)
+            outcome_screen.y_current_correct = self.check_current(TMC_Y2, self.y_current)
+            outcome_screen.z_current_correct = self.check_current(TMC_Z, self.z_current)
 
-            def check_temp_coeff(motor, expected_coeff):
-                if int(self.m.TMC_motor[motor].temperatureCoefficient) != int(expected_coeff):
-                    outcome_screen.thermal_coefficients_correct = False
-
-            check_current(TMC_X1, self.x_current, outcome_screen.x_current_correct)
-            check_current(TMC_X2, self.x_current, outcome_screen.x_current_correct)
-            check_current(TMC_Y1, self.y_current, outcome_screen.y_current_correct)
-            check_current(TMC_Y2, self.y_current, outcome_screen.y_current_correct)
-            check_current(TMC_Z, self.z_current, outcome_screen.z_current_correct)
-
-            check_temp_coeff(TMC_X1, self.x_thermal_coefficient)
-            check_temp_coeff(TMC_X2, self.x_thermal_coefficient)
-            check_temp_coeff(TMC_Y1, self.y_thermal_coefficient)
-            check_temp_coeff(TMC_Y2, self.y_thermal_coefficient)
-            check_temp_coeff(TMC_Z, self.z_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_X1, self.x_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_X2, self.x_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Y1, self.y_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Y2, self.y_thermal_coefficient)
+            outcome_screen.thermal_coefficients_correct = self.check_temp_coeff(TMC_Z, self.z_thermal_coefficient)
 
             self.progress_to_next_screen()
 
         disconnect_and_update()
+
+    def check_current(self, motor, expected_current):
+        if int(self.m.TMC_motor[motor].ActiveCurrentScale) != int(expected_current):
+            return False
+        if int(self.m.TMC_motor[motor].standStillCurrentScale) != int(expected_current):
+            return False
+
+        return True
+
+    def check_temp_coeff(self, motor, expected_coeff):
+        if int(self.m.TMC_motor[motor].temperatureCoefficient) != int(expected_coeff):
+            return False
+
+        return True
 
     def get_fw_path_from_string(self, fw_string):
         return self.usb_path + "GRBL" + "_".join(fw_string.split(".")) + ".hex"

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -668,6 +668,7 @@ class ZHeadPCBSetUp(Screen):
         print("FW version " + str(self.firmware_version))
 
         print("X current: " + str(self.x_current))
+        print("Y current: " + str(self.y_current))
         print("Z current: " + str(self.z_current))
 
         print("X thermal coefficient: " + str(self.x_thermal_coefficient))
@@ -782,6 +783,7 @@ class ZHeadPCBSetUp(Screen):
 
             else:
                 self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
+                self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
                 self.sm.get_screen("qcpcbsetupoutcome").z_current_correct = False
                 self.sm.get_screen("qcpcbsetupoutcome").thermal_coefficients_correct = False
                 self.progress_to_next_screen()
@@ -800,10 +802,11 @@ class ZHeadPCBSetUp(Screen):
                 self.m.set_thermal_coefficients("Y", int(self.y_thermal_coefficient)) and \
                 self.m.set_thermal_coefficients("Z", int(self.z_thermal_coefficient)) and \
                 self.m.set_motor_current("Z", int(self.z_current)) and \
+                self.m.set_motor_current("Y", int(self.y_current)) and \
                 self.m.set_motor_current("X", int(self.x_current)):
 
                 # STORE PARAMETERS
-                Clock.schedule_once(lambda dt: store_params_and_progress(), 1)
+                Clock.schedule_once(lambda dt: store_params_and_progress(), 1.2)
 
             else:
                 log("Z Head not Idle yet, waiting...")
@@ -831,6 +834,11 @@ class ZHeadPCBSetUp(Screen):
             if int(self.m.TMC_motor[TMC_X2].ActiveCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
             if int(self.m.TMC_motor[TMC_X1].standStillCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
             if int(self.m.TMC_motor[TMC_X2].standStillCurrentScale) != int(self.x_current): self.sm.get_screen("qcpcbsetupoutcome").x_current_correct = False
+
+            if int(self.m.TMC_motor[TMC_Y1].ActiveCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
+            if int(self.m.TMC_motor[TMC_Y2].ActiveCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
+            if int(self.m.TMC_motor[TMC_Y1].standStillCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
+            if int(self.m.TMC_motor[TMC_Y2].standStillCurrentScale) != int(self.y_current): self.sm.get_screen("qcpcbsetupoutcome").y_current_correct = False
 
             if int(self.m.TMC_motor[TMC_Z].ActiveCurrentScale) != int(self.z_current): self.sm.get_screen("qcpcbsetupoutcome").z_current_correct = False
             if int(self.m.TMC_motor[TMC_Z].standStillCurrentScale) != int(self.z_current): self.sm.get_screen("qcpcbsetupoutcome").z_current_correct = False

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -429,7 +429,7 @@ class ZHeadPCBSetUp(Screen):
     usb_path = "/media/usb/"
 
     single_stack_single_driver_x_current = 26
-    double_stack_single_driver_x_current = 26
+    double_stack_single_driver_x_current = 31
     single_stack_dual_driver_x_current = 13
     double_stack_dual_driver_x_current = 27
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
@@ -199,24 +199,25 @@ class ZHeadPCBSetUpOutcome(Screen):
                                                 "Y2: " + str(self.m.TMC_motor[TMC_Y2].temperatureCoefficient) + "; " + \
                                                 "Z: " + str(self.m.TMC_motor[TMC_Z].temperatureCoefficient) + ";"
 
-        if self.fw_update_success: self.fw_update_image.source = self.success_image
-        else: self.fw_update_image.source = self.fail_image
 
-        if self.z_current_correct: self.z_current_image.source = self.success_image
-        elif str(self.m.s.fw_version).startswith("1"): self.z_current_image.source = self.undetermined_image
-        else: self.z_current_image.source = self.fail_image
 
-        if self.x_current_correct: self.x_current_image.source = self.success_image
-        elif str(self.m.s.fw_version).startswith("1"): self.x_current_image.source = self.undetermined_image
-        else: self.x_current_image.source = self.fail_image
+        if self.fw_update_success:
+            self.fw_update_image.source = self.success_image
+        else:
+            self.fw_update_image.source = self.fail_image
 
-        if self.y_current_correct: self.y_current_image.source = self.success_image
-        elif str(self.m.s.fw_version).startswith("1"): self.y_current_image.source = self.undetermined_image
-        else: self.y_current_image.source = self.fail_image
+        self.update_images(self.z_current_correct, self.z_current_image)
+        self.update_images(self.x_current_correct, self.x_current_image)
+        self.update_images(self.y_current_correct, self.y_current_image)
+        self.update_images(self.thermal_coefficients_correct, self.thermal_coefficients_image)
 
-        if self.thermal_coefficients_correct: self.thermal_coefficients_image.source = self.success_image
-        elif str(self.m.s.fw_version).startswith("1"): self.thermal_coefficients_image.source = self.undetermined_image
-        else: self.thermal_coefficients_image.source = self.fail_image
+    def update_images(self, correct, image):
+        if self.correct:
+            self.image.source = self.success_image
+        elif str(self.m.s.fw_version).startswith("1"):
+            self.image.source = self.undetermined_image
+        else:
+            self.image.source = self.fail_image
 
     def on_leave(self):
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
@@ -212,12 +212,12 @@ class ZHeadPCBSetUpOutcome(Screen):
         self.update_images(self.thermal_coefficients_correct, self.thermal_coefficients_image)
 
     def update_images(self, correct, image):
-        if self.correct:
-            self.image.source = self.success_image
+        if correct:
+            image.source = self.success_image
         elif str(self.m.s.fw_version).startswith("1"):
-            self.image.source = self.undetermined_image
+            image.source = self.undetermined_image
         else:
-            self.image.source = self.fail_image
+            image.source = self.fail_image
 
     def on_leave(self):
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
@@ -232,14 +232,3 @@ class ZHeadPCBSetUpOutcome(Screen):
         self.x_current_image.source = self.undetermined_image
         self.y_current_image.source = self.undetermined_image
         self.thermal_coefficients_image.source = self.undetermined_image
-
-    # fw_update_image
-    # fw_update_label
-    # fw_version_image
-    # fw_version_label
-    # z_current_image
-    # z_current_label
-    # x_current_image
-    # x_current_label
-    # thermal_coefficients_image
-    # thermal_coefficients_label

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
@@ -16,6 +16,8 @@ Builder.load_string("""
     z_current_label : z_current_label
     x_current_image : x_current_image
     x_current_label : x_current_label
+    y_current_image : y_current_image
+    y_current_label : y_current_label
     thermal_coefficients_image : thermal_coefficients_image
     thermal_coefficients_label : thermal_coefficients_label
 
@@ -60,7 +62,6 @@ Builder.load_string("""
 
                 Label:
                     id: fw_update_label
-                    text: "FW update successful"
                     text_size: self.size
                     markup: 'True'
                     halign: 'left'
@@ -76,7 +77,6 @@ Builder.load_string("""
 
                 Label:
                     id: z_current_label
-                    text: "FW update successful"
                     text_size: self.size
                     markup: 'True'
                     halign: 'left'
@@ -92,7 +92,21 @@ Builder.load_string("""
 
                 Label:
                     id: x_current_label
-                    text: "FW update successful"
+                    text_size: self.size
+                    markup: 'True'
+                    halign: 'left'
+                    valign: 'middle'
+
+                Image:
+                    id: y_current_image
+                    source: "./asmcnc/skavaUI/img/checkbox_inactive.png"
+                    center_x: self.parent.center_x
+                    y: self.parent.y
+                    size: self.parent.width, self.parent.height
+                    allow_stretch: True
+
+                Label:
+                    id: y_current_label
                     text_size: self.size
                     markup: 'True'
                     halign: 'left'
@@ -108,7 +122,6 @@ Builder.load_string("""
 
                 Label:
                     id: thermal_coefficients_label
-                    text: "FW update successful"
                     text_size: self.size
                     markup: 'True'
                     halign: 'left'
@@ -140,6 +153,7 @@ class ZHeadPCBSetUpOutcome(Screen):
     fw_update_success = True
     z_current_correct = True
     x_current_correct = True
+    y_current_correct = True
     thermal_coefficients_correct = True
 
     def __init__(self, **kwargs):
@@ -172,6 +186,12 @@ class ZHeadPCBSetUpOutcome(Screen):
                                         "X2 active " + str(self.m.TMC_motor[TMC_X2].ActiveCurrentScale) + "; " + \
                                         "X2 idle " + str(self.m.TMC_motor[TMC_X2].standStillCurrentScale) + "; "
 
+        self.y_current_label.text =     "Y Current: " + \
+                                        "Y1 active " + str(self.m.TMC_motor[TMC_Y1].ActiveCurrentScale) + "; " + \
+                                        "Y1 idle " + str(self.m.TMC_motor[TMC_Y1].standStillCurrentScale) + "; " + \
+                                        "Y2 active " + str(self.m.TMC_motor[TMC_Y2].ActiveCurrentScale) + "; " + \
+                                        "Y2 idle " + str(self.m.TMC_motor[TMC_Y2].standStillCurrentScale) + "; "
+
         self.thermal_coefficients_label.text = "Thermal coefficients: " + \
                                                 "X1: " + str(self.m.TMC_motor[TMC_X1].temperatureCoefficient) + "; " + \
                                                 "X2: " + str(self.m.TMC_motor[TMC_X2].temperatureCoefficient) + "; " + \
@@ -190,6 +210,10 @@ class ZHeadPCBSetUpOutcome(Screen):
         elif str(self.m.s.fw_version).startswith("1"): self.x_current_image.source = self.undetermined_image
         else: self.x_current_image.source = self.fail_image
 
+        if self.y_current_correct: self.y_current_image.source = self.success_image
+        elif str(self.m.s.fw_version).startswith("1"): self.y_current_image.source = self.undetermined_image
+        else: self.y_current_image.source = self.fail_image
+
         if self.thermal_coefficients_correct: self.thermal_coefficients_image.source = self.success_image
         elif str(self.m.s.fw_version).startswith("1"): self.thermal_coefficients_image.source = self.undetermined_image
         else: self.thermal_coefficients_image.source = self.fail_image
@@ -199,11 +223,13 @@ class ZHeadPCBSetUpOutcome(Screen):
         self.fw_update_success = True
         self.z_current_correct = True
         self.x_current_correct = True
+        self.y_current_correct = True
         self.thermal_coefficients_correct = True
 
         self.fw_update_image.source = self.undetermined_image
         self.z_current_image.source = self.undetermined_image
         self.x_current_image.source = self.undetermined_image
+        self.y_current_image.source = self.undetermined_image
         self.thermal_coefficients_image.source = self.undetermined_image
 
     # fw_update_image

--- a/tests/manual_tests/visual_screen_tests/z_head_qc_pcb_outcome_screen_test.py
+++ b/tests/manual_tests/visual_screen_tests/z_head_qc_pcb_outcome_screen_test.py
@@ -1,0 +1,94 @@
+ # -*- coding: utf-8 -*-
+
+from kivy.config import Config
+from kivy.clock import Clock
+Config.set('kivy', 'keyboard_mode', 'systemanddock')
+Config.set('graphics', 'width', '800')
+Config.set('graphics', 'height', '480')
+Config.set('graphics', 'maxfps', '60')
+Config.set('kivy', 'KIVY_CLOCK', 'interrupt')
+Config.write()
+
+'''
+########################################################
+IMPORTANT!!
+Run from easycut-smartbench folder, with 
+python -m tests.manual_tests.visual_screen_tests.z_head_qc_pcb_outcome_screen_test
+
+'''
+
+import sys, os
+path_to_EC = os.getcwd()
+sys.path.append('./src')
+os.chdir('./src')
+
+import kivy
+from kivy.app import App
+from kivy.uix.screenmanager import ScreenManager, Screen, NoTransition
+from kivy.core.window import Window
+from asmcnc.comms import localization
+from asmcnc.comms import router_machine
+from settings import settings_manager
+
+
+from asmcnc.production.z_head_qc_jig import z_head_qc_pcb_set_up_outcome, z_head_qc_pcb_set_up
+
+try: 
+    from mock import Mock, MagicMock
+    from serial_mock.mock import MockSerial, DummySerial
+    from random import randint
+
+except: 
+    pass
+
+
+from asmcnc.comms.yeti_grbl_protocol.c_defines import *
+
+Cmport = 'COM3'
+
+class ScreenTest(App):
+
+    def build(self):
+
+        # Establish screens
+        sm = ScreenManager(transition=NoTransition())
+
+        # Localization/language object
+        l = localization.Localization()
+
+        # Initialise settings object
+        sett = settings_manager.Settings(sm)
+        # sett.ip_address = ''
+
+        # Initialise 'j'ob 'd'ata object
+        jd = Mock()
+        jd.job_name = ""
+        jd.gcode_summary_string = ""
+
+        db = Mock()
+
+        # Initialise 'm'achine object
+        m = router_machine.RouterMachine(Cmport, sm, sett, l, jd)
+
+        m.s.fw_version = "2.5.5; HW: 35"
+
+        prep_screen = z_head_qc_pcb_set_up.ZHeadPCBSetUp(name='prep', sm = sm, m = m)
+        sm.add_widget(prep_screen)
+        sm.get_screen('prep').usb_path = path_to_EC + "/tests/test_resources/media/usb/"
+
+        test_screen = z_head_qc_pcb_set_up_outcome.ZHeadPCBSetUpOutcome(name='test', sm = sm, m = m)
+        sm.add_widget(test_screen)
+        sm.get_screen('test').usb_path = path_to_EC + "/tests/test_resources/media/usb/"
+        sm.current = 'test'
+
+        outcome_screen = sm.get_screen("test")
+
+        outcome_screen.x_current_correct = sm.get_screen('prep').check_current(TMC_X1, 0)
+        outcome_screen.x_current_correct = sm.get_screen('prep').check_current(TMC_X2, 0)
+        outcome_screen.y_current_correct = sm.get_screen('prep').check_current(TMC_Y1, 0)
+        outcome_screen.y_current_correct = sm.get_screen('prep').check_current(TMC_Y2, 0)
+        outcome_screen.z_current_correct = sm.get_screen('prep').check_current(TMC_Z, 0)
+
+        return sm
+
+ScreenTest().run()

--- a/tests/manual_tests/visual_screen_tests/z_head_qc_pcb_outcome_screen_test.py
+++ b/tests/manual_tests/visual_screen_tests/z_head_qc_pcb_outcome_screen_test.py
@@ -81,13 +81,20 @@ class ScreenTest(App):
         sm.get_screen('test').usb_path = path_to_EC + "/tests/test_resources/media/usb/"
         sm.current = 'test'
 
+        prep = sm.get_screen('prep')
         outcome_screen = sm.get_screen("test")
 
-        outcome_screen.x_current_correct = sm.get_screen('prep').check_current(TMC_X1, 0)
-        outcome_screen.x_current_correct = sm.get_screen('prep').check_current(TMC_X2, 0)
-        outcome_screen.y_current_correct = sm.get_screen('prep').check_current(TMC_Y1, 0)
-        outcome_screen.y_current_correct = sm.get_screen('prep').check_current(TMC_Y2, 0)
-        outcome_screen.z_current_correct = sm.get_screen('prep').check_current(TMC_Z, 0)
+        outcome_screen.x_current_correct*=prep.check_current(TMC_X1, 0)
+        outcome_screen.x_current_correct*=prep.check_current(TMC_X2, 10)
+        outcome_screen.y_current_correct*=prep.check_current(TMC_Y1, 12)
+        outcome_screen.y_current_correct*=prep.check_current(TMC_Y2, 11)
+        outcome_screen.z_current_correct*=prep.check_current(TMC_Z, 2)
+
+        outcome_screen.thermal_coefficients_correct*=prep.check_temp_coeff(TMC_X1, 0)
+        outcome_screen.thermal_coefficients_correct*=prep.check_temp_coeff(TMC_X2, 11)
+        outcome_screen.thermal_coefficients_correct*=prep.check_temp_coeff(TMC_Y1, 0)
+        outcome_screen.thermal_coefficients_correct*=prep.check_temp_coeff(TMC_Y2, 0)
+        outcome_screen.thermal_coefficients_correct*=prep.check_temp_coeff(TMC_Z, 0)
 
         return sm
 


### PR DESCRIPTION
Set: 
```
    double_stack_single_driver_x_current = 31
    double_stack_dual_driver_x_current = 27

    default_z_current = 31
    default_y_current = 28
```

Added in code to set, check, and report on setting of the Y current as well. 

Tested on Dev A through test specific branch [high_current_ZHQC_test](https://github.com/YetiTool/easycut-smartbench/tree/high_current_ZHQC_test) for use of port. 
Checked with main app that currents were getting changed & reported in current screen was same as set by ZHQC.  