### PR TITLE
Spindle test in final test

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1183,7 +1183,7 @@ class PopupConfirmSpindleTest(Widget):
         self.popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
 
         cancel_button.bind(on_press=self.popup.dismiss)
-        resume_button.bind(on_press=self.confirm_func)
+        resume_button.bind(on_press=lambda x: self.confirm_func)
         resume_button.bind(on_press=self.popup.dismiss)
 
     def open(self):

--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1140,8 +1140,8 @@ class PopupConfirmSpindleTest(Widget):
 
     def __init__(self, confirm_func, **kwargs):
         super(PopupConfirmSpindleTest, self).__init__(**kwargs)
-        self.build()
         self.confirm_func = confirm_func
+        self.build()
 
     def build(self):
         stop_description = "Pressing the confirm button will start the spindle test. Ensure it is safe to do so."

--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1183,7 +1183,7 @@ class PopupConfirmSpindleTest(Widget):
         self.popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
 
         cancel_button.bind(on_press=self.popup.dismiss)
-        resume_button.bind(on_press=lambda x: self.confirm_func)
+        resume_button.bind(on_press=lambda x: self.confirm_func())
         resume_button.bind(on_press=self.popup.dismiss)
 
     def open(self):

--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1132,3 +1132,60 @@ class PopupConfirmStoreCurrentValues(Widget):
         resume_button.bind(on_press=popup.dismiss)
 
         popup.open()
+
+
+class PopupConfirmSpindleTest(Widget):
+    popup = None
+    confirm_func = None
+
+    def __init__(self, confirm_func, **kwargs):
+        super(PopupConfirmSpindleTest, self).__init__(**kwargs)
+        self.build()
+        self.confirm_func = confirm_func
+
+    def build(self):
+        stop_description = self.l.get_str(
+            "Pressing the confirm button will start the spindle test. Ensure it is safe to do so.")
+        resume_string = self.l.get_bold("Confirm")
+        cancel_string = self.l.get_bold("Cancel")
+        title_string = self.l.get_str("Warning!")
+
+        img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
+        label = Label(size_hint_y=2, text_size=(360, None), halign='center', valign='middle', text=stop_description,
+                      color=[0, 0, 0, 1], padding=[0, 0], markup=True)
+
+        resume_button = Button(text=resume_string, markup=True)
+        resume_button.background_normal = ''
+        resume_button.background_color = [76 / 255., 175 / 255., 80 / 255., 1.]
+        cancel_button = Button(text=cancel_string, markup=True)
+        cancel_button.background_normal = ''
+        cancel_button.background_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+
+        btn_layout = BoxLayout(orientation='horizontal', spacing=15, padding=[0, 5, 0, 0], size_hint_y=2)
+        btn_layout.add_widget(cancel_button)
+        btn_layout.add_widget(resume_button)
+
+        layout_plan = BoxLayout(orientation='vertical', spacing=5, padding=[30, 20, 30, 0])
+        layout_plan.add_widget(img)
+        layout_plan.add_widget(label)
+        layout_plan.add_widget(btn_layout)
+
+        self.popup = Popup(title=title_string,
+                           title_color=[0, 0, 0, 1],
+                           title_font='Roboto-Bold',
+                           title_size='20sp',
+                           content=layout_plan,
+                           size_hint=(None, None),
+                           size=(400, 500),
+                           auto_dismiss=False)
+
+        self.popup.separator_color = [230 / 255., 74 / 255., 25 / 255., 1.]
+        self.popup.separator_height = '4dp'
+        self.popup.background = './asmcnc/apps/shapeCutter_app/img/popup_background.png'
+
+        cancel_button.bind(on_press=self.popup.dismiss)
+        resume_button.bind(on_press=self.confirm_func)
+        resume_button.bind(on_press=self.popup.dismiss)
+
+    def open(self):
+        self.popup.open()

--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1175,7 +1175,7 @@ class PopupConfirmSpindleTest(Widget):
                            title_size='20sp',
                            content=layout_plan,
                            size_hint=(None, None),
-                           size=(400, 500),
+                           size=(400, 300),
                            auto_dismiss=False)
 
         self.popup.separator_color = [230 / 255., 74 / 255., 25 / 255., 1.]

--- a/src/asmcnc/apps/systemTools_app/screens/popup_system.py
+++ b/src/asmcnc/apps/systemTools_app/screens/popup_system.py
@@ -1144,11 +1144,10 @@ class PopupConfirmSpindleTest(Widget):
         self.confirm_func = confirm_func
 
     def build(self):
-        stop_description = self.l.get_str(
-            "Pressing the confirm button will start the spindle test. Ensure it is safe to do so.")
-        resume_string = self.l.get_bold("Confirm")
-        cancel_string = self.l.get_bold("Cancel")
-        title_string = self.l.get_str("Warning!")
+        stop_description = "Pressing the confirm button will start the spindle test. Ensure it is safe to do so."
+        resume_string = "Confirm"
+        cancel_string = "Cancel"
+        title_string = "Warning!"
 
         img = Image(source="./asmcnc/apps/shapeCutter_app/img/error_icon.png", allow_stretch=False)
         label = Label(size_hint_y=2, text_size=(360, None), halign='center', valign='middle', text=stop_description,

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -310,7 +310,7 @@ Builder.load_string("""
 
                 GridLayout:
                     cols: 2
-                    rows: 7
+                    rows: 8
                     spacing: 2
                     ToggleButton:
                         id: maintenance_reminder_toggle

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -420,7 +420,7 @@ Builder.load_string("""
                         valign: "middle"
                         
                     Button:
-                        text: 'Digital Spindle Test'
+                        text: 'SC2 spindle test'
                         on_press: root.digital_spindle_test_pressed()
                         text_size: self.size
                         halign: "center"

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -420,7 +420,7 @@ Builder.load_string("""
                         valign: "middle"
                         
                     Button:
-                        text: 'D. Spindle Test'
+                        text: 'Digital Spindle Test'
                         on_press: root.digital_spindle_test_pressed()
                         text_size: self.size
                         halign: "center"

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -418,6 +418,13 @@ Builder.load_string("""
                         text_size: self.size
                         halign: "center"
                         valign: "middle"
+                        
+                    Button:
+                        text: 'D. Spindle Test'
+                        on_press: root.digital_spindle_test_pressed()
+                        text_size: self.size
+                        halign: "center"
+                        valign: "middle"
                             
 
             BoxLayout:
@@ -1104,13 +1111,24 @@ class FactorySettingsScreen(Screen):
         
         self.systemtools_sm.sm.current = 'set_thresholds'
 
-
     def enter_general_measurement(self):
         if not self.systemtools_sm.sm.has_screen('general_measurement'):
             general_measurement_screen = screen_general_measurement.GeneralMeasurementScreen(name='general_measurement', systemtools = self.systemtools_sm, machine = self.m)
             self.systemtools_sm.sm.add_widget(general_measurement_screen)
         
         self.systemtools_sm.sm.current = 'general_measurement'
+
+    def digital_spindle_test_pressed(self):
+        from asmcnc.production.z_head_qc_jig.z_head_qc_2 import ZHeadQC2
+
+        zhqc2 = ZHeadQC2(m=self.m, l=self.l, sm=self.systemtools_sm.sm)
+
+        confirm_func = zhqc2.run_digital_spindle_test
+
+        confirm_popup = popup_system.PopupConfirmSpindleTest(confirm_func=confirm_func)
+
+        confirm_popup.open()
+
 
 
 


### PR DESCRIPTION
Added 'Digital Spindle Test' button
![image](https://user-images.githubusercontent.com/46889734/234304362-355dd3c5-aaf9-49cb-95a9-b78781af3ea3.png)

On click shows popup:
![image](https://user-images.githubusercontent.com/46889734/234304479-e70d1c6d-6e9f-45cb-b0b5-0cf5c93f34d0.png)

Pressing confirm will run the spindle test.

Any issues will show up like this:
![image](https://user-images.githubusercontent.com/46889734/234305064-ee596608-d241-404b-be7d-27f53e59b150.png)


Functionality of the spindle test comes from ZHQC app.


Tested on rig, first with known good spindle then by unplugging spindle power cable to simulate fail.