### PR TITLE
Fix shapecutter Z height widget overflowing

### DIFF
--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_height.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_height.py
@@ -23,37 +23,41 @@ Builder.load_string("""
     z_clear:z_clear
     z_bit:z_bit
 
-    Image:
-        id: z_range
-        source: './asmcnc/skavaUI/img/zRange.png'
-        allow_stretch: True
-        keep_ratio: False
+    StencilView:
         size: self.parent.size
         pos: self.parent.pos
-    Image:
-        id:z_cut
-        source: './asmcnc/skavaUI/img/zCut.png'
-        allow_stretch: True
-        keep_ratio: False
-        size: self.parent.width, 0
-        pos: self.parent.pos
-        opacity: 1
-    Image:
-        id:z_clear
-        source: './asmcnc/skavaUI/img/zClear.png'
-        allow_stretch: True
-        keep_ratio: False
-        size: self.parent.width, 0
-        pos: self.parent.pos
-        opacity: 1
-    Image:
-        id: z_bit
-        source: './asmcnc/skavaUI/img/zBit.png'
-        allow_stretch: True
-        keep_ratio: False
-        size: self.parent.width/2, self.parent.height
-        x: self.parent.x+(self.parent.width/4)
-        y: self.parent.y
+
+        Image:
+            id: z_range
+            source: './asmcnc/skavaUI/img/zRange.png'
+            allow_stretch: True
+            keep_ratio: False
+            size: self.parent.size
+            pos: self.parent.pos
+        Image:
+            id:z_cut
+            source: './asmcnc/skavaUI/img/zCut.png'
+            allow_stretch: True
+            keep_ratio: False
+            size: self.parent.width, 0
+            pos: self.parent.pos
+            opacity: 1
+        Image:
+            id:z_clear
+            source: './asmcnc/skavaUI/img/zClear.png'
+            allow_stretch: True
+            keep_ratio: False
+            size: self.parent.width, 0
+            pos: self.parent.pos
+            opacity: 1
+        Image:
+            id: z_bit
+            source: './asmcnc/skavaUI/img/zBit.png'
+            allow_stretch: True
+            keep_ratio: False
+            size: self.parent.width/2, self.parent.height
+            x: self.parent.x+(self.parent.width/4)
+            y: self.parent.y
      
         
 """)


### PR DESCRIPTION
Updated the Z height widget in the shapecutter app to stop it from appearing outside of the widget's limits

Tested on windows

![image](https://user-images.githubusercontent.com/75572055/235233215-260f73b7-c659-44a0-8e22-0b383ec09f76.png)
