### PR TITLE
Exclude leds

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -564,7 +564,7 @@ class SerialConnection(object):
         return line if self.gcode_line_is_excluded(line) else 'N' + str(i) + line
 
     def gcode_line_is_excluded(self, line):
-        return '(' in line or ')' in line or '$' in line or 'AE' in line or 'AF' in line
+        return '(' in line or ')' in line or '$' in line or 'AE' in line or 'AF' in line or '*L' in line
 
     def get_grbl_float(self, line, pattern, last_thing=None):
         match_obj = re.search(pattern, line)

--- a/tests/automated_unit_tests/comms/test_serial_connection_streaming_units.py
+++ b/tests/automated_unit_tests/comms/test_serial_connection_streaming_units.py
@@ -298,7 +298,8 @@ def test_gcode_line_is_excluded(sc):
         ')',
         '$',
         'AE',
-        'AF'
+        'AF',
+        '*L'
     ]
     number_gcodes = 1
     for line in uncountable_gcodes:
@@ -313,6 +314,7 @@ def test_gcode_line_is_not_excluded(sc):
 def test_add_line_number_to_gcode_line(sc):
     assert sc.add_line_number_to_gcode_line("G1", 4) == "N4G1"
     assert sc.add_line_number_to_gcode_line("AE", 2) == "AE"
+    assert sc.add_line_number_to_gcode_line("*LFFFFFF", 3) == "*LFFFFFF"
 
 
 # GRBL mode tracking


### PR DESCRIPTION
LED commands are now excluded from having line numbers added to them.

Tested using unit tests, and on rig with yetipilot enabled on a file with an LED command on it, ensuring that the LED colour is changed correctly