### PR TITLE
Catch error when beta release is not found

### DIFF
--- a/src/settings/settings_manager.py
+++ b/src/settings/settings_manager.py
@@ -195,7 +195,12 @@ class Settings(object):
             try:
                 sw_version_list = (str(os.popen("git tag --sort=-refname |head -n 10").read()).split('\n'))
                 self.latest_sw_version = str([tag for tag in sw_version_list if "beta" not in tag][0])
-                self.latest_sw_beta = str([tag for tag in sw_version_list if "beta" in tag][0])
+
+                beta_list = [tag for tag in sw_version_list if "beta" in tag]
+                if beta_list:
+                    self.latest_sw_beta = str(beta_list[0])
+                else:
+                    self.latest_sw_beta = ""
 
             except: 
                 print("Could not sort software version tags")


### PR DESCRIPTION
When getting list of latest releases, the software no longer assumes that a beta release exists in the 10 latest releases, by first checking if one has been found before assigning it to a variable, instead of throwing an exception.

Tested on rig (by adding new tags locally until the latest beta release is more than 10 releases away, then checking that this causes an error on master, then making sure the software update works regardless on this branch)