### PR TITLE
use total_runtime_seconds as time job_time

### DIFF
--- a/src/asmcnc/comms/smartbench_flurry_database_connection.py
+++ b/src/asmcnc/comms/smartbench_flurry_database_connection.py
@@ -330,7 +330,7 @@ class DatabaseEventManager():
 					"calibration_hrs_before_next": calibration_hrs_left,
 
 					"file_name": self.jd.job_name or '',
-					"job_time": self.sm.get_screen('go').time_taken_seconds or '',
+					"job_time": self.sm.get_screen('go').total_runtime_seconds or 0,
 					"gcode_line": self.m.s.g_count or 0,
 					"job_percent": self.jd.percent_thru_job or 0.0,
 					"overload_peak": float(self.sm.get_screen('go').overload_peak) or 0.0


### PR DESCRIPTION
When we changed the variable that stores the job time a while back, it meant SmartManager wasn't receiving the job time. 

Tested on rig.

<img width="1912" alt="image" src="https://github.com/YetiTool/easycut-smartbench/assets/46889734/780a37ed-bd80-4d3e-9d15-9168f7f7f9ec">
