### PR TITLE
Set YP widget to disabled, not failed if health check is disabled.

### DIFF
--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -701,7 +701,10 @@ class GoScreen(Screen):
                 self._start_running_job()
 
                 if not self.m.has_spindle_health_check_passed():
-                    self.disabled_yp_widget.set_version(DisabledYPCase.FAILED)
+                    if not self.m.is_spindle_health_check_active():
+                        self.disabled_yp_widget.set_version(DisabledYPCase.DISABLED)
+                    else:
+                        self.disabled_yp_widget.set_version(DisabledYPCase.FAILED)
 
         self.listen_for_pauses = Clock.schedule_interval(lambda dt: self.raise_pause_screens_if_paused(), self.POLL_FOR_PAUSE_SCREENS)
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -701,10 +701,10 @@ class GoScreen(Screen):
                 self._start_running_job()
 
                 if not self.m.has_spindle_health_check_passed():
-                    if not self.m.is_spindle_health_check_active():
-                        self.disabled_yp_widget.set_version(DisabledYPCase.DISABLED)
-                    else:
+                    if self.m.is_spindle_health_check_active():
                         self.disabled_yp_widget.set_version(DisabledYPCase.FAILED)
+                    else:
+                        self.disabled_yp_widget.set_version(DisabledYPCase.DISABLED)
 
         self.listen_for_pauses = Clock.schedule_interval(lambda dt: self.raise_pause_screens_if_paused(), self.POLL_FOR_PAUSE_SCREENS)
 


### PR DESCRIPTION
Tested on dev machine by disabling health check and starting the job.

<img width="868" alt="image" src="https://github.com/YetiTool/easycut-smartbench/assets/46889734/4b180459-89db-4b8a-9401-05bd053e9194">
