### PR TITLE
Add reset_grbl_after_stream argument to write_dollar_setting function default is true. Call is as false from set x and y step functions

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
@@ -279,7 +279,7 @@ class FinalTestScreen(Screen):
         try:
             x_overstep = float(self.x_over_count.text)*self.x_calibration_scale_factor
             print(x_overstep)
-            self.m.write_dollar_setting(100, float(self.m.s.setting_100) - x_overstep)
+            self.m.write_dollar_setting(100, float(self.m.s.setting_100) - x_overstep, reset_grbl_after_stream=False)
             self.x_over_count.text = ""
         except:
             pass
@@ -288,7 +288,7 @@ class FinalTestScreen(Screen):
         try:
             y_overstep = float(self.y_over_count.text)*self.y_calibration_scale_factor
             print(y_overstep)
-            self.m.write_dollar_setting(101, float(self.m.s.setting_101) - y_overstep)
+            self.m.write_dollar_setting(101, float(self.m.s.setting_101) - y_overstep, reset_grbl_after_stream=False)
             self.y_over_count.text = ""
         except:
             pass

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -737,12 +737,12 @@ class RouterMachine(object):
     theateam_path =  '../../plus.txt'
 
 # GRBL SETTINGS
-    def write_dollar_setting(self, setting_no, value):
+    def write_dollar_setting(self, setting_no, value, reset_grbl_after_stream=True):
         list_to_stream = [
             '$%s=%s' % (str(setting_no), str(value)),
             '$$'
         ]
-        self.s.start_sequential_stream(list_to_stream, reset_grbl_after_stream=True)
+        self.s.start_sequential_stream(list_to_stream, reset_grbl_after_stream)
 
     def bake_default_grbl_settings(self, z_head_qc_bake=False):
 


### PR DESCRIPTION
Needed to debug after soft reset at end of sequential stream caused issues in final test :)

Tested on machine with Barry to get sign off

Also tested setting serial number and $54 setting to make sure soft reset was happening as default