### PR TITLE
Generalise bake GRBL settings, and ZH cycling (for ZHQC and grbl settings screen)

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
+++ b/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
@@ -94,7 +94,7 @@ class ScreenManagerSystemTools(object):
     # GRBL Settings and popups
     def open_grbl_settings_screen(self):
       if not self.sm.has_screen('grbl_settings'):
-          grbl_settings_screen = screen_grbl_settings.GRBLSettingsScreen(name = 'grbl_settings', machine = self.m, system_tools = self)
+          grbl_settings_screen = screen_grbl_settings.GRBLSettingsScreen(name = 'grbl_settings', machine = self.m, system_tools = self, localization = self.l)
           self.sm.add_widget(grbl_settings_screen)
       self.sm.current = 'grbl_settings'
 

--- a/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
@@ -209,7 +209,7 @@ class GRBLSettingsScreen(Screen):
 
     def bake_default_settings(self):
         if not self.m.bake_default_grbl_settings():
-            popup_info.PopupError(self.sm, self.l, "X current read in as 0! Can't set correct Z travel.")
+            popup_info.PopupError(self.systemtools_sm.sm, self.l, "X current read in as 0! Can't set correct Z travel.")
 
     def send_rst_dollar(self):
         self.m.send_any_gcode_command("$RST=$")

--- a/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
@@ -184,6 +184,7 @@ class GRBLSettingsScreen(Screen):
         super(GRBLSettingsScreen, self).__init__(**kwargs)
         self.systemtools_sm = kwargs['system_tools']
         self.m = kwargs['machine']
+        self.l = kwargs['localization']
 
     def go_back(self):
         self.systemtools_sm.open_system_tools()
@@ -207,7 +208,8 @@ class GRBLSettingsScreen(Screen):
         self.systemtools_sm.restore_grbl_settings_from_file()    
 
     def bake_default_settings(self):
-        self.m.bake_default_grbl_settings()
+        if not self.m.bake_default_grbl_settings():
+            popup_info.PopupError(self.sm, self.l, "X current read in as 0! Can't set correct Z travel.")
 
     def send_rst_dollar(self):
         self.m.send_any_gcode_command("$RST=$")

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
@@ -435,10 +435,14 @@ class ZHeadQC1(Screen):
         except:
             pass
 
-    def bake_grbl_settings(self):
+    def bake_grbl_settings(self):     
 
-        self.m.bake_default_grbl_settings(z_head_qc_bake=True)
-        self.bake_grbl_check.source = "./asmcnc/skavaUI/img/file_select_select.png"
+        if self.m.bake_default_grbl_settings(z_head_qc_bake=True):
+            self.bake_grbl_check.source = "./asmcnc/skavaUI/img/file_select_select.png"
+
+        else: 
+            self.bake_grbl_check.source = "./asmcnc/skavaUI/img/template_cancel.png"
+            popup_info.PopupError(self.sm, self.l, "X current read in as 0! Can't set correct Z travel.")
 
     def test_motor_chips(self):
 
@@ -536,7 +540,7 @@ class ZHeadQC1(Screen):
         self.m.jog_relative('Z', -20, 750)
 
     def mini_cycle(self):
-        self.m.s.write_command('G53 G0 Z-150')
+        self.m.s.write_command('G53 G0 Z-' + str(self.m.grbl_z_max_travel))
         self.m.s.write_command('G53 G0 Z-1')
 
     def quit_jog(self):

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_7.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_7.py
@@ -116,11 +116,11 @@ class ZHeadQC7(Screen):
         self.m.resume_from_alarm()
 
     def do_cycle(self):
-        self.m.s.write_command('G53 G0 Z-150')
+        self.m.s.write_command('G53 G0 Z-' + str(self.m.grbl_z_max_travel))
         self.m.s.write_command('G53 G0 Z-1')
-        self.m.s.write_command('G53 G0 Z-150')
+        self.m.s.write_command('G53 G0 Z-' + str(self.m.grbl_z_max_travel))
         self.m.s.write_command('G53 G0 Z-1')
-        self.m.s.write_command('G53 G0 Z-150')
+        self.m.s.write_command('G53 G0 Z-' + str(self.m.grbl_z_max_travel))
         self.m.s.write_command('G53 G0 Z-1')
 
     def enter_prev_screen(self):

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -209,12 +209,12 @@ Builder.load_string("""
                             orientation: 'horizontal'
                             size_hint_y: 0.2
                             CheckBox:
-                                id: single_stack_x_current_checkbox
+                                id: double_stack_x_current_checkbox
                                 size_hint_x: 0.2
-                                group: "x_current" 
-                                on_press: root.x_current = root.set_value_to_update_to(single_stack_x_current_label, self)
+                                group: "x_current"
+                                on_press: root.x_current = root.set_value_to_update_to(double_stack_x_current_label, self)
                             Label:
-                                id: single_stack_x_current_label
+                                id: double_stack_x_current_label
                                 size_hint_x: 0.8
                                 text_size: self.size
                                 markup: 'True'
@@ -225,12 +225,12 @@ Builder.load_string("""
                             orientation: 'horizontal'
                             size_hint_y: 0.2
                             CheckBox:
-                                id: double_stack_x_current_checkbox
+                                id: single_stack_x_current_checkbox
                                 size_hint_x: 0.2
-                                group: "x_current"
-                                on_press: root.x_current = root.set_value_to_update_to(double_stack_x_current_label, self)
+                                group: "x_current" 
+                                on_press: root.x_current = root.set_value_to_update_to(single_stack_x_current_label, self)
                             Label:
-                                id: double_stack_x_current_label
+                                id: single_stack_x_current_label
                                 size_hint_x: 0.8
                                 text_size: self.size
                                 markup: 'True'

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -533,13 +533,13 @@ class ZHeadPCBSetUp(Screen):
 
     def set_default_x_current(self, number_of_drivers):
 
-        self.single_stack_x_current_checkbox.state = "normal"
         self.double_stack_x_current_checkbox.state = "normal"
+        self.single_stack_x_current_checkbox.state = "normal"
         self.other_x_current_checkbox.state = "normal"
         
         self.generate_recommended_x_currents(number_of_drivers)
         self.other_x_current_textinput.text = str(self.x_current)
-        self.x_current = self.set_value_to_update_to(self.single_stack_x_current_label, self.single_stack_x_current_checkbox)
+        self.x_current = self.set_value_to_update_to(self.double_stack_x_current_label, self.double_stack_x_current_checkbox)
 
     def set_default_firmware_version(self):
 

--- a/tests/automated_unit_tests/comms/test_router_machine_units.py
+++ b/tests/automated_unit_tests/comms/test_router_machine_units.py
@@ -441,4 +441,30 @@ def test_get_is_constant_feed_rate_true_when_diff_equal_to_tolerance(m):
     assert last == last_feed_rate
     assert val
 
+# get_z_max_travel_to_bake TESTS
+
+def test_get_z_max_travel_to_bake_when_fw_is_2_5(m):
+    assert m.get_z_max_travel_to_bake(False, 27) == 150.0
+
+def test_get_z_max_travel_to_bake_when_fw_is_2_6_but_current_is_low(m):
+    assert m.get_z_max_travel_to_bake(True, 26) == 150.0
+
+def test_get_z_max_travel_to_bake_when_fw_is_2_6_and_current_is_27(m):
+    assert m.get_z_max_travel_to_bake(True, 27) == 130.0
+
+def test_get_z_max_travel_to_bake_when_fw_is_2_6_and_current_is_0(m):
+    assert not m.get_z_max_travel_to_bake(True, 0)
+
+def test_get_z_max_travel_to_bake_when_fw_is_1_and_current_is_0(m):
+    assert m.get_z_max_travel_to_bake(False, 0) == 150.0
+
+def test_bake_default_grbl_settings_when_z_max_travel_value_is_false(m):
+    m.get_z_max_travel_to_bake = Mock(return_value=False)
+    assert not m.bake_default_grbl_settings()
+
+def test_bake_default_grbl_settings_when_z_max_travel_value_is_true(m):
+    m.get_z_max_travel_to_bake = Mock(return_value=True)
+    assert m.bake_default_grbl_settings()
+
+
     


### PR DESCRIPTION
Change to new ZH cage to accommodate double stack motors means that $132 = 130.0, instead of 150.0. 

Have set up GRBL settings bake to set the max Z travel based on the X motor current and FW version.

Have also set up error checking so that if X motor current does not get read in properly (and FW version is high enough that it should be), both ZHQC main (not warranty) and password protected grbl settings screen (in system tools) will show the operator a popup. 

ZHQC cycles (for main screen) have been generalised to use the grbl_z_max_travel value, which is read in from $132. 

Also changed current selection checkboxes so that double stack option is first and is checked by default. 

Tests: 
- Unit tests for get_z_max_travel_to_bake function

- GRBL bake from grbl settings screen tested on Dev machine; sort of held down stop bar at start up to prevent read in of registers to check popup failure condition. 

- Tested on ZHQC jig from FW flash through to calibration and the final ZH cycle. Also tested Bake GRBL if flashed single motor current (on double stack ZH) to go through both conditions. 
