### PR TITLE
Hide job recovery button

### DIFF
--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -263,11 +263,15 @@ Builder.load_string("""
             size_hint_y: 0.08
             id: status_container
 
-    FloatLayout: 
+    FloatLayout:
+        size_hint: None, None
+        size: (0,0)
+        opacity: 0
         Image:
             id: job_recovery_button_image
             size_hint: None, None
             size: (0,0)
+            opacity: 0
 
 """)
 

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -263,11 +263,11 @@ Builder.load_string("""
             size_hint_y: 0.08
             id: status_container
 
-FloatLayout: 
-    Image:
-        id: job_recovery_button_image
-        size_hint: None, None
-        size: (0,0)
+    FloatLayout: 
+        Image:
+            id: job_recovery_button_image
+            size_hint: None, None
+            size: (0,0)
 
 """)
 

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -49,7 +49,7 @@ Builder.load_string("""
     gcode_preview_container:gcode_preview_container
     move_tab:move_tab
 
-    job_recovery_button:job_recovery_button
+    # job_recovery_button:job_recovery_button
     job_recovery_button_image:job_recovery_button_image
 
     BoxLayout:

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -211,27 +211,27 @@ Builder.load_string("""
                                             size: self.parent.width, self.parent.height
                                             allow_stretch: True
 
-                                Button:
-                                    id: job_recovery_button
-                                    size_hint_x: 1
-                                    background_color: hex('#F4433600')
-                                    on_press:
-                                        root.manager.current = 'recovery_decision'
-                                    BoxLayout:
-                                        padding: 0
-                                        size: self.parent.size
-                                        pos: self.parent.pos
-                                        Image:
-                                            id: job_recovery_button_image
-                                            source: "./asmcnc/skavaUI/img/recover_job_disabled.png"
-                                            center_x: self.parent.center_x
-                                            y: self.parent.y
-                                            size: self.parent.width, self.parent.height
-                                            allow_stretch: True
+                                # Button:
+                                #     id: job_recovery_button
+                                #     size_hint_x: 1
+                                #     background_color: hex('#F4433600')
+                                #     on_press:
+                                #         root.manager.current = 'recovery_decision'
+                                #     BoxLayout:
+                                #         padding: 0
+                                #         size: self.parent.size
+                                #         pos: self.parent.pos
+                                #         Image:
+                                #             id: job_recovery_button_image
+                                #             source: "./asmcnc/skavaUI/img/recover_job_disabled.png"
+                                #             center_x: self.parent.center_x
+                                #             y: self.parent.y
+                                #             size: self.parent.width, self.parent.height
+                                #             allow_stretch: True
 
                                 Label:
                                     id: file_data_label
-                                    size_hint_x: 5
+                                    size_hint_x: 4
                                     text_size: self.size
                                     font_size: '20sp'
                                     markup: True
@@ -262,6 +262,12 @@ Builder.load_string("""
         BoxLayout:
             size_hint_y: 0.08
             id: status_container
+
+FloatLayout: 
+    Image:
+        id: job_recovery_button_image
+        size_hint: None, None
+        size: (0,0)
 
 """)
 


### PR DESCRIPTION
Commented out the button, but put the image id into an invisible float layout so that no change to main body of code is needed :) 

Tested on Dev B through VNC