### PR TITLE
Swap positions of info and save buttons in maintenance app

### DIFF
--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -17,26 +17,31 @@ Builder.load_string("""
 <BrushSaveWidget>
 
     BoxLayout:
-        size_hint: (None, None)
-        height: dp(250)
-        width: dp(160)
         pos: self.parent.pos
+        size: self.parent.size
         orientation: 'vertical'
 
-        BoxLayout: 
-	        size_hint: (None, None)
-	        height: dp(140)
-	        width: dp(160)
-            padding: [22,20,18,0]
-            ToggleButton:
-                id: save_button
+        BoxLayout:
+            padding: [dp(50), dp(30)]
+	        Button:
+	            on_press: root.get_info()
+	            background_color: [0,0,0,0]
+	            BoxLayout:
+                    size: self.parent.size
+	                pos: self.parent.pos
+	                Image:
+	                    source: "./asmcnc/apps/shapeCutter_app/img/info_icon.png"
+	                    center_x: self.parent.center_x
+	                    y: self.parent.y
+	                    size: self.parent.width, self.parent.height
+	                    allow_stretch: True
+
+        BoxLayout:
+            size_hint_y: 1.2
+            padding: [dp(20), dp(10)]
+            Button:
                 on_press: root.save()
-                size_hint: (None,None)
-                height: dp(120)
-                width: dp(120)
                 background_color: [0,0,0,0]
-                center: self.parent.center
-                pos: self.parent.pos
                 BoxLayout:
                     size: self.parent.size
                     pos: self.parent.pos
@@ -47,26 +52,6 @@ Builder.load_string("""
                         y: self.parent.y
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
-
-        BoxLayout: 
-	        size_hint: (None, None)
-	        height: dp(110)
-	        width: dp(160)
-            padding: [50,0,50,27]
-	        Button:
-	            background_color: hex('#F4433600')
-	            on_press: root.get_info()
-	            BoxLayout:
-	                size_hint: (None,None)
-	                height: dp(60)
-	                width: dp(60)
-	                pos: self.parent.pos
-	                Image:
-	                    source: "./asmcnc/apps/shapeCutter_app/img/info_icon.png"
-	                    center_x: self.parent.center_x
-	                    y: self.parent.y
-	                    size: self.parent.width, self.parent.height
-	                    allow_stretch: True
 
 """)
 

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
@@ -17,26 +17,31 @@ Builder.load_string("""
 <ZMiscSaveWidget>
 
     BoxLayout:
-        size_hint: (None, None)
-        height: dp(350)
-        width: dp(160)
         pos: self.parent.pos
+        size: self.parent.size
         orientation: 'vertical'
 
-        BoxLayout: 
-	        size_hint: (None, None)
-	        height: dp(175)
-	        width: dp(160)
-            padding: [15,21.5,13,21.5]
-            ToggleButton:
-                id: save_button
+        BoxLayout:
+            padding: [dp(50), dp(30)]
+	        Button:
+	            on_press: root.get_info()
+	            background_color: [0,0,0,0]
+	            BoxLayout:
+                    size: self.parent.size
+	                pos: self.parent.pos
+	                Image:
+	                    source: "./asmcnc/apps/shapeCutter_app/img/info_icon.png"
+	                    center_x: self.parent.center_x
+	                    y: self.parent.y
+	                    size: self.parent.width, self.parent.height
+	                    allow_stretch: True
+
+        BoxLayout:
+            size_hint_y: 1.2
+            padding: [dp(20), dp(10)]
+            Button:
                 on_press: root.save()
-                size_hint: (None,None)
-                height: dp(132)
-                width: dp(132)
                 background_color: [0,0,0,0]
-                center: self.parent.center
-                pos: self.parent.pos
                 BoxLayout:
                     size: self.parent.size
                     pos: self.parent.pos
@@ -47,26 +52,6 @@ Builder.load_string("""
                         y: self.parent.y
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
-
-        BoxLayout: 
-	        size_hint: (None, None)
-	        height: dp(175)
-	        width: dp(160)
-            padding: [50,0,50,57.5]
-	        Button:
-	            background_color: hex('#F4433600')
-	            on_press: root.get_info()
-	            BoxLayout:
-	                size_hint: (None,None)
-	                height: dp(60)
-	                width: dp(60)
-	                pos: self.parent.pos
-	                Image:
-	                    source: "./asmcnc/apps/shapeCutter_app/img/info_icon.png"
-	                    center_x: self.parent.center_x
-	                    y: self.parent.y
-	                    size: self.parent.width, self.parent.height
-	                    allow_stretch: True
 
 """)
 


### PR DESCRIPTION
Spindle settings screen was already swapped from previous pull request

Tested on windows

![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/a40ea96e-7dc8-44ed-9a62-603d72cfcd42)
![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/d246c2be-7234-4bd5-85e8-9e057f511808)
![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/f19a1371-9e12-4ec0-9278-acb7535098de)
