### PR TITLE
Made network change without rebooting

### DIFF
--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -457,9 +457,6 @@ class WifiScreen(Screen):
 
     def connect_wifi(self):
         self._password.text = ''
-
-        # Save the current IP address to dismiss the wait popup when the address changes
-        current_ip_address = self.ip_status_label.text
         wait_popup = popup_info.PopupWait(self.sm, self.l)
 
         # pass credentials to wpa_supplicant file
@@ -489,10 +486,12 @@ class WifiScreen(Screen):
             os.system('sudo systemctl restart dhcpcd')
 
             def dismiss_wait_popup(dt):
-                if self.ip_status_label.text != '' and self.ip_status_label.text != current_ip_address:
+                if self.set.wifi_available:
                     wait_popup.popup.dismiss()
+                    return
+                Clock.schedule_once(dismiss_wait_popup, 0.5)
 
-            Clock.schedule_interval(dismiss_wait_popup, 0.5)
+            Clock.schedule_once(dismiss_wait_popup, 5)
 
         except: 
             try: 

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -614,6 +614,9 @@ class WifiScreen(Screen):
                 self.connection_instructions_rst.source = self.wifi_documentation_path + self.l.default_lang + '.rst'
 
     def on_leave(self):
-        self.wifi_error_timeout_event.cancel()
-        self.dismiss_wait_popup_event.cancel()
-        #self.refresh_ip_label_value_event.cancel()
+        if self.wifi_error_timeout_event:
+            self.wifi_error_timeout_event.cancel()
+        if self.dismiss_wait_popup_event:
+            self.dismiss_wait_popup_event.cancel()
+        if self.refresh_ip_label_value_event:
+            self.refresh_ip_label_value_event.cancel()

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -422,7 +422,6 @@ class WifiScreen(Screen):
         self.sm = kwargs['screen_manager']
         self.set = kwargs['settings_manager']
         self.l = kwargs['localization']
-        self.refresh_ip_label_value_event = Clock.schedule_interval(self.refresh_ip_label_value, self.IP_REPORT_INTERVAL)
 
         if sys.platform != 'win32' and sys.platform != 'darwin':
             self.network_name.values = self.get_available_networks()
@@ -431,7 +430,8 @@ class WifiScreen(Screen):
         self.get_rst_source()
 
     def on_enter(self):
-
+        self.refresh_ip_label_value_event = Clock.schedule_interval(self.refresh_ip_label_value,
+                                                                    self.IP_REPORT_INTERVAL)
         self.refresh_ip_label_value(1)
         if sys.platform != 'win32' and sys.platform != 'darwin':
             try: self.network_name.text = ((str((os.popen('grep "ssid" /etc/wpa_supplicant/wpa_supplicant.conf').read())).split("=")[1]).strip('\n')).strip('"')
@@ -616,4 +616,4 @@ class WifiScreen(Screen):
     def on_leave(self):
         self.wifi_error_timeout_event.cancel()
         self.dismiss_wait_popup_event.cancel()
-        self.refresh_ip_label_value_event.cancel()
+        #self.refresh_ip_label_value_event.cancel()

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -518,24 +518,25 @@ class WifiScreen(Screen):
 
         def dismiss_wait_popup(dt):
             if self.set.wifi_available:
+                if self.wifi_error_timeout_event:
+                    Clock.unschedule(self.wifi_error_timeout_event)
                 try:
                     wait_popup.popup.dismiss()
                 except:
                     pass
-                if self.wifi_error_timeout_event:
-                    Clock.unschedule(self.wifi_error_timeout_event)
                 return
             self.dismiss_wait_popup_event = Clock.schedule_once(dismiss_wait_popup, 0.5)
 
         def wifi_error_timeout(dt):
-            if self.dismiss_wait_popup_event:
-                Clock.unschedule(self.dismiss_wait_popup_event)
-            try:
-                wait_popup.popup.dismiss()
-            except:
-                pass
-            message = self.l.get_str("No WiFi connection!")
-            popup_info.PopupWarning(self.sm, self.l, message)
+            if not self.set.wifi_available:
+                if self.dismiss_wait_popup_event:
+                    Clock.unschedule(self.dismiss_wait_popup_event)
+                try:
+                    wait_popup.popup.dismiss()
+                except:
+                    pass
+                message = self.l.get_str("No WiFi connection!")
+                popup_info.PopupWarning(self.sm, self.l, message)
 
         self.dismiss_wait_popup_event = Clock.schedule_once(dismiss_wait_popup, 5)
         self.wifi_error_timeout_event = Clock.schedule_once(wifi_error_timeout, 30)

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -415,13 +415,14 @@ class WifiScreen(Screen):
 
     dismiss_wait_popup_event = None
     wifi_error_timeout_event = None
+    refresh_ip_label_value_event = None
 
     def __init__(self, **kwargs):
         super(WifiScreen, self).__init__(**kwargs)
         self.sm = kwargs['screen_manager']
         self.set = kwargs['settings_manager']
         self.l = kwargs['localization']
-        Clock.schedule_interval(self.refresh_ip_label_value, self.IP_REPORT_INTERVAL)
+        self.refresh_ip_label_value_event = Clock.schedule_interval(self.refresh_ip_label_value, self.IP_REPORT_INTERVAL)
 
         if sys.platform != 'win32' and sys.platform != 'darwin':
             self.network_name.values = self.get_available_networks()
@@ -615,3 +616,4 @@ class WifiScreen(Screen):
     def on_leave(self):
         self.wifi_error_timeout_event.cancel()
         self.dismiss_wait_popup_event.cancel()
+        self.refresh_ip_label_value_event.cancel()


### PR DESCRIPTION
### This popup appears while the network is being changed in the background and goes away automatically once an IPv4 address has been allocated on the new network
![image](https://github.com/YetiTool/easycut-smartbench/assets/126763092/aeb9411c-9c20-4d10-bd20-72d00e76a9b1)

I've tested it by switching between Yeti Wi-Fi and a personal hotspot and checking that the IP address has changed correctly and used `ping` to check Internet connectivity.