### PR TITLE
Stream resume after failed spindle health check to replace soft reset on screen entry. 

### DIFF
--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -692,6 +692,7 @@ class GoScreen(Screen):
                 self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         else:
             # self.m._grbl_soft_reset()
+            self.m.resume_from_a_soft_door()
 
             if self.m.is_spindle_health_check_active() \
                     and not self.m.has_spindle_health_check_run() \

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -692,20 +692,23 @@ class GoScreen(Screen):
                 self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         else:
             # self.m._grbl_soft_reset()
-            self.m.resume_from_a_soft_door()
 
             if self.m.is_spindle_health_check_active() \
                     and not self.m.has_spindle_health_check_run() \
                     and self.m.is_using_sc2():
                 self.run_spindle_health_check(start_after_pass=True)
             else:
-                self._start_running_job()
 
                 if not self.m.has_spindle_health_check_passed():
+
+                    if self.m.has_spindle_health_check_run(): self.m.resume_from_a_soft_door()
+
                     if self.m.is_spindle_health_check_active():
                         self.disabled_yp_widget.set_version(DisabledYPCase.FAILED)
                     else:
                         self.disabled_yp_widget.set_version(DisabledYPCase.DISABLED)
+
+                self._start_running_job()
 
         self.listen_for_pauses = Clock.schedule_interval(lambda dt: self.raise_pause_screens_if_paused(), self.POLL_FOR_PAUSE_SCREENS)
 

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -691,7 +691,6 @@ class GoScreen(Screen):
 
                 self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         else:
-            # self.m._grbl_soft_reset()
 
             if self.m.is_spindle_health_check_active() \
                     and not self.m.has_spindle_health_check_run() \
@@ -701,6 +700,9 @@ class GoScreen(Screen):
 
                 if not self.m.has_spindle_health_check_passed():
 
+                    # If spindle health check fails for some reason, it will put SB into a door/pause state. 
+                    # This will fix that, but also won't cause the same disruption as a soft reset. 
+                    # This is a temporary patch; ideally the handling of the spindle health check needs refactoring. 
                     if self.m.has_spindle_health_check_run(): self.m.resume_from_a_soft_door()
 
                     if self.m.is_spindle_health_check_active():

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -691,7 +691,7 @@ class GoScreen(Screen):
 
                 self.m.s.is_ready_to_assess_spindle_for_shutdown = True # allow spindle overload assessment to resume
         else:
-            self.m._grbl_soft_reset()
+            # self.m._grbl_soft_reset()
 
             if self.m.is_spindle_health_check_active() \
                     and not self.m.has_spindle_health_check_run() \


### PR DESCRIPTION
All cases for various branches tested on rig. Test table in "Testing job start with/without soft reset" gsheet. 

Also tested a few job starts with lowered Z axis on job start, and conducted endurance testing with many_resumes branch to make sure that GRBL resume does not interrupt active moves (unlike GRBL soft reset). 