### PR TITLE
Wifi ssid list

### DIFF
--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -531,8 +531,8 @@ class WifiScreen(Screen):
         raw_SSID_list = os.popen('sudo iwlist wlan0 scan | grep "ESSID:" | sed "s/ESSID://g" | sed "s/^[ \t]*//g"').read()
         SSID_list = raw_SSID_list.replace('"','').strip().split('\n')  # Remove " from network name and split on newline
         if '' in SSID_list: SSID_list.remove('')  # Remove empty entries
-        SSID_list = [x for x in SSID_list if not set(x) <= set("\\x00")]  # Remove any addresses that contain only NULL bytes
-        SSID_list = set(SSID_list)  # Remove duplicate entries
+        # Remove any addresses that contain only NULL bytes and cast it to a set to remove duplicates
+        SSID_list = {x for x in SSID_list if not set(x) <= set("\\x00")}
         return SSID_list
 
     def refresh_available_networks(self):

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -526,9 +526,10 @@ class WifiScreen(Screen):
         self.sm.current = 'lobby'
     
     def get_available_networks(self):
-        raw_SSID_list = os.popen('sudo iw dev wlan0 scan | grep SSID').read()
+        raw_SSID_list = os.popen('sudo iw dev wlan0 scan | grep "SSID:"').read()
         SSID_list = raw_SSID_list.replace('\tSSID: ','').strip().split('\n')
         if '' in SSID_list: SSID_list.remove('')
+        SSID_list = set(SSID_list) #Remove duplicate entries
         return SSID_list
 
     def refresh_available_networks(self):

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -529,6 +529,7 @@ class WifiScreen(Screen):
         raw_SSID_list = os.popen('sudo iw dev wlan0 scan | grep "SSID:"').read()
         SSID_list = raw_SSID_list.replace('\tSSID: ','').strip().split('\n')
         if '' in SSID_list: SSID_list.remove('')
+        SSID_list = [str(x).decode('utf-8') for x in SSID_list if "\\x00" not in x]
         SSID_list = set(SSID_list) #Remove duplicate entries
         return SSID_list
 


### PR DESCRIPTION
Weird or duplicate network names should no longer appear in the list of networks in the Wi-Fi screen. Tested on rig by changing the name of the hotspot on my phone to include special characters like \n, \t, \x00, etc