### PR TITLE
Keyboard enter fix

### DIFF
--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -67,6 +67,7 @@ class Keyboard(VKeyboard):
             if internal == None:
                 if keycode == "enter":
                     if not self.text_instance.multiline:
+                        self.text_instance.focus = False
                         self.text_instance.dispatch("on_text_validate")
                     else:
                         self.text_instance.text = self.text_instance.text + "\n"

--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -38,7 +38,7 @@ class Keyboard(VKeyboard):
 
         self.do_translation = False
         self.width = Window.width
-        self.height = 250
+        self.height = int(Window.height / 2.1)
         self.pos = (Window.width - self.width, 0)
         self.on_key_up = self.key_up
 
@@ -66,7 +66,10 @@ class Keyboard(VKeyboard):
         if self.text_instance:
             if internal == None:
                 if keycode == "enter":
-                    self.text_instance.text = self.text_instance.text + "\n"
+                    if not self.text_instance.multiline:
+                        self.text_instance.dispatch("on_text_validate")
+                    else:
+                        self.text_instance.text = self.text_instance.text + "\n"
                 if keycode == "Han/Yeong":
                     #https://en.wikipedia.org/wiki/Language_input_keys#Keys_for_Korean_Keyboards
                     self.layout = self.qwertyKR_layout if self.layout == self.kr_layout else self.kr_layout


### PR DESCRIPTION
This makes the keyboard behave more like the default one.

- When multiline is set to false, the on_text_validate function is called instead of adding a newline
- The height of the keyboard is slightly smaller, so it doesn't cover up some text inputs, and adjusts based on window size