### PR TITLE
Add spindle state gcode before going to z position

### DIFF
--- a/tests/automated_unit_tests/job/test_generate_recovery_gcode.py
+++ b/tests/automated_unit_tests/job/test_generate_recovery_gcode.py
@@ -816,8 +816,8 @@ def test_spindle_speed(jd):
     assert jd.job_recovery_gcode == [
         "S15000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M03",
+        "G0 Z0.000",
         "S10000 M5"
     ]
     assert jd.job_recovery_offset == -5
@@ -828,8 +828,8 @@ def test_spindle_speed(jd):
     assert jd.job_recovery_gcode == [
         "S20000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M03",
+        "G0 Z0.000",
         "S15000 M03",
         "S10000 M5"
     ]
@@ -841,8 +841,8 @@ def test_spindle_speed(jd):
     assert jd.job_recovery_gcode == [
         "S25000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M3",
+        "G0 Z0.000",
         "M03S20000",
         "G4 P4",
         "S15000 M03",
@@ -856,8 +856,8 @@ def test_spindle_speed(jd):
     assert jd.job_recovery_gcode == [
         "S0",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M3",
+        "G0 Z0.000",
         "M3 S25000",
         "G4 P4",
         "M03S20000",
@@ -873,8 +873,8 @@ def test_spindle_speed(jd):
     assert jd.job_recovery_gcode == [
         "S5000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M3",
+        "G0 Z0.000",
         "S0",
         "G4 P4",
         "M3 S25000",
@@ -1107,8 +1107,8 @@ def test_spindle_state(jd):
         "M30",
         "S20000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M5",
+        "G0 Z0.000",
         "G1"
     ]
     assert jd.job_recovery_offset == 1
@@ -1121,8 +1121,8 @@ def test_spindle_state(jd):
         "M30",
         "S20000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M04",
+        "G0 Z0.000",
         "M5",
         "G1"
     ]
@@ -1135,8 +1135,8 @@ def test_spindle_state(jd):
         "G90",
         "S20000",
         "G0 X0.000 Y0.000",
-        "G0 Z0.000",
         "M3",
+        "G0 Z0.000",
         "M04",
         "M30",
         "M5",
@@ -1199,9 +1199,9 @@ def test_regular_case(jd):
         "M8",
         "S20000",
         "G0 X547.15 Y263",
+        "M3",
         "G0 Z9",
         "G1 F1000",
-        "M3",
         "M5"
     ]
     assert jd.job_recovery_offset == -12
@@ -1216,8 +1216,8 @@ def test_regular_case(jd):
         "G21",
         "S20000",
         "G0 X0.000 Y0.000",
-        "G0 Z20.000",
         "M3",
+        "G0 Z20.000",
         "G28 G91 Z0",
         "G90",
         "T1",


### PR DESCRIPTION
Spindle state gcode is now scraped earlier in job recovery, and placed before the Z movement and after the XY movement commands. This should fix an issue where the spindle hits the material before turning on.

Tested with unit test