### PR TITLE
File unit interpretation

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -639,6 +639,9 @@ class SerialConnection(object):
 
         log("Ending stream...")
 
+        # Always switch to mm, in case the job put you in inches
+        self.write_command('G21')
+
         # Reset flags
         self.is_job_streaming = False
         self.is_stream_lines_remaining = False

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -330,6 +330,8 @@ class JobRecoveryScreen(Screen):
     scroll_up_event = None
     scroll_down_event = None
 
+    using_inches = False
+
     def __init__(self, **kwargs):
         super(JobRecoveryScreen, self).__init__(**kwargs)
 
@@ -476,6 +478,13 @@ class JobRecoveryScreen(Screen):
         else:
             self.pos_z = 0.0
 
+        # Check if these distances are measured in inches, so that GO XY can work correctly
+        unit_line = next((s for s in reversed(self.jd.job_gcode[:self.selected_line_index + 1]) if re.search("G2[0,1]", s)), None)
+        if unit_line:
+            self.using_inches = "G20" in unit_line
+        else:
+            self.using_inches = False
+
         self.pos_label.text = "wX: %s | wY: %s | wZ: %s" % (str(self.pos_x), str(self.pos_y), str(self.pos_z))
         self.speed_label.text = "%s: %s | %s: %s" % (self.l.get_str("F"), str(self.feed), self.l.get_str("S"), str(self.speed))
 
@@ -499,11 +508,15 @@ class JobRecoveryScreen(Screen):
         # Pick min out of safe z height and limit_switch_safety_distance, in case positive value is calculated, which causes errors
         z_safe_height = min(self.m.z_wco() + self.sm.get_screen('home').job_box.range_z[1], -self.m.limit_switch_safety_distance)
 
+        if self.using_inches:
+            self.m.s.write_command('G20')
+
         # If Z is below safe height, then raise it up
         if self.m.mpos_z() < z_safe_height:
             self.m.s.write_command('G53 G0 Z%s F750' % z_safe_height)
 
         self.m.s.write_command('G90 G0 X%s Y%s' % (self.pos_x, self.pos_y))
+        self.m.s.write_command('G21')
 
     def back_to_home(self):
         self.jd.reset_recovery()


### PR DESCRIPTION
Two different fixes related to G20/G21 unit gcodes:

- When a stream ends, a G21 is sent to change the machine back to mm, in case the file used inches
- When using the GO XY button in job recovery, the last G20/G21 command is accounted for so that the position is accurately found.

Tested on windows, by using manual move and doing 1mm movements and seeing if it goes way too far