### PR TITLE
Acrylic profiles localised

### DIFF
--- a/src/asmcnc/comms/foreign_dictionary.txt
+++ b/src/asmcnc/comms/foreign_dictionary.txt
@@ -892,3 +892,5 @@ No network connection.	Keine Netzwerkverbindung.	Pas de connexion réseau.	Nessu
 Please refresh the list and try again.	Bitte aktualisieren Sie die Liste und versuchen Sie es erneut.	Veuillez rafraichir la liste et essayez à nouveau.	Per favore aggiorna la lista e riprova.	Päivitä lista ja yritä uudestaan.	Vernieuw de lijst en probeer het opnieuw.	Proszę odśwież listę i spróbuj ponownie.	Opdater venligst listen, og prøv igen.
 1 flute straight	Einschneidiger Fräser	1 dent droite	Monotagliente Dritto	Suora 1-leikkuinen	1 spaangroeven recht	Frez prosty 1-piórowy	1 skær lige
 Aluminium	Aluminium	Aluminium	Alluminio	Alumiini	Aluminium	Aluminium	Aluminium
+Acrylic	Acryl	Acrylique	Acrilico	Akryyli	Acryl	Akryl	Akryl
+V-groove	V-Nutfräser	fraise en V	Fresa a V	V-ura	V-groef	Frez grawerski typ V	V-rille

--- a/src/asmcnc/job/yetipilot/config/profiles.json
+++ b/src/asmcnc/job/yetipilot/config/profiles.json
@@ -591,6 +591,86 @@
           "Value": 22500.0
         }
       ]
+    },
+    {
+      "Material Type": "ACM",
+      "Cutter Diameter": "90 deg",
+      "Cutter Type": "v groove",
+      "Step Down": "3 mm",
+      "Parameters": [
+        {
+          "Name": "spindle_tool_load_watts",
+          "Value": 320
+        },
+        {
+          "Name": "target_spindle_speed",
+          "Value": 24200.0
+        }
+      ]
+    },
+    {
+      "Material Type": "Acrylic",
+      "Cutter Diameter": "3 mm",
+      "Cutter Type": "1 flute upcut spiral",
+      "Step Down": "2 mm",
+      "Parameters": [
+        {
+          "Name": "spindle_tool_load_watts",
+          "Value": 100
+        },
+        {
+          "Name": "target_spindle_speed",
+          "Value": 24200.0
+        }
+      ]
+    },
+    {
+      "Material Type": "Acrylic",
+      "Cutter Diameter": "4 mm",
+      "Cutter Type": "1 flute upcut spiral",
+      "Step Down": "2 mm",
+      "Parameters": [
+        {
+          "Name": "spindle_tool_load_watts",
+          "Value": 130
+        },
+        {
+          "Name": "target_spindle_speed",
+          "Value": 24200.0
+        }
+      ]
+    },
+    {
+      "Material Type": "Acrylic",
+      "Cutter Diameter": "5 mm",
+      "Cutter Type": "1 flute upcut spiral",
+      "Step Down": "2 mm",
+      "Parameters": [
+        {
+          "Name": "spindle_tool_load_watts",
+          "Value": 130
+        },
+        {
+          "Name": "target_spindle_speed",
+          "Value": 22500.0
+        }
+      ]
+    },
+    {
+      "Material Type": "Acrylic",
+      "Cutter Diameter": "6 mm",
+      "Cutter Type": "1 flute upcut spiral",
+      "Step Down": "2 mm",
+      "Parameters": [
+        {
+          "Name": "spindle_tool_load_watts",
+          "Value": 150
+        },
+        {
+          "Name": "target_spindle_speed",
+          "Value": 22500.0
+        }
+      ]
     }
   ]
 }

--- a/src/asmcnc/job/yetipilot/config/profiles.json
+++ b/src/asmcnc/job/yetipilot/config/profiles.json
@@ -594,8 +594,8 @@
     },
     {
       "Material Type": "ACM",
-      "Cutter Diameter": "90 deg",
-      "Cutter Type": "v groove",
+      "Cutter Diameter": "90°",
+      "Cutter Type": "V-groove",
       "Step Down": "3 mm",
       "Parameters": [
         {

--- a/src/asmcnc/job/yetipilot/yetipilot.py
+++ b/src/asmcnc/job/yetipilot/yetipilot.py
@@ -313,7 +313,7 @@ class YetiPilot(object):
         for profile_json in profiles_json["Profiles"]:
             self.available_profiles.append(
                 YetiPilotProfile(
-                    cutter_diameter=profile_json["Cutter Diameter"],
+                    cutter_diameter=profile_json["Cutter Diameter"].encode('utf-8'),
                     cutter_type=self.l.get_str(profile_json["Cutter Type"]),
                     material_type=self.l.get_str(profile_json["Material Type"]),
                     step_down=profile_json["Step Down"],


### PR DESCRIPTION
# Changes
- New acrylic profiles 
- New ACM profile with V-groove cutter
- Added `.encode('utf-8')` to read in of cutter diameter, because otherwise the degree sign crashes everything. 

# Testing
- Tested in all languages with screen tests
- Tested on Martha in English