### PR TITLE
Change generic spindle on function from S25000 to S12000

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1673,7 +1673,7 @@ class RouterMachine(object):
         self.s.write_realtime('\x85', altDisplayText = 'Quit jog')
 
     def spindle_on(self):
-        self.s.write_command('M3 S25000')
+        self.s.write_command('M3 S12000')
     
     def spindle_off(self):
         self.s.write_command('M5')


### PR DESCRIPTION
This affects: 
- Customer facing screens: 
    - src/asmcnc/apps/maintenance_app/widget_maintenance_laser_buttons.py
    - src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_35.py
    - src/asmcnc/skavaUI/widget_common_move.py

- Production screens:
    - src/asmcnc/production/lower_beam_qc_jig/lower_beam_qc_warranty.py
    - src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
    - src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
    - src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py

Tested all customer facing buttons on rig and checked terminal output. 