### PR TITLE
Use text input native insert text function

### DIFF
--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -79,7 +79,7 @@ class Keyboard(VKeyboard):
                     self.text_instance.text = self.text_instance.text[:-1]
                 return
 
-            self.text_instance.text = self.text_instance.text + internal
+            self.text_instance.insert_text(internal)
 
     def on_focus(self,instance,value):
         if value:


### PR DESCRIPTION
This ensures that all of the native functionality of the text input works as expected, and fixes issues including: 
- input_filter was not working (so letters could be entered in number fields) 
- cursor did not set where the text was added (it was always being added to the end of the line)

Tested on computer