### PR TITLE
Replace for loops in custom_keyboard module with kivy clock alternative

### DIFF
--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -47,9 +47,27 @@ class Keyboard(VKeyboard):
         self.setup_text_inputs(text_inputs)
 
 
-    # This is a wrapper function to make the "func" argument get called recursively, scheduled before the next frame. 
-    # If the same callback is called more than 10 times before the next frame, kivy will issue a warning but won't freeze :). 
     def generic_for_loop_alternative(self, func, list_of_items, i=0, end_func=0):
+
+        '''
+        This alternative to using for loops prevents the UI from locking up while the "loop" continues in the background.
+
+        This is a wrapper function to make the "func" argument get called recursively, scheduled before the next frame. 
+        If the same callback is called more than 10 times before the next frame, kivy will issue a warning but won't freeze :).
+        This means it will scale even if there's a long list of things to get through. 
+
+        func: function that you would call from within the loop; if this returns true the "loop" will break
+        list_of_items and i: imagine you were using 'for x in list_of_items:', list_of_items[i] is x
+        end_func: the function that would be called when the loop ended
+
+        e.g.
+            for x in list_of_items:
+                if func(x): return 
+
+            if end_func: end_func()
+
+        '''
+
         try: 
             # if the given function returns True, exit the "loop" :)
             if func(list_of_items[i]): return

--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -135,3 +135,11 @@ class Keyboard(VKeyboard):
     def remove_children(self, child):
         if isinstance(child, Keyboard):
             Window.remove_widget(child)
+
+    def defocus_all_text_inputs(self, text_inputs):
+        self.generic_for_loop_alternative(self.defocus_text_input, text_inputs)
+
+    def defocus_text_input(self, text_input):
+        text_input.focus = False
+
+

--- a/tests/manual_tests/experiments/experiment_custom_keyboard.py
+++ b/tests/manual_tests/experiments/experiment_custom_keyboard.py
@@ -1,0 +1,148 @@
+ # -*- coding: utf-8 -*-
+
+'''
+########################################################
+IMPORTANT!!
+Run from easycut-smartbench folder, with 
+python -m tests.manual_tests.experiments.experiment_custom_keyboard
+'''
+
+import sys, os, subprocess
+sys.path.append('./src')
+os.chdir('./src')
+
+import kivy
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.uix.screenmanager import ScreenManager, Screen
+from kivy.core.window import Window
+
+from asmcnc.comms import localization
+from asmcnc.keyboard import custom_keyboard
+
+try: 
+    from mock import Mock
+
+except:
+    pass
+
+
+Builder.load_string("""
+<BasicScreen>:
+
+    t1:t1
+    t2:t2
+    t3:t3
+
+    on_touch_down: root.on_touch()
+
+    BoxLayout:
+        orientation: 'horizontal'
+        Button: 
+            text: "Test generic for loop alternative"
+            on_press: root.test_generic_for_loop_alternative()
+            text_size: self.size
+            valign: "top"
+            halign: "center"
+            padding: [0,20]
+
+        Button: 
+            text: 'Add keyboard'
+            on_press: root.add_keyboard_instance()
+            text_size: self.size
+            valign: "top"
+            halign: "center"
+            padding: [0,20]
+
+        Button:
+            text: "Does keyboard exist?"
+            on_press: root.does_keyboard_exist()
+            text_size: self.size
+            valign: "top"
+            halign: "center"
+            padding: [0,20]
+
+        Button: 
+            text: "Remove children"
+            on_press: root.remove_keyboard()
+            text_size: self.size
+            valign: "top"
+            halign: "center"
+            padding: [0,20]
+
+        Button: 
+            text: "Raise keyboard with mocks (this will break stuff)"
+            on_press: root.raise_keyboard_if_none_exists_with_mocks()
+            text_size: self.size
+            valign: "top"
+            halign: "center"
+            padding: [0,20]
+
+        BoxLayout: 
+            orientation: "vertical"
+
+            Label:
+                text: ""
+
+            TextInput:
+                id: t1
+                text: ""
+
+            TextInput:
+                id: t2
+                text: ""
+
+            TextInput:
+                id: t3
+                text: ""
+""")
+
+class BasicScreen(Screen):
+    def __init__(self, **kwargs):
+        super(BasicScreen, self).__init__(**kwargs)
+        self.l = localization.Localization()
+        self.text_inputs = [self.t1, self.t2, self.t3]
+        self.kb = custom_keyboard.Keyboard(self.text_inputs, localization=self.l)
+
+    def on_touch(self):
+        self.kb.defocus_all_text_inputs(self.text_inputs)
+
+    def test_generic_for_loop_alternative(self):
+
+        def func(x):
+            print(x)
+
+        list_of_items = list(range(0, 101))
+        self.kb.generic_for_loop_alternative(func, list_of_items)
+
+    def add_keyboard_instance(self):
+        self.kb.add_keyboard_instance()
+
+    def does_keyboard_exist(self):
+        print(self.kb.return_if_keyboard_exists(Window.children[0]))
+
+    def remove_keyboard(self):
+        self.kb.remove_children(Window.children[0])
+
+    def raise_keyboard_if_none_exists_with_mocks(self):
+
+        def add_keyboard(*args): print("raise keyboard")
+        self.kb.add_keyboard_instance = Mock(side_effect=add_keyboard)
+
+        self.kb.raise_keyboard_if_none_exists()
+
+        
+
+class TestApp(App):
+
+    def build(self):
+        # Create the screen manager
+        sm = ScreenManager()
+        sm.add_widget(BasicScreen(name='basic'))
+        sm.current = 'basic'
+        return sm
+
+if __name__ == '__main__':
+    TestApp().run()
+
+

--- a/tests/manual_tests/experiments/experiment_custom_keyboard.py
+++ b/tests/manual_tests/experiments/experiment_custom_keyboard.py
@@ -28,6 +28,15 @@ except:
 
 
 Builder.load_string("""
+
+<FormattedButton@Button>:
+
+    text_size: self.size
+    valign: "top"
+    halign: "center"
+    padding: [0,20]
+
+
 <BasicScreen>:
 
     t1:t1
@@ -38,45 +47,29 @@ Builder.load_string("""
 
     BoxLayout:
         orientation: 'horizontal'
-        Button: 
+        FormattedButton: 
             text: "Test generic for loop alternative"
             on_press: root.test_generic_for_loop_alternative()
-            text_size: self.size
-            valign: "top"
-            halign: "center"
-            padding: [0,20]
 
-        Button: 
+        FormattedButton: 
+            text: "Test generic for loop alternative with end func"
+            on_press: root.test_generic_for_loop_alternative_with_end_func()
+
+        FormattedButton: 
             text: 'Add keyboard'
             on_press: root.add_keyboard_instance()
-            text_size: self.size
-            valign: "top"
-            halign: "center"
-            padding: [0,20]
 
-        Button:
+        FormattedButton:
             text: "Does keyboard exist?"
             on_press: root.does_keyboard_exist()
-            text_size: self.size
-            valign: "top"
-            halign: "center"
-            padding: [0,20]
 
-        Button: 
+        FormattedButton: 
             text: "Remove children"
             on_press: root.remove_keyboard()
-            text_size: self.size
-            valign: "top"
-            halign: "center"
-            padding: [0,20]
 
-        Button: 
+        FormattedButton: 
             text: "Raise keyboard with mocks (this will break stuff)"
             on_press: root.raise_keyboard_if_none_exists_with_mocks()
-            text_size: self.size
-            valign: "top"
-            halign: "center"
-            padding: [0,20]
 
         BoxLayout: 
             orientation: "vertical"
@@ -98,6 +91,9 @@ Builder.load_string("""
 """)
 
 class BasicScreen(Screen):
+
+    list_of_items = list(range(0, 101))
+
     def __init__(self, **kwargs):
         super(BasicScreen, self).__init__(**kwargs)
         self.l = localization.Localization()
@@ -107,13 +103,17 @@ class BasicScreen(Screen):
     def on_touch(self):
         self.kb.defocus_all_text_inputs(self.text_inputs)
 
+    def func(self, x):
+        print(x)
+
+    def end_func(self):
+        print("YAY")
+
     def test_generic_for_loop_alternative(self):
+        self.kb.generic_for_loop_alternative(self.func, self.list_of_items)
 
-        def func(x):
-            print(x)
-
-        list_of_items = list(range(0, 101))
-        self.kb.generic_for_loop_alternative(func, list_of_items)
+    def test_generic_for_loop_alternative_with_end_func(self):
+        self.kb.generic_for_loop_alternative(self.func, self.list_of_items, end_func=self.end_func)
 
     def add_keyboard_instance(self):
         self.kb.add_keyboard_instance()


### PR DESCRIPTION
The generic_for_loop_alternative function will call the repeating function up to 10 times before the next frame of the application, and schedule the next 10 calls after the next frame. This is a bit more scalable than the loops, and guarantees that the UI won't lock on screens with a lot of text inputs. 

Also made a little manual test module for playing with the keyboard functions. 

Tested via test script, tested through EC on the computer, and tested on rig. 