### PR TITLE
Move exit cross up by 1 pixel

### DIFF
--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -254,7 +254,7 @@ Builder.load_string("""
                         on_press: root.back_to_home()
                         BoxLayout:
                             size: self.parent.size
-                            pos: self.parent.pos
+                            pos: self.parent.pos[0], self.parent.pos[1] + dp(1)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/exit_cross.png"
                                 center_x: self.parent.center_x

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -72,7 +72,7 @@ Builder.load_string("""
                         on_press: root.back_to_home()
                         BoxLayout:
                             size: self.parent.size
-                            pos: self.parent.pos
+                            pos: self.parent.pos[0], self.parent.pos[1] + dp(1)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/exit_cross.png"
                                 center_x: self.parent.center_x

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -35,7 +35,7 @@ Builder.load_string("""
                 on_press: root.back_to_home()
                 BoxLayout:
                     size: self.parent.size
-                    pos: self.parent.pos
+                    pos: self.parent.pos[0], self.parent.pos[1] + dp(1)
                     Image:
                         source: "./asmcnc/apps/shapeCutter_app/img/exit_cross.png"
                         center_x: self.parent.center_x


### PR DESCRIPTION
Moves the exit cross up by 1 pixel on job recovery screens, to hide the thin background line above it.

Tested on rig