### PR TITLE
Automatically set screen resolution

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ from kivy.clock import Clock
 Config.set('kivy', 'keyboard_mode', 'systemanddock')
 
 if sys.platform.startswith("linux"):
-    # get screen resolution as "1280x800"
+    # get screen resolution as "1280x800" or "800x480"
     resolution = os.popen(""" fbset | grep -oP 'mode "\K[^"]+' """).read().strip()
     width, height = resolution.split("x")
     Config.set('graphics', 'width', width)

--- a/src/main.py
+++ b/src/main.py
@@ -26,8 +26,17 @@ from os import path
 from kivy.config import Config
 from kivy.clock import Clock
 Config.set('kivy', 'keyboard_mode', 'systemanddock')
-Config.set('graphics', 'width', '800')
-Config.set('graphics', 'height', '480')
+
+if sys.platform.startswith("linux"):
+    # get screen resolution as "1280x800"
+    resolution = os.popen(""" fbset | grep -oP 'mode "\K[^"]+' """).read().strip()
+    width, height = resolution.split("x")
+    Config.set('graphics', 'width', width)
+    Config.set('graphics', 'height', height)
+else:
+    Config.set('graphics', 'width', '800')
+    Config.set('graphics', 'height', '480')
+
 Config.set('graphics', 'maxfps', '60')
 Config.set('kivy', 'KIVY_CLOCK', 'interrupt')
 Config.write()


### PR DESCRIPTION
Automatically detects the resolution of the screen on the raspberry pi's and defaults to 800x480 for all other operating systems.

Tested on laptop and console