### PR TITLE
Remove disable probe reminder popup from drywall app widget

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/widget_xy_move_drywall.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_xy_move_drywall.py
@@ -266,7 +266,3 @@ class XYMoveDrywall(Widget):
 
     def probe_z(self):
         self.m.probe_z()
-        self.disable_z_datum_reminder()
-
-    def disable_z_datum_reminder(self):
-        self.sm.get_screen('home').has_datum_been_reset = True


### PR DESCRIPTION
Otherwise you can probe in the app, exit it, and still have a the necessary reminder in the home app disabled (because what you've probed in the app probably won't match what you want to do in the home screen). 

Tested on rig