### PR TITLE
Display config name

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
@@ -222,9 +222,9 @@ class DrywallCutterScreen(Screen):
         """
         self.dwt_config.load_config(config)
 
-        file_name_no_ext = config.split('/')[-1].split('.')[0]
-
-        # set the label on the screen to the name of the config file below
+        # Show config name
+        file_name_no_ext = config.split('/')[-1].split('\\')[-1].split('.')[0]
+        self.drywall_shape_display_widget.config_name_label.text = file_name_no_ext
 
         toolpath_offset = self.dwt_config.active_config.toolpath_offset
         self.shape_selection.text = self.dwt_config.active_config.shape_type

--- a/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
@@ -16,6 +16,8 @@ Builder.load_string("""
     x_datum_label:x_datum_label
     y_datum_label:y_datum_label
 
+    config_name_label:config_name_label
+
     BoxLayout:
         size: self.parent.size
         pos: self.parent.pos
@@ -162,6 +164,18 @@ Builder.load_string("""
                 size_hint: (None, None)
                 text: 'Y:'
                 color: 0,0,0,1
+
+            # TextInput instead of Label, as there is no way to left align a Label in a FloatLayout
+            TextInput:
+                id: config_name_label
+                font_size: dp(20)
+                size: self.parent.width, dp(40)
+                size_hint: (None, None)
+                pos: self.parent.pos[0], self.parent.size[1] - self.height + dp(7)
+                multiline: False
+                background_color: (0,0,0,0)
+                disabled_foreground_color: (0,0,0,1)
+                disabled: True
 
 """)
 


### PR DESCRIPTION
Added a config name display label

Tested on windows

![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/6b0d8fb2-a6da-41eb-b2fb-a78b76e7ba61)
