### PR TITLE
Add grbl monitor to zh jig warranty screens

### DIFF
--- a/src/asmcnc/production/database/calibration_database.py
+++ b/src/asmcnc/production/database/calibration_database.py
@@ -68,7 +68,7 @@ class CalibrationDatabase(object):
             from asmcnc.production.database import credentials
 
         except ImportError:
-            if sys.platform != 'win32':
+            if sys.platform != 'win32' and sys.platform != 'darwin':
                 log("Can't import credentials (trying to get local folder creds)")
                 import credentials
 

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -395,6 +395,7 @@ class ZHeadMechanics(Screen):
 
 
     def go_to_monitor(self):
+        self.sm.get_screen('monitor').parent_screen = 'mechanics'
         self.sm.current = 'monitor'
 
     def go_to_manual_move(self):

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_booting.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_booting.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 
 from kivy.uix.screenmanager import Screen
@@ -32,9 +33,10 @@ class ZHeadMechanicsBooting(Screen):
 
     def next_screen(self, dt):
         try:
-            self.sm.get_screen('mechanics').z_axis_max_travel = -self.m.s.setting_132
-            self.sm.get_screen('mechanics').z_axis_max_speed = self.m.s.setting_112
-            self.m.send_command_to_motor("DISABLE MOTOR DRIVERS", motor=TMC_Z, command=SET_MOTOR_ENERGIZED, value=0)
+            if sys.platform != 'darwin' and sys.platform != 'win32':
+                self.sm.get_screen('mechanics').z_axis_max_travel = -self.m.s.setting_132
+                self.sm.get_screen('mechanics').z_axis_max_speed = self.m.s.setting_112
+                self.m.send_command_to_motor("DISABLE MOTOR DRIVERS", motor=TMC_Z, command=SET_MOTOR_ENERGIZED, value=0)
             self.sm.current = 'mechanics'
         except:
             Clock.schedule_once(self.next_screen, 1)

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_monitor.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_monitor.py
@@ -34,6 +34,9 @@ Builder.load_string("""
 
 
 class ZHeadMechanicsMonitor(Screen):
+
+    parent_screen = ''
+
     def __init__(self, **kwargs):
         super(ZHeadMechanicsMonitor, self).__init__(**kwargs)
 
@@ -44,4 +47,4 @@ class ZHeadMechanicsMonitor(Screen):
         self.gcode_monitor_container.add_widget(widget_gcode_monitor.GCodeMonitor(machine=self.m, screen_manager=self.sm, localization=self.l))
 
     def back(self):
-        self.sm.current = 'mechanics'
+        self.sm.current = self.parent_screen

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
@@ -12,7 +12,7 @@ try:
     import pigpio
 
 except:
-    pass
+    pass 
 
 import kivy
 from kivy.lang import Builder
@@ -110,13 +110,22 @@ Builder.load_string("""
                         background_color: [1,0,0,1]
                         background_normal: ''
         # Row 2
-                Button:
-                    text: '  2. Bake GRBL Settings'
-                    text_size: self.size
-                    markup: 'True'
-                    halign: 'left'
-                    valign: 'middle'
-                    on_press: root.bake_grbl_settings()
+                GridLayout:
+                    cols: 2
+                    Button:
+                        text: '  2. Bake GRBL Settings'
+                        text_size: self.size
+                        markup: 'True'
+                        halign: 'left'
+                        valign: 'middle'
+                        on_press: root.bake_grbl_settings()
+                    Button: 
+                        text: '  2a. GRBL Monitor'
+                        text_size: self.size
+                        markup: 'True'
+                        halign: 'left'
+                        valign: 'middle'
+                        on_press: root.open_monitor()
                 Button:
                     text: '  10. DISABLE ALARMS'
                     text_size: self.size
@@ -410,6 +419,10 @@ class ZHeadQCWarrantyAfterApr21(Screen):
             ]
 
         self.m.s.start_sequential_stream(grbl_settings, reset_grbl_after_stream=True)   # Send any grbl specific parameters
+
+    def open_monitor(self):
+        self.sm.get_screen('monitor').parent_screen = 'qcW136'
+        self.sm.current = "monitor"
 
     def home(self):
         self.m.is_machine_completed_the_initial_squaring_decision = True

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
@@ -96,13 +96,22 @@ Builder.load_string("""
                     background_color: [1,0,0,1]
                     background_normal: ''
         # Row 2
-                Button:
-                    text: '  2. Bake GRBL Settings'
-                    text_size: self.size
-                    markup: 'True'
-                    halign: 'left'
-                    valign: 'middle'
-                    on_press: root.bake_grbl_settings()
+                GridLayout:
+                    cols: 2
+                    Button:
+                        text: '  2. Bake GRBL Settings'
+                        text_size: self.size
+                        markup: 'True'
+                        halign: 'left'
+                        valign: 'middle'
+                        on_press: root.bake_grbl_settings()
+                    Button: 
+                        text: '  2a. GRBL Monitor'
+                        text_size: self.size
+                        markup: 'True'
+                        halign: 'left'
+                        valign: 'middle'
+                        on_press: root.open_monitor()
                 Button:
                     text: '  10. DISABLE ALARMS'
                     text_size: self.size
@@ -383,6 +392,10 @@ class ZHeadQCWarrantyBeforeApr21(Screen):
             ]
 
         self.m.s.start_sequential_stream(grbl_settings, reset_grbl_after_stream=True)   # Send any grbl specific parameters
+
+    def open_monitor(self):
+        self.sm.get_screen('monitor').parent_screen = 'qcW112'
+        self.sm.current = "monitor"
 
     def home(self):
         self.m.is_machine_completed_the_initial_squaring_decision = True

--- a/src/lb_calibration_app.py
+++ b/src/lb_calibration_app.py
@@ -31,6 +31,7 @@ from asmcnc.comms.router_machine import RouterMachine
 from settings.settings_manager import Settings
 from asmcnc.job.job_data import JobData
 from asmcnc.comms.localization import Localization
+from asmcnc.keyboard.custom_keyboard import Keyboard
 from asmcnc.comms import smartbench_flurry_database_connection
 
 from asmcnc.production.lowerbeam_calibration_jig.lowerbeam_calibration_1 import LBCalibration1
@@ -64,6 +65,8 @@ class LBCalibration(App):
 
         l = Localization()
 
+        kb = Keyboard(localization=l)
+
         jd = JobData(localization = l, settings_manager = sett)
 
         m = RouterMachine(Cmport, sm, sett, l, jd)
@@ -76,7 +79,7 @@ class LBCalibration(App):
         if m.s.is_connected():
             Clock.schedule_once(m.s.start_services, 1)
 
-        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l)
+        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l, keyboard = kb)
         sm.add_widget(home_screen)
 
         error_screen = screen_error.ErrorScreenClass(name='errorScreen', screen_manager = sm, machine = m, job = jd, database = db, localization = l)

--- a/src/lower_beam_qc_app.py
+++ b/src/lower_beam_qc_app.py
@@ -30,6 +30,7 @@ from asmcnc.apps.app_manager import AppManagerClass
 from settings.settings_manager import Settings
 from asmcnc.job.job_data import JobData
 from asmcnc.comms.localization import Localization
+from asmcnc.keyboard.custom_keyboard import Keyboard
 from kivy.clock import Clock
 from asmcnc.comms import smartbench_flurry_database_connection
 
@@ -58,6 +59,8 @@ class LowerBeamQCApp(App):
 
         l = Localization()
 
+        kb = Keyboard(localization=l)
+
         jd = JobData(localization = l, settings_manager = sett)
 
         m = RouterMachine(Cmport, sm, sett, l, jd)
@@ -67,7 +70,7 @@ class LowerBeamQCApp(App):
         if m.s.is_connected():
             Clock.schedule_once(m.s.start_services, 4)
 
-        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l)
+        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l, keyboard = kb)
         sm.add_widget(home_screen)
 
         error_screen = screen_error.ErrorScreenClass(name='errorScreen', screen_manager = sm, machine = m, job = jd, database = db, localization = l)

--- a/src/z_head_mechanics_app.py
+++ b/src/z_head_mechanics_app.py
@@ -6,6 +6,7 @@ from settings.settings_manager import Settings
 from asmcnc.job.job_data import JobData
 from asmcnc.comms.router_machine import RouterMachine
 from asmcnc.comms.localization import Localization
+from asmcnc.keyboard.custom_keyboard import Keyboard
 from asmcnc.comms import smartbench_flurry_database_connection
 
 from asmcnc.skavaUI.screen_home import HomeScreen
@@ -40,6 +41,8 @@ class ZHeadMechanicsApp(App):
 
         l = Localization()
 
+        kb = Keyboard(localization=l)
+
         jd = JobData(localization = l, settings_manager = sett)
 
         m = RouterMachine(Cmport, sm, sett, l, jd)
@@ -49,7 +52,7 @@ class ZHeadMechanicsApp(App):
         if m.s.is_connected():
             Clock.schedule_once(m.s.start_services, 4)
 
-        home_screen = HomeScreen(name = 'home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l)
+        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l, keyboard = kb)
         sm.add_widget(home_screen)
 
         squaring_decision_screen = SquaringScreenDecisionManualVsSquare(name = 'squaring_decision', screen_manager = sm, machine =m, localization = l)

--- a/src/z_head_qc_app.py
+++ b/src/z_head_qc_app.py
@@ -33,6 +33,7 @@ from asmcnc.apps.app_manager import AppManagerClass
 from settings.settings_manager import Settings
 from asmcnc.job.job_data import JobData
 from asmcnc.comms.localization import Localization
+from asmcnc.keyboard.custom_keyboard import Keyboard
 from asmcnc.comms import usb_storage
 from asmcnc.comms import smartbench_flurry_database_connection
 
@@ -63,6 +64,7 @@ from asmcnc.production.z_head_qc_jig.z_head_qc_db1 import ZHeadQCDB1
 from asmcnc.production.z_head_qc_jig.z_head_qc_db2 import ZHeadQCDB2
 from asmcnc.production.z_head_qc_jig.z_head_qc_db_success import ZHeadQCDBSuccess
 from asmcnc.production.z_head_qc_jig.z_head_qc_db_fail import ZHeadQCDBFail
+from asmcnc.production.z_head_mechanics_jig.z_head_mechanics_monitor import ZHeadMechanicsMonitor
 
 from asmcnc.production.database.calibration_database import CalibrationDatabase
 
@@ -85,6 +87,8 @@ class ZHeadQC(App):
 
         l = Localization()
 
+        kb = Keyboard(localization=l)
+
         jd = JobData(localization = l, settings_manager = sett)
 
         m = RouterMachine(Cmport, sm, sett, l, jd)
@@ -106,7 +110,7 @@ class ZHeadQC(App):
         door_screen = screen_door.DoorScreen(name = 'door', screen_manager = sm, machine =m, job = jd, database = db, localization = l)
         sm.add_widget(door_screen)
 
-        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l)
+        home_screen = HomeScreen(name='home', screen_manager = sm, machine = m, job = jd, settings = sett, localization = l, keyboard = kb)
         sm.add_widget(home_screen)
 
         squaring_decision_screen = SquaringScreenDecisionManualVsSquare(name = 'squaring_decision', screen_manager = sm, machine =m, localization = l)
@@ -177,6 +181,9 @@ class ZHeadQC(App):
 
         z_head_qc_db_fail = ZHeadQCDBFail(name='qcDB4', sm = sm, m = m)
         sm.add_widget(z_head_qc_db_fail)
+
+        z_head_mechanics_monitor = ZHeadMechanicsMonitor(name = 'monitor', sm = sm, m = m, l = l)
+        sm.add_widget(z_head_mechanics_monitor)
 
         sm.current = 'qcconnecting'
         return sm


### PR DESCRIPTION
(and ensure production jigs have access to keyboard - they weren't running otherwise)

Production needs a way to enter custom dollar settings for warranty & older model ZHs asap. 

Tested on Mac