### PR TITLE
Vlad/wifi spinner font size

### DIFF
--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -30,6 +30,7 @@ Builder.load_string(
     color: 0,0,0,1
     halign: 'left'
     markup: 'True'
+    font_size: str(0.01875*app.width) + 'sp'
 
 <WifiScreen>:
     
@@ -479,6 +480,7 @@ class WifiScreen(Screen):
         self.kb = kwargs["keyboard"]
         if sys.platform != "win32" and sys.platform != "darwin":
             self.network_name.values = self.get_available_networks()
+        self.network_name.values = ["Test"]
         self.update_strings()
         self.get_rst_source()
 

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -480,7 +480,6 @@ class WifiScreen(Screen):
         self.kb = kwargs["keyboard"]
         if sys.platform != "win32" and sys.platform != "darwin":
             self.network_name.values = self.get_available_networks()
-        self.network_name.values = ["Test"]
         self.update_strings()
         self.get_rst_source()
 

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -30,7 +30,7 @@ Builder.load_string(
     color: 0,0,0,1
     halign: 'left'
     markup: 'True'
-    font_size: str(0.01875*app.width) + 'sp'
+    font_size: sp(app.get_scaled_width(15))
 
 <WifiScreen>:
     


### PR DESCRIPTION
### Updated the spinner to scale the font size of the options. Tested on laptop and console 10

### Console 7 size:
![image](https://github.com/YetiTool/easycut-smartbench/assets/126763092/84d63d5c-293a-4d27-9e7c-00e224a75451)


### Console 10 size:
![image](https://github.com/YetiTool/easycut-smartbench/assets/126763092/02a36854-c4ef-449a-aac0-bf8e78998e84)
