### PR TITLE
Allowed health check image to stretch to scale on C10

### DIFF
--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -89,7 +89,7 @@ Builder.load_string(
             center_x: self.parent.center_x
             y: self.parent.y
             size: self.parent.width, self.parent.height
-            allow_stretch: False
+            allow_stretch: True
 
 
 


### PR DESCRIPTION
### Allowed health check image to stretch so it scales on C10. Tested on laptop

![image](https://github.com/YetiTool/easycut-smartbench/assets/126763092/c766d633-eb4a-4d37-9bdc-75ca48e86e1a)
