### PR TITLE
Archie/dwt rebrand/2451

### DIFF
--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -88,15 +88,15 @@ class Localization(object):
 
     # Getters/formatters
     def get_str(self, string):
-        return self._get(string)
+        return self.__get(string)
 
     def get_bold(self, string):
-        return "[b]{0}[/b]".format(self._get(string))
+        return "[b]{0}[/b]".format(self.__get(string))
 
     def get_italic(self, string):
-        return "[i]{0}[/i]".format(self._get(string))
+        return "[i]{0}[/i]".format(self.__get(string))
 
-    def _get(self, string):
+    def __get(self, string):
         string = self.dictionary.get(str(string), str(string))
 
         # If the original product name is in the string, replace it with the new product name (if it's different)

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
-import time
-import os, csv, re
+import csv
+import os
+import re
 from datetime import datetime
-from kivy.lang import Builder
-from kivy.core.text import LabelBase
 
+from kivy.core.text import LabelBase
+from kivy.lang import Builder
 
 kr_font_path = '/asmcnc/keyboard/fonts/KRFont.ttf'
 kr_font_bold_path = '/asmcnc/keyboard/fonts/KRFont-Bold.ttf'
 
-try: 
+try:
     LabelBase.register(name='KRFont',
                        fn_regular="." + kr_font_path,
                        fn_bold="." + kr_font_bold_path)
@@ -31,12 +32,13 @@ builder_font_string = """
     title_font: "%s"
 """
 
+
 def log(message):
     timestamp = datetime.now()
-    print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + str(message))
+    print (timestamp.strftime('%H:%M:%S.%f')[:12] + ' ' + str(message))
+
 
 class Localization(object):
-
     dictionary = {}
 
     gb = "English (GB)"
@@ -50,18 +52,17 @@ class Localization(object):
     nl = "Nederlands (NL)"
 
     approved_languages = [
-                            gb,
-                            it, 
-                            fi, 
-                            de,
-                            fr,
-                            pl,
-                            dk,
-                            ko
-                        ]
+        gb,
+        it,
+        fi,
+        de,
+        fr,
+        pl,
+        dk,
+        ko
+    ]
 
     supported_languages = approved_languages + [nl]
-
 
     # use this for just getting user language, and if it's empty just assume english
     persistent_language_path = './sb_values/user_language.txt'
@@ -75,13 +76,12 @@ class Localization(object):
     korean_font = 'KRFont'
     korean_font_bold = 'KRFont-Bold'
 
-    kivy_markup_regex = re.compile('\[.*?\]')
+    kivy_markup_regex = re.compile(r"\[.*?\]")
 
     ORIGINAL_PRODUCT_NAME = "SmartBench"
     PRODUCT_NAME = "Smart CNC"
 
     def __init__(self):
-
         if os.path.exists(self.persistent_language_path):
             self.read_in_language_name()
 
@@ -100,27 +100,24 @@ class Localization(object):
     def _get(self, string):
         string = self.dictionary.get(str(string), str(string))
 
+        # If the original product name is in the string, replace it with the new product name (if it's different)
         if self.ORIGINAL_PRODUCT_NAME in string and self.ORIGINAL_PRODUCT_NAME != self.PRODUCT_NAME:
             string = string.replace(self.ORIGINAL_PRODUCT_NAME, self.PRODUCT_NAME)
         return string
 
     def get_localized_days(self, string):
-
         if "days" in string:
             return string.replace("days", self.get_str("days"))
-
         elif "day" in string:
             return string.replace("day", self.get_str("day"))
 
-        else: 
-            return string
-    
+        return string
+
     # Removes kivy markup tags to leave only text before returning length, and decode to correctly count Korean characters
     def get_text_length(self, string):
         if self.lang == self.ko:
             string = string.decode('utf-8')
         return len(re.sub(self.kivy_markup_regex, '', string))
-
 
     ## DEBUGGING (forces KeyErrors)
     # def get_str(self, string):
@@ -135,13 +132,13 @@ class Localization(object):
     # LANGUAGE NAME
     # Read in name of language, so it can be used as a key when accessing the complete language dictionary
     def read_in_language_name(self):
-        try: 
+        try:
             file = open(self.persistent_language_path, 'r')
-            self.lang  = str(file.read())
+            self.lang = str(file.read())
             file.close()
             log("Read in language name: using " + self.lang)
 
-        except: 
+        except:
             self.lang = self.default_lang
             log("Could not read in language name, using English (GB) as default")
 
@@ -151,7 +148,6 @@ class Localization(object):
         else:
             log("Could not find " + self.lang + " in list of supported_languages, using English (GB) as default")
             self.lang = self.default_lang
-            
 
     # Save language name
     def save_language_name(self):
@@ -164,8 +160,7 @@ class Localization(object):
         except:
             log("Could not save language name, using English (GB) as default")
 
-
-    ## DICTIONARY
+    # DICTIONARY
     def load_from_dictionary(self):
         try:
             with open(self.complete_foreign_dictionary_path, "r") as csv_file:
@@ -178,7 +173,7 @@ class Localization(object):
             if self.lang == self.ko:
                 self.font_regular = self.korean_font
                 self.font_bold = self.korean_font_bold
-            
+
                 # Only do this load for Korean, as it prevents some spinner weirdness
                 Builder.load_string(builder_font_string % (self.font_regular, self.font_bold))
 
@@ -191,16 +186,14 @@ class Localization(object):
         except:
             log("Could not load in from full dictionary")
 
-
-    ## LOAD IN NEW LANGUAGE
+    # LOAD IN NEW LANGUAGE
     def load_in_new_language(self, language):
         # When choosing a language, read in from full dictionary
         self.lang = language
         self.load_from_dictionary()
         self.save_language_name()
 
-    
-    ## LOAD SUPPORTED LANGUAGES
+    # LOAD SUPPORTED LANGUAGES
     # def load_supported_languages(self):
     #     try: 
     #         with open(self.complete_foreign_dictionary_path, "r") as csv_file:
@@ -211,17 +204,16 @@ class Localization(object):
     #     except:
     #         log("Could not load list of supported_languages from dictionary")
 
+    # FAST DICTIONARY
 
-    ## FAST DICTIONARY
+    # fast_dictionary_path = './sb_values/fast_dictionary.csv'
 
-        # fast_dictionary_path = './sb_values/fast_dictionary.csv'
+    # if os.path.exists(self.fast_dictionary_path):
+    #     # self.load_language() # only use this when not adding new keys!
+    #     self.load_in_new_language(self.lang)
 
-        # if os.path.exists(self.fast_dictionary_path):
-        #     # self.load_language() # only use this when not adding new keys!
-        #     self.load_in_new_language(self.lang)
-
-        # else:
-        #     self.load_in_new_language(self.lang)
+    # else:
+    #     self.load_in_new_language(self.lang)
 
     # def load_language(self):
     #     try: 
@@ -247,4 +239,3 @@ class Localization(object):
 
     #     except:
     #         log("Could not save fast dictionary")
-

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -9,24 +9,18 @@ from kivy.lang import Builder
 
 from asmcnc.comms import model_detector
 
-kr_font_path = '/asmcnc/keyboard/fonts/KRFont.ttf'
-kr_font_bold_path = '/asmcnc/keyboard/fonts/KRFont-Bold.ttf'
+asmcnc_path = os.path.dirname(os.path.dirname(__file__))
+fonts_path = os.path.join(asmcnc_path, "keyboard", "fonts")
+kr_font_path = os.path.join(fonts_path, 'KRFont.ttf')
+kr_font_bold_path = os.path.join(fonts_path, 'KRFont-Bold.ttf')
 
-try:
-    LabelBase.register(name='KRFont',
-                       fn_regular="." + kr_font_path,
-                       fn_bold="." + kr_font_bold_path)
+LabelBase.register(name='KRFont',
+                   fn_regular=kr_font_path,
+                   fn_bold=kr_font_bold_path)
 
-    LabelBase.register(name='KRFont-Bold',
-                       fn_regular="." + kr_font_bold_path)
+LabelBase.register(name='KRFont-Bold',
+                   fn_regular=kr_font_bold_path)
 
-except:
-    LabelBase.register(name='KRFont',
-                       fn_regular="./src" + kr_font_path,
-                       fn_bold="./src" + kr_font_bold_path)
-
-    LabelBase.register(name='KRFont-Bold',
-                       fn_regular="./src" + kr_font_bold_path)
 
 builder_font_string = """
 <Widget>:
@@ -68,7 +62,7 @@ class Localization(object):
 
     # use this for just getting user language, and if it's empty just assume english
     persistent_language_path = './sb_values/user_language.txt'
-    complete_foreign_dictionary_path = './asmcnc/comms/foreign_dictionary.txt'
+    complete_foreign_dictionary_path = os.path.join(asmcnc_path, "comms", "foreign_dictionary.txt")
 
     default_lang = 'English (GB)'
     lang = default_lang

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -90,7 +90,7 @@ class Localization(object):
         self.load_from_dictionary()
 
         if model_detector.is_machine_drywall():
-            self.PRODUCT_NAME = "Smart CNC"
+            self.PRODUCT_NAME = "SmartCNC"
 
     # Getters/formatters
     def get_str(self, string):

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from kivy.core.text import LabelBase
 from kivy.lang import Builder
 
+from asmcnc.comms import model_detector
+
 kr_font_path = '/asmcnc/keyboard/fonts/KRFont.ttf'
 kr_font_bold_path = '/asmcnc/keyboard/fonts/KRFont-Bold.ttf'
 
@@ -79,13 +81,16 @@ class Localization(object):
     kivy_markup_regex = re.compile(r"\[.*?\]")
 
     ORIGINAL_PRODUCT_NAME = "SmartBench"
-    PRODUCT_NAME = "Smart CNC"
+    PRODUCT_NAME = "SmartBench"
 
     def __init__(self):
         if os.path.exists(self.persistent_language_path):
             self.read_in_language_name()
 
         self.load_from_dictionary()
+
+        if model_detector.is_machine_drywall():
+            self.PRODUCT_NAME = "Smart CNC"
 
     # Getters/formatters
     def get_str(self, string):

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -77,6 +77,9 @@ class Localization(object):
 
     kivy_markup_regex = re.compile('\[.*?\]')
 
+    ORIGINAL_PRODUCT_NAME = "SmartBench"
+    PRODUCT_NAME = "Smart CNC"
+
     def __init__(self):
 
         if os.path.exists(self.persistent_language_path):
@@ -86,13 +89,20 @@ class Localization(object):
 
     # Getters/formatters
     def get_str(self, string):
-        return str(self.dictionary.get(str(string), str(string)))
+        return self._get(string)
 
     def get_bold(self, string):
-        return ('[b]' + str(self.dictionary.get(str(string), str(string))) + '[/b]')
+        return "[b]{0}[/b]".format(self._get(string))
 
     def get_italic(self, string):
-        return ('[i]' + str(self.dictionary.get(str(string), str(string))) + '[/i]')
+        return "[i]{0}[/i]".format(self._get(string))
+
+    def _get(self, string):
+        string = self.dictionary.get(str(string), str(string))
+
+        if self.ORIGINAL_PRODUCT_NAME in string and self.ORIGINAL_PRODUCT_NAME != self.PRODUCT_NAME:
+            string = string.replace(self.ORIGINAL_PRODUCT_NAME, self.PRODUCT_NAME)
+        return string
 
     def get_localized_days(self, string):
 

--- a/src/asmcnc/comms/model_detector.py
+++ b/src/asmcnc/comms/model_detector.py
@@ -1,0 +1,13 @@
+import os
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.getcwd()))
+DWT_FILE_PATH = os.path.join(ROOT_DIR, "dwt.txt")
+
+
+def is_machine_drywall():
+    # () -> bool
+    """
+    Checks for the existence of the dwt.txt file.
+    :return: True if the file exists, False otherwise.
+    """
+    return os.path.exists(DWT_FILE_PATH)

--- a/tests/automated_unit_tests/comms/test_localization_product_name.py
+++ b/tests/automated_unit_tests/comms/test_localization_product_name.py
@@ -1,0 +1,31 @@
+from asmcnc.comms import model_detector
+from automated_unit_tests.unit_test_base import UnitTestBase
+
+
+class TestLocalizationProductName(UnitTestBase):
+    def setUp(self):
+        super(TestLocalizationProductName, self).setUp()
+
+    def test_get_str(self):
+        # Patch model_detector.is_machine_drywall to return False
+        model_detector.is_machine_drywall = lambda: False
+
+        # Create the localization module
+        self._localization_module = self._create_localization_module()
+
+        # Set the dictionary to a single entry, "SmartBench": "SmartBench"
+        self._localization_module.dictionary = {
+            "SmartBench": "SmartBench",
+        }
+
+        # Test that the get_str method returns the value from the dictionary
+        self.assertEqual(self._localization_module.get_str("SmartBench"), "SmartBench")
+
+        # Patch model_detector.is_machine_drywall to return True
+        model_detector.is_machine_drywall = lambda: True
+
+        # Recreate the localization module (to update the PRODUCT_NAME)
+        self._localization_module = self._create_localization_module()
+
+        # Test that the get_str method returns the value from the dictionary, with the PRODUCT_NAME replaced
+        self.assertEqual(self._localization_module.get_str("SmartBench"), "SmartCNC")


### PR DESCRIPTION
# Change instances of "SmartBench" to "Smart CNC" on DWT machines

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-2451)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [x] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
I've updated the localisation module to replace any instance of "SmartBench" to "SmartCNC".

## Notes

## Dependencies for merge
None

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [x] Completed

## Screenshots (if applicable)