### PR TITLE
Archie/scaling/fix scaling utils

### DIFF
--- a/src/asmcnc/core_UI/scaling_utils.py
+++ b/src/asmcnc/core_UI/scaling_utils.py
@@ -1,7 +1,7 @@
 from kivy.core.window import Window
 
 Width = Window.width if Window.width in [1280, 800] else 800
-Height = Window.height - 32 if Window.height == 800 else Window.height if Window.height in [768, 480] else 480
+Height = Window.height - 32 if Window.height == 800 else 480
 
 
 def is_screen_big():

--- a/src/asmcnc/core_UI/scaling_utils.py
+++ b/src/asmcnc/core_UI/scaling_utils.py
@@ -1,7 +1,9 @@
 from kivy.core.window import Window
 
 Width = Window.width if Window.width in [1280, 800] else 800
-Height = Window.height if Window.height in [768, 480] else 480
+Height = Window.height - 32 if Window.height == 800 else Window.height if Window.height in [768, 480] else 480
+
+print("Height: ", Height)
 
 
 def is_screen_big():

--- a/src/asmcnc/core_UI/scaling_utils.py
+++ b/src/asmcnc/core_UI/scaling_utils.py
@@ -3,8 +3,6 @@ from kivy.core.window import Window
 Width = Window.width if Window.width in [1280, 800] else 800
 Height = Window.height - 32 if Window.height == 800 else Window.height if Window.height in [768, 480] else 480
 
-print("Height: ", Height)
-
 
 def is_screen_big():
     """


### PR DESCRIPTION
# Fix scaling utils module

- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [ ] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
@VladPavelescu found an issue with the scaling_utils module, as Window.height isn't (768,480), as it's actually 800. This just subtracts 32 if 800, otherwise returns 480. This enforces the scaling of screens on macOS where setting Window.size doesn't behave nicely.

## Notes

## Dependencies for merge
None

## Testing

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [x] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)