### PR TITLE
Add labels to canvas text inputs

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
@@ -65,6 +65,15 @@ Builder.load_string("""
                     pos: self.parent.pos
                     background_color: (0,0,0,0)
 
+            Label:
+                text: 'D'
+                font_size: dp(25)
+                pos: d_input.pos[0] - self.width, d_input.pos[1] + dp(3)
+                opacity: d_input.opacity
+                color: 0,0,0,1
+                size: self.texture_size
+                size_hint: (None, None)
+
             BoxLayout:
                 size: dp(70), dp(40)
                 size_hint: (None, None)
@@ -85,6 +94,15 @@ Builder.load_string("""
                     size: self.parent.size
                     pos: self.parent.pos
                     background_color: (0,0,0,0)
+
+            Label:
+                text: 'L'
+                font_size: dp(25)
+                pos: l_input.pos[0] - self.width, l_input.pos[1] + dp(3)
+                opacity: l_input.opacity
+                color: 0,0,0,1
+                size: self.texture_size
+                size_hint: (None, None)
 
             BoxLayout:
                 size: dp(70), dp(40)
@@ -107,6 +125,15 @@ Builder.load_string("""
                     pos: self.parent.pos
                     background_color: (0,0,0,0)
 
+            Label:
+                text: 'R'
+                font_size: dp(25)
+                pos: r_input.pos[0] - self.width, r_input.pos[1] + dp(3)
+                opacity: r_input.opacity
+                color: 0,0,0,1
+                size: self.texture_size
+                size_hint: (None, None)
+
             BoxLayout:
                 size: dp(70), dp(40)
                 size_hint: (None, None)
@@ -128,6 +155,15 @@ Builder.load_string("""
                     pos: self.parent.pos
                     background_color: (0,0,0,0)
 
+            Label:
+                text: 'X'
+                font_size: dp(25)
+                pos: x_input.pos[0] - self.width, x_input.pos[1] + dp(3)
+                opacity: x_input.opacity
+                color: 0,0,0,1
+                size: self.texture_size
+                size_hint: (None, None)
+
             BoxLayout:
                 size: dp(70), dp(40)
                 size_hint: (None, None)
@@ -148,6 +184,15 @@ Builder.load_string("""
                     size: self.parent.size
                     pos: self.parent.pos
                     background_color: (0,0,0,0)
+
+            Label:
+                text: 'Y'
+                font_size: dp(25)
+                pos: y_input.pos[0] - self.width, y_input.pos[1] + dp(3)
+                opacity: y_input.opacity
+                color: 0,0,0,1
+                size: self.texture_size
+                size_hint: (None, None)
 
             Label:
                 id: x_datum_label


### PR DESCRIPTION
# Drywall canvas input labels

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-2657)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

Added labels next to text inputs on canvas widget

![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/8dd29f30-c81e-4b42-9cc3-f2e7c158d1d4)

## Notes

## Dependencies for merge
- [ ] [#<pull_request_number>]

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [x] Not applicable
- [ ] Completed

## Screenshots (if applicable)