### PR TITLE
archie/minirig_fix

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -199,7 +199,7 @@ class SerialConnection(EventDispatcher):
 
             filesForDevice = listdir('/dev/')  # put all device files into list[]
             for line in filesForDevice:
-                if line.startswith('tty.usbmodem'):  # look for...
+                if line.startswith('tty.usbmodem') or line.startswith('tty.usbserial'):  # look for...
 
                     print("Mac port to try: ")  # for debugging
                     print(line)


### PR DESCRIPTION
# Add ports to check on macOS to find MiniRig

- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [ ] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
My mini rig was on port tty.usbserial210, but the serial connection was only checked tty.usbmodem*.

## Notes

## Dependencies for merge
## Testing

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)