### PR TITLE
Marc/detect model 50

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
@@ -19,6 +19,8 @@ from asmcnc.apps.start_up_sequence.data_consent_app import screen_manager_data_c
 from asmcnc.apps.systemTools_app.screens.popup_system import PopupSSHToggleFailed
 from asmcnc.core_UI import scaling_utils as utils
 
+from src.asmcnc.comms.model_manager import ModelManagerSingleton
+
 Builder.load_string(
     """
 
@@ -689,7 +691,7 @@ class BuildInfoScreen(Screen):
                 "CNC Router", ""
             )
         else:
-            self.smartbench_model.text = "SmartBench CNC Router"
+            self.smartbench_model.text = ModelManagerSingleton().product_code.name
 
     def choose_language(self):
         chosen_lang = self.language_button.text

--- a/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
@@ -618,7 +618,7 @@ class BuildInfoScreen(Screen):
         self.latest_sw_version = self.set.latest_sw_version
         self.latest_platform_version = self.set.latest_platform_version
         self.hw_version_label.text = self.m.s.hw_version
-        self.zh_version_label.text = str(self.m.z_head_version())
+        self.zh_version_label.text = str(self.m.get_product_code().value)
         try:
             self.machine_serial_number_label.text = (
                 "YS6" + str(self.m.serial_number())[0:4]

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -31,6 +31,9 @@ from asmcnc.apps.systemTools_app.screens.calibration import screen_set_threshold
 from asmcnc.apps.systemTools_app.screens.calibration import screen_general_measurement
 from asmcnc.production.database.calibration_database import CalibrationDatabase
 
+from src.asmcnc.comms import model_manager
+from src.asmcnc.comms.router_machine import ProductCodes
+
 Builder.load_string(
     """
 
@@ -577,6 +580,9 @@ class FactorySettingsScreen(Screen):
     latest_machine_model_values = [
         "SmartBench V1.3 PrecisionPro CNC Router",
         "SmartBench Mini V1.3 PrecisionPro",
+        "SmartBench Mini V1.3 PrecisionPro Plus",
+        "SmartBench Mini V1.3 PrecisionPro X",
+        "DRYWALLTEC SmartCNC",
     ]
     old_machine_model_values = [
         "SmartBench V1.0 CNC Router",
@@ -740,12 +746,8 @@ class FactorySettingsScreen(Screen):
             )
             popup_info.PopupWarning(self.systemtools_sm.sm, self.l, warning_message)
             return False
-        elif not (
-            str(self.product_number_input.text) == "01"
-            or str(self.product_number_input.text) == "02"
-            or str(self.product_number_input.text) == "03"
-        ):
-            warning_message = "Product code should 01, 02, or 03."
+        elif int(self.product_number_input.text) not in [pc.value for pc in ProductCodes]:
+            warning_message = "Product code should be 01 to 06."
             popup_info.PopupWarning(self.systemtools_sm.sm, self.l, warning_message)
             return False
         elif len(str(self.serial_prefix.text)) != 3:
@@ -779,6 +781,8 @@ class FactorySettingsScreen(Screen):
                 + "."
                 + str(self.product_number_input.text)
             )
+            # Do specific tasks for setting up the machine model (e.g. splash screen)
+            model_manager.set_machine_type(ProductCodes(int(self.product_number_input.text)))
             self.m.write_dollar_setting(50, full_serial_number)
             self.machine_serial.text = "updating..."
 
@@ -992,7 +996,15 @@ ALLOW THE CONSOLE TO SHUTDOWN COMPLETELY, AND WAIT 30 SECONDS BEFORE SWITCHING O
             or self.smartbench_model.text == "SmartBench V1.2 Precision CNC Router"
         ):
             self.product_number_input.text = "02"
+        elif "DRYWALLTEC SmartCNC" in self.smartbench_model.text:
+            self.product_number_input.text = "06"
+        elif "PrecisionPro X" in self.smartbench_model.text:
+            self.product_number_input.text = "05"
+        elif "PrecisionPro Plus" in self.smartbench_model.text:
+            self.product_number_input.text = "04"
         elif "PrecisionPro" in self.smartbench_model.text:
+            self.product_number_input.text = "03"
+        elif "Precision/Standard" in self.smartbench_model.text:
             self.product_number_input.text = "03"
         else:
             self.product_number_input.text = "01"

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -31,7 +31,7 @@ from asmcnc.apps.systemTools_app.screens.calibration import screen_set_threshold
 from asmcnc.apps.systemTools_app.screens.calibration import screen_general_measurement
 from asmcnc.production.database.calibration_database import CalibrationDatabase
 
-from src.asmcnc.comms import model_manager
+from src.asmcnc.comms.model_manager import ModelManagerSingleton
 from src.asmcnc.comms.router_machine import ProductCodes
 
 Builder.load_string(
@@ -604,6 +604,7 @@ class FactorySettingsScreen(Screen):
         self.l = kwargs["localization"]
         self.kb = kwargs["keyboard"]
         self.usb_stick = kwargs["usb_stick"]
+        self.model_manager = ModelManagerSingleton()
         self.software_version_label.text = self.set.sw_version
         self.platform_version_label.text = self.set.platform_version
         self.latest_software_version.text = self.set.latest_sw_version
@@ -782,7 +783,7 @@ class FactorySettingsScreen(Screen):
                 + str(self.product_number_input.text)
             )
             # Do specific tasks for setting up the machine model (e.g. splash screen)
-            model_manager.set_machine_type(ProductCodes(int(self.product_number_input.text)))
+            self.model_manager.set_machine_type(ProductCodes(int(self.product_number_input.text)), True)
             self.m.write_dollar_setting(50, full_serial_number)
             self.machine_serial.text = "updating..."
 

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -82,8 +82,8 @@ class Localization(object):
             self.read_in_language_name()
 
         self.load_from_dictionary()
-
-        if ModelManagerSingleton().is_machine_drywall():
+        self.model_manager = ModelManagerSingleton()
+        if self.model_manager.is_machine_drywall():
             self.PRODUCT_NAME = "SmartCNC"
 
     # Getters/formatters

--- a/src/asmcnc/comms/localization.py
+++ b/src/asmcnc/comms/localization.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from kivy.core.text import LabelBase
 from kivy.lang import Builder
 
-from asmcnc.comms import model_manager
+from src.asmcnc.comms.model_manager import ModelManagerSingleton
 
 asmcnc_path = os.path.dirname(os.path.dirname(__file__))
 fonts_path = os.path.join(asmcnc_path, "keyboard", "fonts")
@@ -83,7 +83,7 @@ class Localization(object):
 
         self.load_from_dictionary()
 
-        if model_manager.is_machine_drywall():
+        if ModelManagerSingleton().is_machine_drywall():
             self.PRODUCT_NAME = "SmartCNC"
 
     # Getters/formatters

--- a/src/asmcnc/comms/model_manager.py
+++ b/src/asmcnc/comms/model_manager.py
@@ -12,6 +12,7 @@ from src.asmcnc.comms.router_machine import ProductCodes
 class ModelManagerSingleton(EventDispatcher):
     _instance = None
     _initialized = False
+    product_code = ProductCodes.UNKNOWN
     _lock = threading.Lock()
 
     # File paths:
@@ -43,7 +44,6 @@ class ModelManagerSingleton(EventDispatcher):
             return
         self._initialized = True
         # Do init here:
-        self.product_code = ProductCodes.UNKNOWN
         self.set_machine_type(self.load_saved_product_code())
 
     def on_setting_50(self, instance, value):

--- a/src/asmcnc/comms/model_manager.py
+++ b/src/asmcnc/comms/model_manager.py
@@ -1,5 +1,7 @@
 import os
 
+from src.asmcnc.comms.router_machine import ProductCodes
+
 ROOT_DIR = os.path.dirname(os.path.dirname(os.getcwd()))
 DWT_FILE_PATH = os.path.join(ROOT_DIR, "dwt.txt")
 
@@ -19,26 +21,29 @@ def is_machine_drywall():
     return os.path.exists(DWT_FILE_PATH)
 
 
-def set_machine_drywall(is_drywall):
+def set_machine_type(pc):
+    # type: (ProductCodes) ->  None
     # (bool) -> None
     """
     Creates the dwt.txt file.
     """
-    if is_drywall:
+    if pc is ProductCodes.DRYWALLTEC:
         if not os.path.exists(DWT_FILE_PATH):
             open(DWT_FILE_PATH, "w").close()
     else:
         if os.path.exists(DWT_FILE_PATH):
             os.remove(DWT_FILE_PATH)
 
-    __set_splash_screen()
+    __set_splash_screen(pc)
 
 
-def __set_splash_screen():
-    # () -> None
+def __set_splash_screen(pc):
+    # type: (ProductCodes) ->  None
     """
     Sets the plymouth splash screen to the appropriate one.
     """
-    new_splash = DWT_SPLASH_PATH if is_machine_drywall() else YETI_SPLASH_PATH
-    os.system("sudo cp {} {}".format(new_splash, PLYMOUTH_SPLASH_FILE_PATH))
+    if pc is ProductCodes.DRYWALLTEC:
+        os.system("sudo cp {} {}".format(DWT_SPLASH_PATH, PLYMOUTH_SPLASH_FILE_PATH))
+    else:
+        os.system("sudo cp {} {}".format(YETI_SPLASH_PATH, PLYMOUTH_SPLASH_FILE_PATH))
 

--- a/src/asmcnc/comms/model_manager.py
+++ b/src/asmcnc/comms/model_manager.py
@@ -69,20 +69,14 @@ class ModelManagerSingleton(EventDispatcher):
         # type: (ProductCodes, bool) ->  None
         # (bool) -> None
         """
-        Creates the dwt.txt file.
+        Sets the console to a specific product code. See ProductCodes for more info.
+        Takes care of additional needed changes like splash screen.
         """
         if self.product_code == pc:
             return
         self.product_code = pc
         if save:
             self.save_product_code(pc)
-
-        if pc is ProductCodes.DRYWALLTEC:
-            if not os.path.exists(self.DWT_FILE_PATH):
-                open(self.DWT_FILE_PATH, "w").close()
-        else:
-            if os.path.exists(self.DWT_FILE_PATH):
-                os.remove(self.DWT_FILE_PATH)
 
         self.__set_splash_screen(pc)
 

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -3,6 +3,7 @@ Created on 31 Jan 2018
 @author: Ed
 This module defines the machine's properties (e.g. travel), services (e.g. serial comms) and functions (e.g. move left)
 '''
+from enum import Enum
 
 import logging, threading, re, traceback
 
@@ -31,8 +32,19 @@ def log(message):
     print (timestamp.strftime('%H:%M:%S.%f' )[:12] + ' ' + str(message))
 
 
+class ProductCodes(Enum):
+    DRYWALLTEC = 06
+    PRECISION_PRO_X = 05
+    PRECISION_PRO_PLUS = 04
+    PRECISION_PRO = 03
+    STANDARD = 02
+    FIRST_VERSION = 01
+    UNKNOWN = 00
+
+
 class RouterMachine(object):
 
+    DEBUG_PRODUCT_CODE = ProductCodes.PRECISION_PRO_PLUS
 # SETUP
     
     s = None # serial object
@@ -1603,10 +1615,19 @@ class RouterMachine(object):
         except: return 0
         else: return self.s.setting_50
 
-    def z_head_version(self):
-        try: self.s.setting_50
-        except: return 0
-        else: return str(self.s.setting_50)[-2] + str(self.s.setting_50)[-1]
+    def get_product_code(self):
+        """takes the last two digits of $50 and converts them to a ProductCode."""
+        try:
+            return self.DEBUG_PRODUCT_CODE
+        except:
+            pass
+        try:
+            self.s.setting_50
+        except:
+            return ProductCodes.UNKNOWN
+        else:
+            pc = str(self.s.setting_50)[-2] + str(self.s.setting_50)[-1]
+            return ProductCodes(int(pc))
 
     def firmware_version(self):
         try: self.s.fw_version
@@ -1616,29 +1637,33 @@ class RouterMachine(object):
     dwt_path =  "../../dwt.txt"
 
     def bench_is_dwt(self):
-        return path.isfile(self.dwt_path)
+        return self.get_product_code() is ProductCodes.DRYWALLTEC
 
-    def smartbench_model(self):  # recommend refactoring models into an enum, relying on strings is error-prone
-        if self.bench_is_dwt():
+    def smartbench_model(self):
+        # recommend refactoring models into an enum, relying on strings is error-prone
+        pc = self.get_product_code()
+        if pc is ProductCodes.DRYWALLTEC:
             return "DRYWALLTEC SmartCNC"
-        elif self.bench_is_short():
-            return "SmartBench Mini V1.3 PrecisionPro"
-        elif self.is_machines_fw_version_equal_to_or_greater_than_version('2.2.8', 'Smartbench model'):
-            return "SmartBench V1.3 PrecisionPro CNC Router"
-        elif self.is_machines_fw_version_equal_to_or_greater_than_version('1.4.0', 'Smartbench model'):
-            return "SmartBench V1.2 PrecisionPro CNC Router"
-        else:
-            zh_ver = self.z_head_version()
-
-            if zh_ver == "03":
+        elif pc == ProductCodes.PRECISION_PRO_X:
+            return "SmartBench V1.3 PrecisionPro X"
+        elif pc is ProductCodes.PRECISION_PRO_PLUS:
+            return "SmartBench V1.3 PrecisionPro Plus"
+        elif pc is ProductCodes.PRECISION_PRO:
+            if self.bench_is_short():
+                return "SmartBench Mini V1.3 PrecisionPro"
+            elif self.is_machines_fw_version_equal_to_or_greater_than_version('2.2.8', 'Smartbench model'):
+                return "SmartBench V1.3 PrecisionPro CNC Router"
+            elif self.is_machines_fw_version_equal_to_or_greater_than_version('1.4.0', 'Smartbench model'):
+                return "SmartBench V1.2 PrecisionPro CNC Router"
+            else:
                 return "SmartBench V1.2 Precision CNC Router"
-            elif zh_ver == "02":
-                return "SmartBench V1.2 Standard CNC Router"
-            elif zh_ver == "01":
-                if self.is_machines_hw_version_equal_to_or_greater_than_version(5, 'Smartbench model'):
-                    return "SmartBench V1.1 CNC Router"
-                else:
-                    return "SmartBench V1.0 CNC Router"
+        elif pc is ProductCodes.STANDARD:
+            return "SmartBench V1.2 Standard CNC Router"
+        elif pc is ProductCodes.FIRST_VERSION:
+            if self.is_machines_hw_version_equal_to_or_greater_than_version(5, 'Smartbench model'):
+                return "SmartBench V1.1 CNC Router"
+            else:
+                return "SmartBench V1.0 CNC Router"
 
         log("SmartBench model detection failed")
         return "SmartBench model detection failed"

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1609,18 +1609,11 @@ class RouterMachine(object):
 
 # SETTINGS GETTERS
     def serial_number(self): 
-        try:
-            self.s.setting_50
-        except:
-            return 0
-        else:
-            return self.s.setting_50
+        return self.s.setting_50
 
     def get_product_code(self):
         """takes the last two digits of $50 and converts them to a ProductCode."""
-        try:
-            self.s.setting_50
-        except:
+        if self.s.setting_50 == 0.0:
             return ProductCodes.UNKNOWN
         else:
             pc = str(self.s.setting_50)[-2] + str(self.s.setting_50)[-1]

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -43,9 +43,7 @@ class ProductCodes(Enum):
 
 
 class RouterMachine(object):
-
-    DEBUG_PRODUCT_CODE = ProductCodes.PRECISION_PRO_PLUS
-# SETUP
+    # SETUP
     
     s = None # serial object
 
@@ -1611,16 +1609,15 @@ class RouterMachine(object):
 
 # SETTINGS GETTERS
     def serial_number(self): 
-        try: self.s.setting_50
-        except: return 0
-        else: return self.s.setting_50
+        try:
+            self.s.setting_50
+        except:
+            return 0
+        else:
+            return self.s.setting_50
 
     def get_product_code(self):
         """takes the last two digits of $50 and converts them to a ProductCode."""
-        try:
-            return self.DEBUG_PRODUCT_CODE
-        except:
-            pass
         try:
             self.s.setting_50
         except:
@@ -1634,7 +1631,6 @@ class RouterMachine(object):
         except: return 0
         else: return self.s.fw_version
 
-    dwt_path =  "../../dwt.txt"
 
     def bench_is_dwt(self):
         return self.get_product_code() is ProductCodes.DRYWALLTEC

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -11,7 +11,7 @@ import serial, sys, time, string, threading, serial.tools.list_ports
 from datetime import datetime, timedelta
 from os import listdir
 from kivy.clock import Clock
-from kivy.properties import StringProperty
+from kivy.properties import StringProperty, NumericProperty
 from kivy.event import EventDispatcher
 
 import re
@@ -32,6 +32,7 @@ def log(message):
 
 
 class SerialConnection(EventDispatcher):
+    setting_50 = NumericProperty(0.0)
     STATUS_INTERVAL = 0.1  # How often to poll general status to update UI (0.04 = 25Hz = smooth animation)
 
     s = None  # Serial comms object

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -23,6 +23,8 @@ from asmcnc.skavaUI import popup_info
 from asmcnc.core_UI.popups import BasicPopup, PopupType
 from kivy.core.window import Window
 
+from src.asmcnc.comms.model_manager import ModelManagerSingleton
+
 Builder.load_string("""
 
 <LobbyScreen>:
@@ -550,12 +552,13 @@ class LobbyScreen(Screen):
         self.m = kwargs['machine']
         self.am = kwargs['app_manager']
         self.l = kwargs['localization']
+        self.model_manager = ModelManagerSingleton()
         self.show_desired_apps()
         self.update_strings()
 
     def show_desired_apps(self):
         # If it's a SmartCNC machine, then show the drywalltec app instead of shapecutter
-        if "DRYWALLTEC" in self.m.smartbench_model():
+        if self.model_manager.is_machine_drywall():
             self.remove_everything_but(self.drywall_app_container)
             self.put_drywall_app_first()
         # Check that window.height is valid & being read in - otherwise will default to SC

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from kivy.uix.boxlayout import BoxLayout
 
 from asmcnc.core_UI import scaling_utils
 from asmcnc.core_UI.popup_manager import PopupManager
+from src.asmcnc.comms.model_manager import ModelManagerSingleton
 
 Config.set('kivy', 'keyboard_mode', 'systemanddock')
 
@@ -191,6 +192,9 @@ class SkavaUI(App):
 
         # Initialise 'm'achine object
         m = router_machine.RouterMachine(Cmport, sm, sett, l, jd)
+
+        # initialise ModelManagerSingleton with serial for setting_50 update
+        ModelManagerSingleton(m.s)
 
         # Initialise yetipilot
         yp = YetiPilot(screen_manager=sm, machine=m, job_data=jd, localization=l)

--- a/tests/automated_unit_tests/comms/test_localization_product_name.py
+++ b/tests/automated_unit_tests/comms/test_localization_product_name.py
@@ -1,4 +1,4 @@
-from asmcnc.comms import model_manager
+from asmcnc.comms.model_manager import ModelManagerSingleton
 from automated_unit_tests.unit_test_base import UnitTestBase
 
 
@@ -8,7 +8,7 @@ class TestLocalizationProductName(UnitTestBase):
 
     def test_get_str(self):
         # Patch model_manager.is_machine_drywall to return False
-        model_manager.is_machine_drywall = lambda: False
+        ModelManagerSingleton().is_machine_drywall = lambda: False
 
         # Create the localization module
         self._localization_module = self._create_localization_module()
@@ -22,7 +22,7 @@ class TestLocalizationProductName(UnitTestBase):
         self.assertEqual(self._localization_module.get_str("SmartBench"), "SmartBench")
 
         # Patch model_manager.is_machine_drywall to return True
-        model_manager.is_machine_drywall = lambda: True
+        ModelManagerSingleton().is_machine_drywall = lambda: True
 
         # Recreate the localization module (to update the PRODUCT_NAME)
         self._localization_module = self._create_localization_module()

--- a/tests/automated_unit_tests/comms/test_localization_product_name.py
+++ b/tests/automated_unit_tests/comms/test_localization_product_name.py
@@ -1,18 +1,19 @@
-from asmcnc.comms.model_manager import ModelManagerSingleton
-from automated_unit_tests.unit_test_base import UnitTestBase
+from mock import patch
+
+from tests.automated_unit_tests.unit_test_base import UnitTestBase
 
 
 class TestLocalizationProductName(UnitTestBase):
     def setUp(self):
         super(TestLocalizationProductName, self).setUp()
 
-    def test_get_str(self):
+    @patch('src.asmcnc.comms.model_manager.ModelManagerSingleton.is_machine_drywall')
+    def test_get_str(self,mock_is_machine_drywall):
         # Patch model_manager.is_machine_drywall to return False
-        ModelManagerSingleton().is_machine_drywall = lambda: False
+        mock_is_machine_drywall.return_value = False
 
         # Create the localization module
         self._localization_module = self._create_localization_module()
-
         # Set the dictionary to a single entry, "SmartBench": "SmartBench"
         self._localization_module.dictionary = {
             "SmartBench": "SmartBench",
@@ -22,7 +23,7 @@ class TestLocalizationProductName(UnitTestBase):
         self.assertEqual(self._localization_module.get_str("SmartBench"), "SmartBench")
 
         # Patch model_manager.is_machine_drywall to return True
-        ModelManagerSingleton().is_machine_drywall = lambda: True
+        mock_is_machine_drywall.return_value = True
 
         # Recreate the localization module (to update the PRODUCT_NAME)
         self._localization_module = self._create_localization_module()

--- a/tests/automated_unit_tests/comms/test_smartbench_model_detection.py
+++ b/tests/automated_unit_tests/comms/test_smartbench_model_detection.py
@@ -51,6 +51,30 @@ def test_initial_failure(m):
     m.bench_is_dwt = Mock(return_value=False)
     assert (m.smartbench_model() == "SmartBench model detection failed")
 
+def test_drywalltec_smartcnc(m):
+    m.bench_is_dwt = Mock(return_value=False)
+    m.grbl_y_max_travel = 2500
+    # m.s.hw_version = 19
+    # m.s.fw_version = '1.1.2'
+    m.s.setting_50 = 0.04
+    assert (m.smartbench_model() == "DRYWALLTEC SmartCNC")
+
+def test_precision_pro_x(m):
+    m.bench_is_dwt = Mock(return_value=False)
+    m.grbl_y_max_travel = 2500
+    # m.s.hw_version = 19
+    # m.s.fw_version = '1.1.2'
+    m.s.setting_50 = 0.05
+    assert (m.smartbench_model() == "SmartBench V1.3 PrecisionPro X")
+
+def test_precision_pro_plus(m):
+    m.bench_is_dwt = Mock(return_value=False)
+    m.grbl_y_max_travel = 2500
+    # m.s.hw_version = 19
+    # m.s.fw_version = '1.1.2'
+    m.s.setting_50 = 0.04
+    assert (m.smartbench_model() == "SmartBench V1.3 PrecisionPro Plus")
+
 
 def test_mini_v1_3_precision_pro(m):
     m.bench_is_dwt = Mock(return_value=False)


### PR DESCRIPTION
# Set SmartBench model in factory

[Jira Ticket](<https://yetitoolsmartsoftware.atlassian.net/jira/software/projects/YTSS/boards/1?selectedIssue=YTSS-2484>)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [x] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

- setting serial number in the factory screen saves product code (Pro, Pro plus, DWT) in a md5 hashed format in a json file
- old consoles without file get file created when $50 is first read (migration of existing machines)
- binds a console to be a DWT
- removes dwt.txt from the game! 


## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"


## Screenshots (if applicable)