### PR TITLE
Added mechanism for setting a fixed keyboard position

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
@@ -15,6 +15,8 @@ from asmcnc.apps.drywall_cutter_app import screen_config_filechooser
 from asmcnc.apps.drywall_cutter_app import screen_config_filesaver
 from asmcnc.apps.drywall_cutter_app import material_setup_popup
 
+from asmcnc.core_UI import scaling_utils
+
 
 class ImageButton(ButtonBehavior, Image):
     pass
@@ -180,10 +182,12 @@ class DrywallCutterScreen(Screen):
     def on_pre_enter(self):
         self.apply_active_config()
         self.pulse_poll = Clock.schedule_interval(self.xy_move_widget.check_zh_at_datum, 0.04)
+        self.kb.set_numeric_pos((scaling_utils.get_scaled_width(565), scaling_utils.get_scaled_height(85)))
 
     def on_pre_leave(self):
         if self.pulse_poll:
             Clock.unschedule(self.pulse_poll)
+        self.kb.set_numeric_pos(None)
 
     def home(self):
         self.m.request_homing_procedure('drywall_cutter', 'drywall_cutter')

--- a/src/asmcnc/keyboard/custom_keyboard.py
+++ b/src/asmcnc/keyboard/custom_keyboard.py
@@ -27,6 +27,8 @@ class Keyboard(VKeyboard):
         self.bind(do_translation=self.set_keyboard_background)
 
         self.text_instance = None
+        self.custom_numeric_pos = None
+        self.custom_qwerty_pos = None
 
         dirname = os.path.dirname(__file__)
 
@@ -146,10 +148,7 @@ class Keyboard(VKeyboard):
             self.margin_hint = [.05, .06, .05, .06]  # Default margin
             self.background = "atlas://data/images/defaulttheme/vkeyboard_background"
 
-        if self.layout == self.numeric_layout:
-            self.width = scaling_utils.Width / 3
-        else:
-            self.width = scaling_utils.Width
+        self.setup_layout()
 
         # Make sure keyboard never goes off-screen and becomes unusable/unreachable
         if self.pos[0] + self.width > scaling_utils.Width:
@@ -160,6 +159,23 @@ class Keyboard(VKeyboard):
             self.pos = (0, self.pos[1])
         if self.pos[1] + self.height > scaling_utils.Height:
             self.pos = (self.pos[0], scaling_utils.Height - self.height)
+
+    def setup_layout(self):
+        if self.layout == self.numeric_layout:
+            self.width = scaling_utils.Width / 3.4
+            if self.custom_numeric_pos:
+                self.pos = self.custom_numeric_pos
+        else:
+            self.width = scaling_utils.Width
+            if self.custom_qwerty_pos:
+                self.pos = self.custom_qwerty_pos
+
+    # Set custom positions for the keyboard
+    def set_numeric_pos(self, pos):
+        self.custom_numeric_pos = pos
+
+    def set_qwerty_pos(self, pos):
+        self.custom_qwerty_pos = pos
 
     # On focus behaviour is bound to all text inputs
     def on_focus_raise_keyboard(self,instance,value):
@@ -175,6 +191,7 @@ class Keyboard(VKeyboard):
                 self.layout = self.previous_layout
             instance.focus = True
             self.text_instance = instance
+            self.setup_layout()
             self.raise_keyboard_if_none_exists()
         else:
             self.lower_keyboard_if_not_focused()


### PR DESCRIPTION
# Numpad comes up on the right in drywall app

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-2662?atlOrigin=eyJpIjoiZjAyZmVmYTRjMTYxNDBiM2E4Y2M2YTI2NzQxZjc1OTYiLCJwIjoiaiJ9)
- [X] Ready for review

## Checklist
- [X] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [X] I have updated the jira ticket
- [X] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
The keyboard now comes up on the right and the numeric layout is narrower. One current issue is that the numpad comes up in the same position in the material popup as well.

## Notes

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [X] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [X] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)
![image](https://github.com/YetiTool/easycut-smartbench/assets/126763092/f32bb434-afb9-48f5-b9dd-f49979252eb2)
