### PR TITLE
Archie/dwt rebrand/smartbench name

### DIFF
--- a/src/asmcnc/comms/model_manager.py
+++ b/src/asmcnc/comms/model_manager.py
@@ -27,7 +27,14 @@ class ModelManagerSingleton(EventDispatcher):
     DWT_SPLASH_PATH = os.path.join(SKAVA_UI_IMAGES_PATH, "dwt_splash_screen.png")
 
     SMARTBENCH_DEFAULT_NAME = "My SmartBench"
-    SMARTCNC_DEFAULT_NAME = "My SmartCNC"
+    SMARTBENCH_DEFAULT_LOCATION = "SmartBench location"
+
+    MODEL_NAME_LOCATIONS = {
+        ProductCodes.DRYWALLTEC: {
+            'name': 'SmartCNC',
+            'location': 'SmartCNC location'
+        },
+    }
 
     def __new__(cls, machine=None):
         with cls._lock:
@@ -147,15 +154,20 @@ class ModelManagerSingleton(EventDispatcher):
         with open(self.PC_FILE_PATH, 'w') as f:
             json.dump(d, f)
 
-    def __set_default_machine_name(self):
+    def __set_default_machine_fields(self):
         # type: () -> None
         """
-        Sets the default machine name to the relevant name.
+        Sets the default machine name and location to the relevant strings.
+        Either gets the value from the dictionary or uses the default values.
+
         Only called when the serial number is first read.
-
-        SmartBench -> My SmartBench
-        DryWallTec SmartCNC -> My SmartCNC
         """
-        default_name = self.SMARTCNC_DEFAULT_NAME if self.is_machine_drywall() else self.SMARTBENCH_DEFAULT_NAME
+        default = {
+            'name': self.SMARTBENCH_DEFAULT_NAME,
+            'location': self.SMARTBENCH_DEFAULT_LOCATION
+        }
 
-        self.machine.write_device_label(default_name)
+        name_location = self.MODEL_NAME_LOCATIONS.get(self.product_code, default)
+
+        self.machine.write_device_label(name_location['name'])
+        self.machine.write_device_location(name_location['location'])


### PR DESCRIPTION
# Set the default name and location of a machine on first serial read

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/jira/software/projects/YTSS/boards/1?assignee=5f8db15e6bc6340068c0bfc3&selectedIssue=YTSS-2681)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)

## Description

## Notes

## Dependencies for merge

## Testing

### Visual Test
- [x] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [x] Console 10"

### Unit Tests
- [x] Not applicable
- [ ] Completed

## Screenshots (if applicable)