### PR TITLE
start_sequential_streaming can now be called simultaneously

### DIFF
--- a/src/asmcnc/comms/grbl_settings_manager.py
+++ b/src/asmcnc/comms/grbl_settings_manager.py
@@ -26,7 +26,6 @@ class GRBLSettingsManagerSingleton(object):
     _received_sn = ''
 
     SERIAL_ID = 50
-    WRITE_DOLLAR_INTERVAL = 0.2  # needed, because serial_connection sequential stream is not thread safe!!!
 
     # json skeletons
     _machine_saved_data = {
@@ -103,8 +102,7 @@ class GRBLSettingsManagerSingleton(object):
             # check if saved value exists:
             if self._machine_saved_data[self.SERIAL_ID] != '0000.00':
                 # restore saved value:
-                Clock.schedule_once(lambda dt: self.machine.write_dollar_setting(
-                    self.SERIAL_ID, self._machine_saved_data[self.SERIAL_ID]), self._get_write_interval())
+                self.machine.write_dollar_setting(self.SERIAL_ID, self._machine_saved_data[self.SERIAL_ID])
                 log('Restored $50 (serial number) from file: {}'.format(self._machine_saved_data[self.SERIAL_ID]))
             else:
                 log('Cannot restore serial number. Nothing saved yet!')
@@ -138,9 +136,7 @@ class GRBLSettingsManagerSingleton(object):
             if self._machine_saved_data[setting] != 0:  # saved value exists?
                 if self._machine_saved_data[self.SERIAL_ID] == self._received_sn:  # serial number matches?
                     # restore saved value:
-                    Clock.schedule_once(lambda dt: self.machine.write_dollar_setting(setting,
-                                        self._machine_saved_data[setting]),
-                                        self._get_write_interval())
+                    self.machine.write_dollar_setting(setting, self._machine_saved_data[setting])
                     log('Restored {} from file: {}'.format(descriptions[setting], self._machine_saved_data[setting]))
                 else:
                     log('Cannot restore {}. Wrong serial detected! Found: {} | Expected: {}'.
@@ -153,17 +149,3 @@ class GRBLSettingsManagerSingleton(object):
                 self.save_machine_data_to_file()
                 log('Calibration run? Updated {} in file: {}'.
                     format(descriptions[setting], value))
-
-    def _get_write_interval(self):
-        """
-        Returns the next write interval and increases it for the next call.
-        This is needed to avoid race conditions with simultaneous write_dollar_setting calls.
-        """
-        ret = self.WRITE_DOLLAR_INTERVAL
-        self.WRITE_DOLLAR_INTERVAL += self.WRITE_DOLLAR_INTERVAL
-        return ret
-
-
-
-
-

--- a/src/asmcnc/comms/model_manager.py
+++ b/src/asmcnc/comms/model_manager.py
@@ -136,13 +136,13 @@ class ModelManagerSingleton(object):
         if md5('YS6' + sn).hexdigest() in data['Pro Plus']:
             full_sn = sn + '.04'
             log('Old Pro Plus detected. Fixed SN to: {}'.format(full_sn))
-            Clock.schedule_once(lambda dt: self.machine.write_dollar_setting(50, full_sn), 1)
+            self.machine.write_dollar_setting(50, full_sn)
             self._data['product_code'] = ProductCodes.PRECISION_PRO_PLUS.value
             return ProductCodes.PRECISION_PRO_PLUS
         elif md5(sn).hexdigest() in data['Pro X']:
             full_sn = sn + '.05'
             log('Old Pro X detected. Fixed SN to: {}'.format(full_sn))
-            Clock.schedule_once(lambda dt: self.machine.write_dollar_setting(50, full_sn), 1)
+            self.machine.write_dollar_setting(50, full_sn)
             return ProductCodes.PRECISION_PRO_X
         else:
             return ProductCodes.UNKNOWN

--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -1732,6 +1732,10 @@ class SerialConnection(EventDispatcher):
     _micro_dwell_command = "G4 P" + str(0.01)
 
     def start_sequential_stream(self, list_to_stream, reset_grbl_after_stream=False, end_dwell=False):
+        if self.is_sequential_streaming:
+            log('already streaming...try again later')
+            Clock.schedule_once(lambda dt: self.start_sequential_stream(list_to_stream, reset_grbl_after_stream, end_dwell), 0.3)
+            return
         self.is_sequential_streaming = True
         log("Start_sequential_stream")
         if reset_grbl_after_stream:


### PR DESCRIPTION
# Fix start_sequential_streaming


- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [x] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

## Notes

## Dependencies for merge
- [ ] [#<pull_request_number>]

## Testing

### Visual Test
- [x] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [x] Completed

## Screenshots (if applicable)