### PR TITLE
Archie/sb values fix

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -9,6 +9,7 @@ import traceback
 
 from enum import Enum
 from asmcnc.comms.logging_system.logging_system import Logger
+from asmcnc.core_UI import path_utils
 
 try:
     import pigpio
@@ -78,21 +79,21 @@ class RouterMachine(EventDispatcher):
     # PERSISTENT MACHINE VALUES
 
     ## PERSISTENT VALUES SETUP
-    smartbench_values_dir = './sb_values/'
+    smartbench_values_dir = path_utils.sb_values_path
 
     ### Individual files to hold persistent values
-    set_up_options_file_path = smartbench_values_dir + 'set_up_options.txt'
-    z_touch_plate_thickness_file_path = smartbench_values_dir + 'z_touch_plate_thickness.txt'
-    calibration_settings_file_path = smartbench_values_dir + 'calibration_settings.txt'
-    z_head_maintenance_settings_file_path = smartbench_values_dir + 'z_head_maintenance_settings.txt'
-    z_head_laser_offset_file_path = smartbench_values_dir + 'z_head_laser_offset.txt'
-    spindle_brush_values_file_path = smartbench_values_dir + 'spindle_brush_values.txt'
-    spindle_cooldown_settings_file_path = smartbench_values_dir + 'spindle_cooldown_settings.txt'
-    spindle_cooldown_rpm_override_file_path = smartbench_values_dir + 'spindle_cooldown_rpm_override.txt'
-    stylus_settings_file_path = smartbench_values_dir + 'stylus_settings.txt'
-    spindle_health_check_file_path = smartbench_values_dir + 'spindle_health_check.txt'
-    device_label_file_path = '../../smartbench_name.txt' # this puts it above EC folder in filesystem
-    device_location_file_path = '../../smartbench_location.txt' # this puts it above EC folder in filesystem
+    set_up_options_file_path = os.path.join(smartbench_values_dir, 'set_up_options.txt')
+    z_touch_plate_thickness_file_path = os.path.join(smartbench_values_dir, 'z_touch_plate_thickness.txt')
+    calibration_settings_file_path = os.path.join(smartbench_values_dir, 'calibration_settings.txt')
+    z_head_maintenance_settings_file_path = os.path.join(smartbench_values_dir, 'z_head_maintenance_settings.txt')
+    z_head_laser_offset_file_path = os.path.join(smartbench_values_dir, 'z_head_laser_offset.txt')
+    spindle_brush_values_file_path = os.path.join(smartbench_values_dir, 'spindle_brush_values.txt')
+    spindle_cooldown_settings_file_path = os.path.join(smartbench_values_dir, 'spindle_cooldown_settings.txt')
+    spindle_cooldown_rpm_override_file_path = os.path.join(smartbench_values_dir, 'spindle_cooldown_rpm_override.txt')
+    stylus_settings_file_path = os.path.join(smartbench_values_dir, 'stylus_settings.txt')
+    spindle_health_check_file_path = os.path.join(smartbench_values_dir, 'spindle_health_check.txt')
+    device_label_file_path = os.path.join(path_utils.above_easycut_path, 'smartbench_name.txt')
+    device_location_file_path = os.path.join(path_utils.above_easycut_path, 'smartbench_location.txt')
 
     ## LOCALIZATION
     persistent_language_path = smartbench_values_dir + 'user_language.txt'

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -82,21 +82,21 @@ class RouterMachine(EventDispatcher):
     smartbench_values_dir = path_utils.sb_values_path
 
     ### Individual files to hold persistent values
-    set_up_options_file_path = os.path.join(smartbench_values_dir, 'set_up_options.txt')
-    z_touch_plate_thickness_file_path = os.path.join(smartbench_values_dir, 'z_touch_plate_thickness.txt')
-    calibration_settings_file_path = os.path.join(smartbench_values_dir, 'calibration_settings.txt')
-    z_head_maintenance_settings_file_path = os.path.join(smartbench_values_dir, 'z_head_maintenance_settings.txt')
-    z_head_laser_offset_file_path = os.path.join(smartbench_values_dir, 'z_head_laser_offset.txt')
-    spindle_brush_values_file_path = os.path.join(smartbench_values_dir, 'spindle_brush_values.txt')
-    spindle_cooldown_settings_file_path = os.path.join(smartbench_values_dir, 'spindle_cooldown_settings.txt')
-    spindle_cooldown_rpm_override_file_path = os.path.join(smartbench_values_dir, 'spindle_cooldown_rpm_override.txt')
-    stylus_settings_file_path = os.path.join(smartbench_values_dir, 'stylus_settings.txt')
-    spindle_health_check_file_path = os.path.join(smartbench_values_dir, 'spindle_health_check.txt')
-    device_label_file_path = os.path.join(path_utils.above_easycut_path, 'smartbench_name.txt')
-    device_location_file_path = os.path.join(path_utils.above_easycut_path, 'smartbench_location.txt')
+    set_up_options_file_path = path_utils.join(smartbench_values_dir, 'set_up_options.txt')
+    z_touch_plate_thickness_file_path = path_utils.join(smartbench_values_dir, 'z_touch_plate_thickness.txt')
+    calibration_settings_file_path = path_utils.join(smartbench_values_dir, 'calibration_settings.txt')
+    z_head_maintenance_settings_file_path = path_utils.join(smartbench_values_dir, 'z_head_maintenance_settings.txt')
+    z_head_laser_offset_file_path = path_utils.join(smartbench_values_dir, 'z_head_laser_offset.txt')
+    spindle_brush_values_file_path = path_utils.join(smartbench_values_dir, 'spindle_brush_values.txt')
+    spindle_cooldown_settings_file_path = path_utils.join(smartbench_values_dir, 'spindle_cooldown_settings.txt')
+    spindle_cooldown_rpm_override_file_path = path_utils.join(smartbench_values_dir, 'spindle_cooldown_rpm_override.txt')
+    stylus_settings_file_path = path_utils.join(smartbench_values_dir, 'stylus_settings.txt')
+    spindle_health_check_file_path = path_utils.join(smartbench_values_dir, 'spindle_health_check.txt')
+    device_label_file_path = path_utils.join(path_utils.above_easycut_path, 'smartbench_name.txt')
+    device_location_file_path = path_utils.join(path_utils.above_easycut_path, 'smartbench_location.txt')
 
     ## LOCALIZATION
-    persistent_language_path = smartbench_values_dir + 'user_language.txt'
+    persistent_language_path = path_utils.join(smartbench_values_dir, 'user_language.txt')
 
     ## PROBE SETTINGS
     z_lift_after_probing = 20.0

--- a/src/asmcnc/core_UI/path_utils.py
+++ b/src/asmcnc/core_UI/path_utils.py
@@ -149,3 +149,4 @@ asmcnc_path = get_path("asmcnc") # easycut-smartbench/src/asmcnc
 skava_ui_path = get_path("skavaUI") # easycut-smartbench/src/asmcnc/skavaUI
 skava_ui_img_path = get_path("skavaUI/img") # easycut-smartbench/src/asmcnc/skavaUI/img
 sb_values_path = get_path("sb_values")  # easycut-smartbench/src/sb_values
+above_easycut_path = os.path.dirname(easycut_path)


### PR DESCRIPTION
Change paths to use path_utils and join instead of just concatenating. Stops multiple sb_values folders from appearing when running from different cwds. Searched repository for folders using find . -type d -name 'sb_values' and only got one after running from different wds.
