### PR TITLE
fixed crash on save_/restore_settings

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
+++ b/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
@@ -190,14 +190,12 @@ class ScreenManagerSystemTools(object):
                     os.system('sudo tar czf /media/usb/transfer.tar.gz -C /home/pi/easycut-smartbench/transfer_tmp .')
                 except Exception as e:
                     Logger.error(e)
-                    pass
                 try:
                     #clean up
                     Logger.info('Clean up...')
                     os.system('rm -r /home/pi/easycut-smartbench/transfer_tmp')
                 except Exception as e:
                     Logger.error('Could not delete temporary files: {}'.format(e))
-                    pass
                 self.sm.pm.close_info_popup()
                 #check if transfer file exists
                 if os.path.isfile('/media/usb/transfer.tar.gz'):
@@ -254,7 +252,6 @@ class ScreenManagerSystemTools(object):
                 except Exception as e:
                     success_flag = False
                     Logger.error(e)
-                    pass
                 self.sm.pm.close_info_popup()
                 self.usb_stick.disable()
                 if success_flag:

--- a/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
+++ b/src/asmcnc/apps/systemTools_app/screen_manager_systemtools.py
@@ -160,7 +160,7 @@ class ScreenManagerSystemTools(object):
     def download_settings_to_usb(self, *args):
         if self.mutex.locked():
             # already running
-            Logger.info('mutex locked!')
+            Logger.debug('mutex locked!')
             return
         self.mutex.acquire(True)
         self.usb_stick.enable()
@@ -168,7 +168,7 @@ class ScreenManagerSystemTools(object):
         self.sm.pm.show_info_popup(message, 600)
 
         def copy_settings_to_usb(loop_counter):
-            Logger.info('Loop: {}').format(loop_counter)
+            Logger.debug('Loop: {}'.format(loop_counter))
             if self.usb_stick.is_usb_mounted_flag:
                 try:
                     Logger.info('Copying...')
@@ -189,14 +189,14 @@ class ScreenManagerSystemTools(object):
                     Logger.info('Create tar...')
                     os.system('sudo tar czf /media/usb/transfer.tar.gz -C /home/pi/easycut-smartbench/transfer_tmp .')
                 except Exception as e:
-                    Logger.info(e)
+                    Logger.error(e)
                     pass
                 try:
                     #clean up
                     Logger.info('Clean up...')
                     os.system('rm -r /home/pi/easycut-smartbench/transfer_tmp')
                 except Exception as e:
-                    Logger.info("Could not delete temporary files: {e}").format(e)
+                    Logger.error('Could not delete temporary files: {}'.format(e))
                     pass
                 self.sm.pm.close_info_popup()
                 #check if transfer file exists
@@ -225,7 +225,7 @@ class ScreenManagerSystemTools(object):
     def upload_settings_from_usb(self, *args):
         if self.mutex.locked():
             # already running
-            Logger.info('mutex locked!')
+            Logger.debug('mutex locked!')
             return
         self.mutex.acquire(True)
         self.usb_stick.enable()
@@ -233,7 +233,7 @@ class ScreenManagerSystemTools(object):
         self.sm.pm.show_info_popup(message, 600)
 
         def restore_settings_from_usb(loop_counter):
-            Logger.info('Loop: {}').format(loop_counter)
+            Logger.debug('Loop: {}'.format(loop_counter))
             if self.usb_stick.is_usb_mounted_flag:
                 # TODO restore files here
                 success_flag = True
@@ -253,7 +253,7 @@ class ScreenManagerSystemTools(object):
                         self.m.get_persistent_values()
                 except Exception as e:
                     success_flag = False
-                    Logger.info(e)
+                    Logger.error(e)
                     pass
                 self.sm.pm.close_info_popup()
                 self.usb_stick.disable()


### PR DESCRIPTION
When try to save or restore settings from and to usb, it crashed due to a exception in logger. I wonder how this would not crash with a simple print() but it is fixed now.