### PR TITLE
Depth per pass warning shows as you type

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/material_setup_popup.py
+++ b/src/asmcnc/apps/drywall_cutter_app/material_setup_popup.py
@@ -302,13 +302,14 @@ class CuttingDepthsPopup(Popup):
         self.kb.setup_text_inputs(self.text_inputs)
         for text_input in self.text_inputs:
             text_input.bind(focus=self.text_on_focus)
+        self.depth_per_pass.bind(text=self.warning_pass_depth)
 
         # Defining the error messages in one place since they need to be changed throughout the popup
         self.pass_depth_warning_cutter_max = "[color=#FF0000]" + self.l.get_str("Max depth per pass for this tool is") \
                                              + " Xmm[/color]".replace("X",
                                                                       str(self.dwt_config.active_cutter.max_depth_per_pass))
         self.pass_depth_warning_zero = "[color=#FF0000]" + self.l.get_str("Depth per pass must be greater than 0") \
-                                           + "[/color]"
+                                       + "[/color]"
 
         self.cut_depth_warning_soft_limit = "[color=#FF0000]" + self.l.get_str("Max allowable cut is") + \
                                             " Xmm[/color]".replace("X", str(self.soft_limit_total_cut_depth))
@@ -316,7 +317,7 @@ class CuttingDepthsPopup(Popup):
                                             " Xmm[/color]".replace("X",
                                                                    str(self.dwt_config.active_cutter.max_depth_total))
         self.cut_depth_warning_zero = "[color=#FF0000]" + self.l.get_str("Total cut depth must be greater than 0") \
-                                          + "[/color]"
+                                      + "[/color]"
 
         self.update_strings()
 
@@ -417,6 +418,31 @@ class CuttingDepthsPopup(Popup):
 
         self.disable_confirm_button()
 
+    def warning_pass_depth(self, *args):
+        if self.auto_pass_checkbox.active:
+            try:
+                depth_per_pass = self.dwt_config.active_cutter.max_depth_per_pass
+                if depth_per_pass <= 0:
+                    self.pass_depth_warning.text = self.pass_depth_warning_zero
+                    self.float_layout.add_widget(self.pass_depth_warning)
+                else:
+                    self.float_layout.remove_widget(self.pass_depth_warning)
+            except:
+                pass
+        else:
+            depth_per_pass = self.get_safe_float(self.depth_per_pass.text)
+            try:
+                if depth_per_pass > self.dwt_config.active_cutter.max_depth_per_pass:
+                    self.pass_depth_warning.text = self.pass_depth_warning_cutter_max
+                    self.float_layout.add_widget(self.pass_depth_warning)
+                elif depth_per_pass <= 0:
+                    self.pass_depth_warning.text = self.pass_depth_warning_zero
+                    self.float_layout.add_widget(self.pass_depth_warning)
+                else:
+                    self.float_layout.remove_widget(self.pass_depth_warning)
+            except:
+                pass
+
     def disable_confirm_button(self):
         children = self.float_layout.children
         if self.cut_depth_warning in children or self.pass_depth_warning in children:
@@ -463,29 +489,12 @@ class CuttingDepthsPopup(Popup):
                 self.depth_per_pass.text = str(max_cut_depth_per_pass)
             else:
                 self.depth_per_pass.text = str(round(depth_per_pass, 1))
-            try:
-                if depth_per_pass <= 0:
-                    self.pass_depth_warning.text = self.pass_depth_warning_zero
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                else:
-                    self.float_layout.remove_widget(self.pass_depth_warning)
-            except:
-                pass
+
             self.disable_confirm_button()
             self.generate_pass_depth_lines(number_of_passes)
         else:
             depth_per_pass = self.get_safe_float(self.depth_per_pass.text)
-            try:
-                if depth_per_pass > max_cut_depth_per_pass:
-                    self.pass_depth_warning.text = self.pass_depth_warning_cutter_max
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                elif depth_per_pass <= 0:
-                    self.pass_depth_warning.text = self.pass_depth_warning_zero
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                else:
-                    self.float_layout.remove_widget(self.pass_depth_warning)
-            except:
-                pass
+
             self.disable_confirm_button()
             number_of_passes = 0 if depth_per_pass == 0 else math.ceil(self.get_safe_float(self.total_cut_depth.text) / depth_per_pass)
             self.generate_pass_depth_lines(number_of_passes)

--- a/src/asmcnc/apps/drywall_cutter_app/material_setup_popup.py
+++ b/src/asmcnc/apps/drywall_cutter_app/material_setup_popup.py
@@ -405,43 +405,37 @@ class CuttingDepthsPopup(Popup):
         self.update_graphic_position()
         self.calculate_depth_per_pass()
 
-        try:
-            if float(self.total_cut_depth.text) > max_cut_depth:
-                self.float_layout.add_widget(self.cut_depth_warning)
-            elif float(self.total_cut_depth.text) <= 0:
-                self.cut_depth_warning.text = self.cut_depth_warning_zero
-                self.float_layout.add_widget(self.cut_depth_warning)
-            else:
-                self.float_layout.remove_widget(self.cut_depth_warning)
-        except:
-            pass
+        if self.cut_depth_warning not in self.float_layout.children:
+            self.float_layout.add_widget(self.cut_depth_warning)
+        if float(self.total_cut_depth.text) > max_cut_depth:
+            self.cut_depth_warning.text = self.cut_depth_warning_cutter_max
+        elif float(self.total_cut_depth.text) <= 0:
+            self.cut_depth_warning.text = self.cut_depth_warning_zero
+        else:
+            self.float_layout.remove_widget(self.cut_depth_warning)
 
         self.disable_confirm_button()
 
     def warning_pass_depth(self, *args):
         if self.auto_pass_checkbox.active:
-            try:
-                depth_per_pass = self.dwt_config.active_cutter.max_depth_per_pass
-                if depth_per_pass <= 0:
-                    self.pass_depth_warning.text = self.pass_depth_warning_zero
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                else:
-                    self.float_layout.remove_widget(self.pass_depth_warning)
-            except:
-                pass
+            depth_per_pass = self.dwt_config.active_cutter.max_depth_per_pass
+            if self.pass_depth_warning not in self.float_layout.children:
+                self.float_layout.add_widget(self.pass_depth_warning)
+            if depth_per_pass <= 0:
+                self.pass_depth_warning.text = self.pass_depth_warning_zero
+            else:
+                self.float_layout.remove_widget(self.pass_depth_warning)
         else:
             depth_per_pass = self.get_safe_float(self.depth_per_pass.text)
-            try:
-                if depth_per_pass > self.dwt_config.active_cutter.max_depth_per_pass:
-                    self.pass_depth_warning.text = self.pass_depth_warning_cutter_max
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                elif depth_per_pass <= 0:
-                    self.pass_depth_warning.text = self.pass_depth_warning_zero
-                    self.float_layout.add_widget(self.pass_depth_warning)
-                else:
-                    self.float_layout.remove_widget(self.pass_depth_warning)
-            except:
-                pass
+            if self.pass_depth_warning not in self.float_layout.children:
+                self.float_layout.add_widget(self.pass_depth_warning)
+            if depth_per_pass > self.dwt_config.active_cutter.max_depth_per_pass:
+                self.pass_depth_warning.text = self.pass_depth_warning_cutter_max
+            elif depth_per_pass <= 0:
+                self.pass_depth_warning.text = self.pass_depth_warning_zero
+            else:
+                self.float_layout.remove_widget(self.pass_depth_warning)
+
 
     def disable_confirm_button(self):
         children = self.float_layout.children


### PR DESCRIPTION
# Made depth per pass warning show as you type

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-2703?atlOrigin=eyJpIjoiZTlkNjkwNzBkN2Y4NDQ3MjgzNzhjZDUwYjhiMWVmMWYiLCJwIjoiaiJ9)
- [X] Ready for review

## Checklist
- [X] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [X] I have updated the jira ticket
- [X] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
I moved the checks for the depth per pass error message to a separate function which is called on text change

## Notes

## Dependencies for merge


## Testing

### Visual Test
- [ ] Not applicable
- [X] Own computer
- [X] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [X] Own computer
- [X] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)