### PR TITLE
set  z max travel dependent on machine type

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -785,8 +785,15 @@ class FactorySettingsScreen(Screen):
                 + str(self.product_number_input.text)
             )
             # Do specific tasks for setting up the machine model (e.g. splash screen)
-            self.model_manager.set_machine_type(ProductCodes(int(self.product_number_input.text)), True)
+            pc = ProductCodes(int(self.product_number_input.text))
+            self.model_manager.set_machine_type(pc, True)
             self.m.write_dollar_setting(50, full_serial_number)
+            if pc is ProductCodes.DRYWALLTEC:  # set max z travel to 120mm because of the rubber bellow
+                Logger.info("Z max travel ($132) is set to 130 for double stack motors.")
+                self.m.write_dollar_setting(132, 120)
+            elif pc in [ProductCodes.PRECISION_PRO, ProductCodes.PRECISION_PRO_X, ProductCodes.PRECISION_PRO_PLUS]:
+                Logger.info("Z max travel ($132) is set to 120 for Drywalltec machine.")
+                self.m.write_dollar_setting(132, 130)
             self.machine_serial.text = "updating..."
 
             def update_text_with_serial():

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -789,10 +789,10 @@ class FactorySettingsScreen(Screen):
             self.model_manager.set_machine_type(pc, True)
             self.m.write_dollar_setting(50, full_serial_number)
             if pc is ProductCodes.DRYWALLTEC:  # set max z travel to 120mm because of the rubber bellow
-                Logger.info("Z max travel ($132) is set to 130 for double stack motors.")
+                Logger.info("Z max travel ($132) is set to 120 for Drywalltec machine.")
                 self.m.write_dollar_setting(132, 120)
             elif pc in [ProductCodes.PRECISION_PRO, ProductCodes.PRECISION_PRO_X, ProductCodes.PRECISION_PRO_PLUS]:
-                Logger.info("Z max travel ($132) is set to 120 for Drywalltec machine.")
+                Logger.info("Z max travel ($132) is set to 130 for double stack motors.")
                 self.m.write_dollar_setting(132, 130)
             self.machine_serial.text = "updating..."
 


### PR DESCRIPTION

## Checklist
- [x] I have completed a self review
- [ ] I have updated the [spreadsheet](https://docs.google.com/spreadsheets/d/1277nPOKtBFOk_kCo870_zA460-qlw_kGnYlLPwtnadE/edit#gid=0)
- [ ] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
DWT will have a lower z_max_travel of 120mm. (normal double stack machines have 130). Factory screen takes care of that.

## Notes

## Dependencies for merge
- [ ] [#<pull_request_number>]

## Testing

### Visual Test
- [x] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)