### PR TITLE
Fix rounded edge on separator line

### DIFF
--- a/src/asmcnc/core_UI/new_popups/popup_bases.py
+++ b/src/asmcnc/core_UI/new_popups/popup_bases.py
@@ -59,7 +59,7 @@ class PopupTitle(BoxLayout):
         self.canvas.before.clear()  # Clear previous drawing
         with self.canvas.before:
             Color(*self.separator_colour)
-            Line(points=[self.x, self.y, self.x + self.width, self.y], width=dp(2), cap="square")
+            Line(points=[self.x + 2, self.y, self.x + self.width - 2, self.y], width=dp(2), cap="square")
 
     def on_label_size(self, instance, value):
         self.label.pos = (self.label.pos[0], self.label.pos[1] + 5)  # Cheat way to center the label

--- a/src/asmcnc/core_UI/new_popups/popup_bases.py
+++ b/src/asmcnc/core_UI/new_popups/popup_bases.py
@@ -59,8 +59,7 @@ class PopupTitle(BoxLayout):
         self.canvas.before.clear()  # Clear previous drawing
         with self.canvas.before:
             Color(*self.separator_colour)
-            self.line = Line(points=[self.x, self.y, self.x + self.width, self.y],
-                             width=dp(2), cap="square")
+            Line(points=[self.x, self.y, self.x + self.width, self.y], width=dp(2), cap="square")
 
     def on_label_size(self, instance, value):
         self.label.pos = (self.label.pos[0], self.label.pos[1] + 5)  # Cheat way to center the label

--- a/src/asmcnc/core_UI/new_popups/popup_bases.py
+++ b/src/asmcnc/core_UI/new_popups/popup_bases.py
@@ -60,7 +60,7 @@ class PopupTitle(BoxLayout):
         with self.canvas.before:
             Color(*self.separator_colour)
             self.line = Line(points=[self.x, self.y, self.x + self.width, self.y],
-                             width=dp(2))
+                             width=dp(2), cap="square")
 
     def on_label_size(self, instance, value):
         self.label.pos = (self.label.pos[0], self.label.pos[1] + 5)  # Cheat way to center the label


### PR DESCRIPTION
The separator line for the job validation popup had slightly rounded edges. This makes the edges square.