### PR TITLE
Remove logger calls

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/widget_final_test_xy_move.py
+++ b/src/asmcnc/apps/systemTools_app/screens/widget_final_test_xy_move.py
@@ -169,11 +169,9 @@ Builder.load_string("""
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
-                    Logger.info('release')
                     root.cancelXYJog()
                     self.background_color = hex('#F4433600')
                 on_press: 
-                    Logger.info('press')
                     root.buttonJogXY('X-')
                     self.background_color = hex('#F44336FF')
                 BoxLayout:


### PR DESCRIPTION
In the widget there were print() statements, which were changed into Logger....() 