### PR TITLE
Set button opacity to 0

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
@@ -482,6 +482,7 @@ Builder.load_string(
                         on_press: root.toggle_ssh()
                         color: hex('#f9f9f9ff')
                         markup: True
+                        opacity: 0  # Set opacity to 0 to make the button invisible
 
                     ToggleButton:
                         font_size: str(0.01875 * app.width) + 'sp'

--- a/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
@@ -482,7 +482,6 @@ Builder.load_string(
                         on_press: root.toggle_ssh()
                         color: hex('#f9f9f9ff')
                         markup: True
-                        opacity: 0  # Set opacity to 0 to make the button invisible
 
                     ToggleButton:
                         font_size: str(0.01875 * app.width) + 'sp'
@@ -635,6 +634,10 @@ class BuildInfoScreen(Screen):
 
         # Add the IDs of ALL the TextInputs on this screen
         self.text_inputs = [self.smartbench_name_input, self.smartbench_location_input]
+
+        # Hide SSH button if drywall machine (button still works but is hidden)
+        if self.m.model_manager.is_machine_drywall():
+            self.toggle_ssh_button.opacity = 0
 
     ## EXIT BUTTONS
     def go_back(self):


### PR DESCRIPTION
# Hide SSH button
Yes this is disgusting - Az's idea & he approved it

(the button still works) - for use in house. SSH still disabled on power cycle

![image](https://github.com/YetiTool/easycut-smartbench/assets/89073517/414bb712-b9ef-4676-9f82-f34a155d17bb)
