### PR TITLE
delayed closing of probing screen

### DIFF
--- a/src/asmcnc/skavaUI/screen_probing.py
+++ b/src/asmcnc/skavaUI/screen_probing.py
@@ -178,7 +178,8 @@ class ProbingScreen(Screen):
             Logger.warning("Probing screen exited due to alarm")
             self.exit()
         if screen == 'probing' and self.not_probing:
-            self.exit()
+            Clock.unschedule(self.watchdog_event)
+            Clock.schedule_once(lambda dt:self.exit(), 2)
 
         if self.variable_debug:
             Logger.debug(("Watchdog:\nMachine state: " + machine_state, "Not probing: " + str(self.not_probing), "Alarm triggered: " + str(self.alarm_triggered)))


### PR DESCRIPTION
# Delayed dismiss of probing screen to give spindle time to retract


- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [x] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

## Notes


## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)