### PR TITLE
Disable speed down button if close to threshold

### DIFF
--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -121,6 +121,15 @@ class SpeedOverride(Widget):
     def update_spindle_speed_label(self, instance, value):
         self.spindle_rpm.text = str(value)
 
+        current_multiplier = float(self.m.s.speed_override_percentage) / 100
+        rpm_down_5 = (value / current_multiplier) * (current_multiplier - 0.05)
+
+        # If the speed down button produces speed below minimum, don't allow it to be pressed
+        if rpm_down_5 < self.m.minimum_spindle_speed():
+            self.down_5.disabled = True
+        else:
+            self.down_5.disabled = False
+
     def update_speed_percentage_override_label(self):
         self.speed_override_percentage = self.m.s.speed_override_percentage
         self.speed_rate_label.text = str(self.m.s.speed_override_percentage) + "%"


### PR DESCRIPTION
# Account for tool diameter in min labels

[Jira Ticket]()

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

On go screen, speed down button is disabled if close to minimum RPM.

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

## Screenshots

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed