### PR TITLE
Clean up scaling format

### DIFF
--- a/src/asmcnc/apps/SWupdater_app/screen_update_SW.py
+++ b/src/asmcnc/apps/SWupdater_app/screen_update_SW.py
@@ -40,8 +40,8 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None, None)
-        height: dp(1.0*app.height)
-        width: dp(1.0*app.width)
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
         orientation: 'vertical'
         spacing: 0
         canvas:
@@ -54,22 +54,22 @@ Builder.load_string("""
         # Header box    
         BoxLayout:
             size_hint: (None, None)
-            height: dp(0.333333333333*app.height)
-            width: dp(1.0*app.width)
-            padding:[dp(0.0375)*app.width, dp(0.0625)*app.height, dp(0.0375)*app.width, dp(0.0375)*app.height]
-            spacing:0.0375*app.width
+            height: app.get_scaled_height(160.0)
+            width: app.get_scaled_width(800.0)
+            padding: app.get_scaled_tuple([30.0, 30.0, 30.0, 18.0])
+            spacing: app.get_scaled_width(30.0)
             orientation: 'horizontal'
 
             # Version labels box
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.233333333333*app.height)
-                width: dp(0.7475*app.width)
-                padding:[0, 0, 0, dp(0.025)*app.height]
+                height: app.get_scaled_height(112.0)
+                width: app.get_scaled_width(598.0)
+                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 12.0])
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.7475*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(598.0)
                     orientation: "horizontal"
                     canvas:
                         Color:
@@ -81,8 +81,8 @@ Builder.load_string("""
                     # Version labels:
                     BoxLayout:
                         orientation: 'horizontal'
-                        height: dp(0.208333333333*app.height)
-                        width: dp(0.46875*app.width)
+                        height: app.get_scaled_height(100.0)
+                        width: app.get_scaled_width(375.0)
                         Image:
                             size_hint_x: 0.35
                             source: "./asmcnc/skavaUI/img/qr_release_notes.png"
@@ -91,7 +91,7 @@ Builder.load_string("""
                             LabelBase:
                                 id: current_version_label
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 valign: "bottom"
                                 text_size: self.size
@@ -99,7 +99,7 @@ Builder.load_string("""
                             LabelBase:
                                 id: sw_version_label
                                 color: 0,0,0,1
-                                font_size: 0.02875*app.width
+                                font_size: app.get_scaled_width(23.0)
                                 markup: True
                                 text_size: self.size
 
@@ -107,30 +107,30 @@ Builder.load_string("""
                                 id: find_release_notes_label
                                 size_hint_y: 1.1
                                 color: 0,0,0,1
-                                font_size: 0.01625*app.width
+                                font_size: app.get_scaled_width(13.0)
                                 markup: True
                                 valign: "middle"
                                 text_size: self.size
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.208333333333*app.height)
-                        width: dp(0.27875*app.width)
+                        height: app.get_scaled_height(100.0)
+                        width: app.get_scaled_width(223.0)
                         orientation: "horizontal"
-                        padding:[0, 0, dp(0.0375)*app.width, 0]
+                        padding: app.get_scaled_tuple([0.0, 0.0, 30.0, 0.0])
 
                         BoxLayout: 
                             size_hint: (None, None) 
                             orientation: "vertical"
-                            height: dp(0.208333333333*app.height)
-                            width: dp(0.06125*app.width)
-                            padding:[dp(0.00625)*app.width, dp(0.0729166666667)*app.height, dp(0.01875)*app.width, dp(0.0729166666667)*app.height]
+                            height: app.get_scaled_height(100.0)
+                            width: app.get_scaled_width(49.0)
+                            padding: app.get_scaled_tuple([5.0, 35.0, 15.0, 35.0])
                             Button:
                                 id: refresh_button
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 size_hint: (None,None)
-                                height: dp(0.0625*app.height)
-                                width: dp(0.03625*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(29.0)
                                 background_color: hex('#F4433600')
                                 center: self.parent.center
                                 pos: self.parent.pos
@@ -149,7 +149,7 @@ Builder.load_string("""
                         LabelBase: 
                             id: latest_software_version_label
                             color: 0,0,0,1
-                            font_size: 0.0225*app.width
+                            font_size: app.get_scaled_width(18.0)
                             markup: True
                             halign: "center"
                             valign: "center"
@@ -161,13 +161,13 @@ Builder.load_string("""
             # Exit button
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.233333333333*app.height)
-                width: dp(0.14*app.width)
+                height: app.get_scaled_height(112.0)
+                width: app.get_scaled_width(112.0)
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint: (None,None)
-                    height: dp(0.233333333333*app.height)
-                    width: dp(0.14*app.width)
+                    height: app.get_scaled_height(112.0)
+                    width: app.get_scaled_width(112.0)
                     background_color: hex('#F4433600')
                     center: self.parent.center
                     pos: self.parent.pos
@@ -186,18 +186,18 @@ Builder.load_string("""
         # Body box
         BoxLayout:
             size_hint: (None, None)
-            height: dp(0.666666666667*app.height)
-            width: dp(1.0*app.width)
-            padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, dp(0.0625)*app.height]
-            spacing:0.0375*app.width
+            height: app.get_scaled_height(320.0)
+            width: app.get_scaled_width(800.0)
+            padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 30.0])
+            spacing: app.get_scaled_width(30.0)
             orientation: 'horizontal'
             
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.604166666667*app.height)
-                width: dp(0.44375*app.width)    
+                height: app.get_scaled_height(290.0)
+                width: app.get_scaled_width(355.0)
                 orientation: "vertical"  
-                padding:[dp(0.0375)*app.width, dp(0.0625)*app.height, dp(0.0375)*app.width, dp(0.0625)*app.height]
+                padding: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
                 spacing: 0
                 canvas:
                     Color:
@@ -208,13 +208,13 @@ Builder.load_string("""
                         
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.0416666666667*app.height)
-                    width: dp(0.36875*app.width)
-                    # padding: [0,5,0,0]
+                    height: app.get_scaled_height(20.0)
+                    width: app.get_scaled_width(295.0)
+                    # padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
                     LabelBase: 
                         id: update_using_wifi_label
                         color: 0,0,0,1
-                        font_size: 0.0225*app.width
+                        font_size: app.get_scaled_width(18.0)
                         markup: True
                         halign: "left"
                         valign: "middle"
@@ -224,13 +224,13 @@ Builder.load_string("""
                     
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.36875*app.width)
-                    # padding: [0,5,0,0]
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(295.0)
+                    # padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
                     LabelBase:
                         id: update_using_wifi_instructions_label
                         color: 0,0,0,1
-                        font_size: 0.02*app.width
+                        font_size: app.get_scaled_width(16.0)
                         markup: True
                         halign: "left"
                         valign: "top"
@@ -240,13 +240,13 @@ Builder.load_string("""
 
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.229166666667*app.height)
-                    width: dp(0.36875*app.width)                    
+                    height: app.get_scaled_height(110.0)
+                    width: app.get_scaled_width(295.0)
                     BoxLayout:
                         size_hint: (None, None)
-                        height: dp(0.229166666667*app.height)
-                        width: dp(0.18125*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0520833333333)*app.height, dp(0.08125)*app.width, dp(0.0520833333333)*app.height]
+                        height: app.get_scaled_height(110.0)
+                        width: app.get_scaled_width(145.0)
+                        padding: app.get_scaled_tuple([20.0, 25.0, 65.0, 25.0])
                         Image:
                             id: wifi_image
                             source: root.wifi_on
@@ -257,19 +257,19 @@ Builder.load_string("""
 
                     BoxLayout:
                         size_hint: (None, None)
-                        height: dp(0.229166666667*app.height)
-                        width: dp(0.1875*app.width)
+                        height: app.get_scaled_height(110.0)
+                        width: app.get_scaled_width(150.0)
                         Button:
                             id: wifi_update_button
                             background_normal: "./asmcnc/apps/SWupdater_app/img/update_button.png"
                             background_down: "./asmcnc/apps/SWupdater_app/img/update_button.png"
-                            border: [dp(14.5)]*4
+                            border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                             size_hint: (None,None)
-                            width: dp(0.1875*app.width)
-                            height: dp(0.229166666667*app.height)
+                            width: app.get_scaled_width(150.0)
+                            height: app.get_scaled_height(110.0)
                             on_press: root.prep_for_sw_update("WiFi")
                             # text: 'Update'
-                            # font_size: '28sp'
+                            # font_size: app.get_scaled_sp('28sp')
                             color: hex('#f9f9f9ff')
                             markup: True
                             center: self.parent.center
@@ -277,11 +277,11 @@ Builder.load_string("""
                         
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.604166666667*app.height)
-                width: dp(0.44375*app.width)
+                height: app.get_scaled_height(290.0)
+                width: app.get_scaled_width(355.0)
                 orientation: "vertical"  
-                padding:[dp(0.0375)*app.width, dp(0.0625)*app.height, dp(0.0375)*app.width, dp(0.0625)*app.height]
-                spacing: 0  
+                padding: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                spacing: 0
                 canvas:
                     Color:
                         rgba: [1,1,1,1]
@@ -291,12 +291,12 @@ Builder.load_string("""
 
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.0416666666667*app.height)
-                    width: dp(0.36875*app.width)
+                    height: app.get_scaled_height(20.0)
+                    width: app.get_scaled_width(295.0)
                     LabelBase:
                         id: update_using_usb_label
                         color: 0,0,0,1
-                        font_size: 0.0225*app.width
+                        font_size: app.get_scaled_width(18.0)
                         markup: True
                         halign: "left"
                         valign: "middle"
@@ -306,12 +306,12 @@ Builder.load_string("""
                     
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.36875*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(295.0)
                     LabelBase:
                         id: update_using_usb_instructions_label
                         color: 0,0,0,1
-                        font_size: 0.02*app.width
+                        font_size: app.get_scaled_width(16.0)
                         markup: True
                         halign: "left"
                         valign: "top"
@@ -321,14 +321,14 @@ Builder.load_string("""
 
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.229166666667*app.height)
-                    width: dp(0.36875*app.width)
+                    height: app.get_scaled_height(110.0)
+                    width: app.get_scaled_width(295.0)
                     orientation: "horizontal"
                     BoxLayout:
                         size_hint: (None, None)
-                        height: dp(0.229166666667*app.height)
-                        width: dp(0.18125*app.width)
-                        padding:[0, dp(0.0552083333333)*app.height, dp(0.04)*app.width, dp(0.0552083333333)*app.height]
+                        height: app.get_scaled_height(110.0)
+                        width: app.get_scaled_width(145.0)
+                        padding: app.get_scaled_tuple([0.0, 26.5, 32.0, 26.5])
                         Image:
                             id: usb_image
                             source: root.usb_off
@@ -339,19 +339,19 @@ Builder.load_string("""
 
                     BoxLayout:
                         size_hint: (None, None)
-                        height: dp(0.229166666667*app.height)
-                        width: dp(0.1875*app.width)
+                        height: app.get_scaled_height(110.0)
+                        width: app.get_scaled_width(150.0)
                         Button:
                             id: usb_update_button
                             background_normal: "./asmcnc/apps/SWupdater_app/img/update_button.png"
                             background_down: "./asmcnc/apps/SWupdater_app/img/update_button.png"
-                            border: [dp(14.5)]*4
+                            border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                             size_hint: (None,None)
-                            width: dp(0.1875*app.width)
-                            height: dp(0.229166666667*app.height)
+                            width: app.get_scaled_width(150.0)
+                            height: app.get_scaled_height(110.0)
                             on_press: root.prep_for_sw_update("USB")
                             # text: 'Update'
-                            # font_size: '28sp'
+                            # font_size: app.get_scaled_sp('28sp')
                             color: hex('#f9f9f9ff')
                             markup: True
                             center: self.parent.center

--- a/src/asmcnc/apps/drywall_cutter_app/screen_config_filechooser.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_config_filechooser.py
@@ -49,7 +49,7 @@ Builder.load_string("""
 
     BoxLayout:
         padding: 0
-        spacing: 10
+        spacing: app.get_scaled_width(10.0)
         size: root.size
         pos: root.pos
         orientation: "vertical"
@@ -71,7 +71,7 @@ Builder.load_string("""
                 size_hint_y: 1
                 text: root.filename_selected_label_text
                 markup: True
-                font_size: '18sp'   
+                font_size: app.get_scaled_sp('18sp')
                 valign: 'middle'
                 halign: 'center'
                 bold: True
@@ -103,13 +103,13 @@ Builder.load_string("""
                         size_hint_y: None
                         height: self.texture_size[1]
                         text_size: self.width, None
-                        padding: 10, 10
+                        padding: app.get_scaled_tuple([10.0, 10.0])
                         markup: True
 
 
         BoxLayout:
             size_hint_y: None
-            height: 100
+            height: app.get_scaled_height(100.0)
 
             ToggleButton:
                 id: toggle_view_button
@@ -117,7 +117,7 @@ Builder.load_string("""
                 on_press: root.switch_view()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -134,7 +134,7 @@ Builder.load_string("""
                 on_press: root.switch_sort()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -150,7 +150,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     
@@ -159,7 +159,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     
@@ -174,7 +174,7 @@ Builder.load_string("""
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -195,7 +195,7 @@ Builder.load_string("""
                     root.delete_popup(file_selection = 'all')
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -215,7 +215,7 @@ Builder.load_string("""
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -235,7 +235,7 @@ Builder.load_string("""
                     root.load_config_and_return_to_dwt()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:

--- a/src/asmcnc/apps/drywall_cutter_app/screen_config_filesaver.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_config_filesaver.py
@@ -43,7 +43,7 @@ Builder.load_string("""
 
     BoxLayout:
         padding: 0
-        spacing: 10
+        spacing: app.get_scaled_width(10.0)
         size: root.size
         pos: root.pos
         orientation: "vertical"
@@ -60,11 +60,11 @@ Builder.load_string("""
                 text: root.filename_selected_label_text
                 markup: True
                 color: hex('#FFFFFFFF')
-                font_size: '18sp'   
+                font_size: app.get_scaled_sp('18sp')
                 valign: 'middle'
                 halign: 'center'
                 bold: True
-                padding: 10, 10
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 multiline: False
                 size_hint_x: 1
 
@@ -95,13 +95,13 @@ Builder.load_string("""
                         size_hint_y: None
                         height: self.texture_size[1]
                         text_size: self.width, None
-                        padding: 10, 10
+                        padding: app.get_scaled_tuple([10.0, 10.0])
                         markup: True
 
 
         BoxLayout:
             size_hint_y: None
-            height: 100
+            height: app.get_scaled_height(100.0)
 
             ToggleButton:
                 id: toggle_view_button
@@ -109,7 +109,7 @@ Builder.load_string("""
                 on_press: root.switch_view()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -126,7 +126,7 @@ Builder.load_string("""
                 on_press: root.switch_sort()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -142,7 +142,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     
@@ -151,7 +151,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     
@@ -160,7 +160,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
             Button:
@@ -168,7 +168,7 @@ Builder.load_string("""
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
             Button:
@@ -181,7 +181,7 @@ Builder.load_string("""
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -201,7 +201,7 @@ Builder.load_string("""
                     root.save_config_and_return_to_dwt()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 25
+                    padding: app.get_scaled_width(25.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:

--- a/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
@@ -38,8 +38,8 @@ Builder.load_string("""
         orientation: 'vertical'
         BoxLayout:
             orientation: 'horizontal'
-            padding: dp(5)
-            spacing: dp(10)
+            padding: app.get_scaled_width(5.0)
+            spacing: app.get_scaled_width(10.0)
             ImageButton:
                 source: './asmcnc/apps/drywall_cutter_app/img/home_button.png'
                 allow_stretch: True
@@ -106,19 +106,19 @@ Builder.load_string("""
         BoxLayout:
             size_hint_y: 5
             orientation: 'horizontal'
-            padding: dp(5)
-            spacing: dp(10)
+            padding: app.get_scaled_width(5.0)
+            spacing: app.get_scaled_width(10.0)
             BoxLayout:
                 id: shape_display_container
                 size_hint_x: 55
             BoxLayout:
                 size_hint_x: 23
                 orientation: 'vertical'
-                spacing: dp(10)
+                spacing: app.get_scaled_width(10.0)
                 BoxLayout:
                     id: xy_move_container
                     size_hint_y: 31
-                    padding: [dp(0), dp(30)]
+                    padding: app.get_scaled_tuple([0.0, 30.0])
                     canvas.before:
                         Color:
                             rgba: hex('#FFFFFFFF')
@@ -128,7 +128,7 @@ Builder.load_string("""
                 BoxLayout:
                     size_hint_y: 7
                     orientation: 'horizontal'
-                    spacing: dp(10)
+                    spacing: app.get_scaled_width(10.0)
                     ImageButton:
                         source: './asmcnc/apps/drywall_cutter_app/img/simulate_button.png'
                         allow_stretch: True

--- a/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
@@ -66,12 +66,12 @@ Builder.load_string("""
 
             Switch:
                 id: unit_switch
-                size: dp(83), dp(32)
+                size: app.get_scaled_tuple([83.0, 32.0])
                 size_hint: (None, None)
                 pos: self.parent.pos[0] + self.parent.size[0] - self.size[0] - dp(9), self.parent.pos[1] + dp(6)
 
             BoxLayout:
-                size: dp(90), dp(40)
+                size: app.get_scaled_tuple([90.0, 40.0])
                 size_hint: (None, None)
 
                 canvas.before:
@@ -83,7 +83,7 @@ Builder.load_string("""
 
                 FloatInput:
                     id: d_input
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'center'
                     multiline: False
                     size: self.parent.size
@@ -92,7 +92,7 @@ Builder.load_string("""
 
             Label:
                 text: 'D'
-                font_size: dp(25)
+                font_size: app.get_scaled_width(25.0)
                 pos: d_input.pos[0] - self.width - 2.5, d_input.pos[1] + dp(3)
                 opacity: d_input.opacity
                 color: 0,0,0,1
@@ -101,7 +101,7 @@ Builder.load_string("""
 
             Label:
                 id: d_input_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: d_input.size
                 size_hint: (None, None)
                 pos: d_input.pos[0], d_input.pos[1] - dp(30)
@@ -110,7 +110,7 @@ Builder.load_string("""
                 opacity: 0
 
             BoxLayout:
-                size: dp(90), dp(40)
+                size: app.get_scaled_tuple([90.0, 40.0])
                 size_hint: (None, None)
 
                 canvas.before:
@@ -122,7 +122,7 @@ Builder.load_string("""
 
                 FloatInput:
                     id: l_input
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'center'
                     multiline: False
                     size: self.parent.size
@@ -131,7 +131,7 @@ Builder.load_string("""
 
             Label:
                 text: 'L'
-                font_size: dp(25)
+                font_size: app.get_scaled_width(25.0)
                 pos: l_input.pos[0] - self.width - 2.5, l_input.pos[1] + dp(3)
                 opacity: l_input.opacity
                 color: 0,0,0,1
@@ -140,7 +140,7 @@ Builder.load_string("""
 
             Label:
                 id: l_input_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: l_input.size
                 size_hint: (None, None)
                 pos: l_input.pos[0], l_input.pos[1] - dp(30)
@@ -149,7 +149,7 @@ Builder.load_string("""
                 opacity: 0
 
             BoxLayout:
-                size: dp(90), dp(40)
+                size: app.get_scaled_tuple([90.0, 40.0])
                 size_hint: (None, None)
 
                 canvas.before:
@@ -161,7 +161,7 @@ Builder.load_string("""
 
                 FloatInput:
                     id: r_input
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'center'
                     multiline: False
                     size: self.parent.size
@@ -170,7 +170,7 @@ Builder.load_string("""
 
             Label:
                 text: 'R'
-                font_size: dp(25)
+                font_size: app.get_scaled_width(25.0)
                 pos: r_input.pos[0] - self.width - 2.5, r_input.pos[1] + dp(3)
                 opacity: r_input.opacity
                 color: 0,0,0,1
@@ -179,7 +179,7 @@ Builder.load_string("""
 
             Label:
                 id: r_input_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: r_input.size
                 size_hint: (None, None)
                 pos: r_input.pos[0], r_input.pos[1] - dp(30)
@@ -188,7 +188,7 @@ Builder.load_string("""
                 opacity: 0
 
             BoxLayout:
-                size: dp(90), dp(40)
+                size: app.get_scaled_tuple([90.0, 40.0])
                 size_hint: (None, None)
 
                 canvas.before:
@@ -200,7 +200,7 @@ Builder.load_string("""
 
                 FloatInput:
                     id: x_input
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'center'
                     multiline: False
                     size: self.parent.size
@@ -209,7 +209,7 @@ Builder.load_string("""
 
             Label:
                 text: 'X'
-                font_size: dp(25)
+                font_size: app.get_scaled_width(25.0)
                 pos: x_input.pos[0] - self.width - 2.5, x_input.pos[1] + dp(3)
                 opacity: x_input.opacity
                 color: 0,0,0,1
@@ -218,7 +218,7 @@ Builder.load_string("""
 
             Label:
                 id: x_input_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: x_input.size
                 size_hint: (None, None)
                 pos: x_input.pos[0], x_input.pos[1] - dp(30)
@@ -227,7 +227,7 @@ Builder.load_string("""
                 opacity: 0
 
             BoxLayout:
-                size: dp(90), dp(40)
+                size: app.get_scaled_tuple([90.0, 40.0])
                 size_hint: (None, None)
 
                 canvas.before:
@@ -239,7 +239,7 @@ Builder.load_string("""
 
                 FloatInput:
                     id: y_input
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'center'
                     multiline: False
                     size: self.parent.size
@@ -248,7 +248,7 @@ Builder.load_string("""
 
             Label:
                 text: 'Y'
-                font_size: dp(25)
+                font_size: app.get_scaled_width(25.0)
                 pos: y_input.pos[0] - self.width - 2.5, y_input.pos[1] + dp(3)
                 opacity: y_input.opacity
                 color: 0,0,0,1
@@ -257,7 +257,7 @@ Builder.load_string("""
 
             Label:
                 id: y_input_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: y_input.size
                 size_hint: (None, None)
                 pos: y_input.pos[0], y_input.pos[1] - dp(30)
@@ -267,8 +267,8 @@ Builder.load_string("""
 
             Label:
                 id: x_datum_label
-                font_size: dp(25)
-                size: dp(150), dp(40)
+                font_size: app.get_scaled_width(25.0)
+                size: app.get_scaled_tuple([150.0, 40.0])
                 size_hint: (None, None)
                 text: 'X:'
                 color: 0,0,0,1
@@ -276,7 +276,7 @@ Builder.load_string("""
 
             Label:
                 id: x_datum_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: x_datum_label.size
                 size_hint: (None, None)
                 pos: x_datum_label.pos[0], x_datum_label.pos[1] - dp(20)
@@ -286,15 +286,15 @@ Builder.load_string("""
 
             Label:
                 id: y_datum_label
-                font_size: dp(25)
-                size: dp(150), dp(40)
+                font_size: app.get_scaled_width(25.0)
+                size: app.get_scaled_tuple([150.0, 40.0])
                 size_hint: (None, None)
                 text: 'Y:'
                 color: 0,0,0,1
 
             Label:
                 id: y_datum_validation_label
-                font_size: dp(15)
+                font_size: app.get_scaled_width(15.0)
                 size: y_datum_label.size
                 size_hint: (None, None)
                 pos: y_datum_label.pos[0], y_datum_label.pos[1] - dp(35)
@@ -329,7 +329,7 @@ Builder.load_string("""
             # TextInput instead of Label, as there is no way to left align a Label in a FloatLayout
             TextInput:
                 id: config_name_label
-                font_size: dp(20)
+                font_size: app.get_scaled_width(20.0)
                 size: self.parent.width, dp(40)
                 size_hint: (None, None)
                 pos: self.parent.pos[0] + dp(5), self.parent.size[1] - self.height + dp(5)
@@ -340,7 +340,7 @@ Builder.load_string("""
 
             Label:
                 id: machine_state_label
-                font_size: dp(20)
+                font_size: app.get_scaled_width(20.0)
                 size: self.texture_size[0], dp(40)
                 size_hint: (None, None)
                 pos: self.parent.pos[0] + self.parent.size[0] - self.texture_size[0] - dp(10), self.parent.size[1] - self.height + dp(5)

--- a/src/asmcnc/apps/drywall_cutter_app/widget_xy_move_drywall.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_xy_move_drywall.py
@@ -19,7 +19,7 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        spacing: 10
+        spacing: app.get_scaled_width(10.0)
         
         GridLayout:
             cols: 3
@@ -29,7 +29,7 @@ Builder.load_string("""
             height: self.width
     
             BoxLayout:
-                padding:dp(10)
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
                 Button:
@@ -60,7 +60,7 @@ Builder.load_string("""
                     root.buttonJogXY('X+')
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:dp(0)
+                    padding: 0
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -71,7 +71,7 @@ Builder.load_string("""
                         allow_stretch: True
     
             BoxLayout:
-                padding:dp(10)
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
                 Button:
@@ -101,7 +101,7 @@ Builder.load_string("""
                     root.buttonJogXY('Y+')
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:dp(0)
+                    padding: 0
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -118,7 +118,7 @@ Builder.load_string("""
                     root.jogModeCycled()
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:dp(0)
+                    padding: 0
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -138,7 +138,7 @@ Builder.load_string("""
                     root.buttonJogXY('Y-')
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:dp(0)
+                    padding: 0
                     size: self.parent.size
                     pos: self.parent.pos  
                     Image:
@@ -148,7 +148,7 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             BoxLayout:
-                padding: 15
+                padding: app.get_scaled_width(15.0)
                 size: self.parent.size
                 pos: self.parent.pos                 
                 id: probe_button_container
@@ -162,7 +162,7 @@ Builder.load_string("""
                     root.buttonJogXY('X-')
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:dp(0)
+                    padding: 0
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -172,7 +172,7 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             BoxLayout:
-                padding:dp(10)
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
                 ToggleButton:

--- a/src/asmcnc/apps/maintenance_app/screen_maintenance.py
+++ b/src/asmcnc/apps/maintenance_app/screen_maintenance.py
@@ -73,15 +73,15 @@ Builder.load_string("""
     TabbedPanel:
         id: tab_panel
         size_hint: (None,None)
-        height: dp(1.0*app.height)
-        width: dp(1.005*app.width)
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(804.0)
         pos: (0, 0)
-        padding:[dp(-0.0025)*app.width, dp(-0.00416666666667)*app.height, dp(-0.0025)*app.width, 0]
-        spacing:[0, dp(-0.00833333333333)*app.height]
+        padding: app.get_scaled_tuple([-2.0, -2.0, -2.0, 0.0])
+        spacing: app.get_scaled_tuple([0.0, -4.0])
         do_default_tab: False
         tab_pos: 'top_left'
-        tab_height: dp(90.0/480.0)*app.height
-        tab_width: dp((710.0/6.0)/800.0)*app.width
+        tab_height: app.get_scaled_height(90.0)
+        tab_width: app.get_scaled_width(118.33)
         on_touch_down: root.on_tab_switch()
 
 
@@ -94,11 +94,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "horizontal" 
-                padding:[dp(0.015)*app.width, dp(0.0208333333333)*app.height, dp(0.015)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.0125*app.width
+                padding: app.get_scaled_tuple([12.0, 10.0, 12.0, 20.0])
+                spacing: app.get_scaled_width(10.0)
                 canvas:
                     Color:
                         rgba: hex('#E5E5E5FF')
@@ -108,15 +108,15 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.75*app.height)
-                    width: dp(0.35*app.width)
-                    spacing:0.0208333333333*app.height
+                    height: app.get_scaled_height(360.0)
+                    width: app.get_scaled_width(280.0)
+                    spacing: app.get_scaled_width(10.0)
                     orientation: "vertical"
                     id: left_panel
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.145833333333*app.height)
-                        width: dp(0.35*app.width)
+                        height: app.get_scaled_height(70.0)
+                        width: app.get_scaled_width(280.0)
                         id: title
                         canvas:
                             Color:
@@ -126,15 +126,15 @@ Builder.load_string("""
                                 pos: self.pos
                         BoxLayout: 
                             size_hint: (None, None)
-                            height: dp(0.145833333333*app.height)
-                            width: dp(0.35*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(70.0)
+                            width: app.get_scaled_width(280.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: 'horizontal'
 
                             LabelBase: 
                                 id: laser_datum_label
                                 color: 0,0,0,1
-                                font_size: dp(0.0325*app.width)
+                                font_size: app.get_scaled_width(26.0)
                                 markup: True
                                 halign: "left"
                                 valign: "middle"
@@ -145,14 +145,14 @@ Builder.load_string("""
 
                             BoxLayout:
                                 size_hint: (None,None)
-                                height: dp(0.145833333333*app.height)
-                                width: dp(0.1875*app.width)
+                                height: app.get_scaled_height(70.0)
+                                width: app.get_scaled_width(150.0)
                                 id: switch_container
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.583333333333*app.height)
-                        width: dp(0.35*app.width)
+                        height: app.get_scaled_height(280.0)
+                        width: app.get_scaled_width(280.0)
                         id: laser_button_container
                         canvas:
                             Color:
@@ -163,16 +163,16 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.75*app.height)
-                    width: dp(0.3375*app.width)
-                    spacing:0.0208333333333*app.height
+                    height: app.get_scaled_height(360.0)
+                    width: app.get_scaled_width(270.0)
+                    spacing: app.get_scaled_width(10.0)
                     orientation: "vertical"
                     id: middle_panel
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.75*app.height)
-                        width: dp(0.3375*app.width)
+                        height: app.get_scaled_height(360.0)
+                        width: app.get_scaled_width(270.0)
                         id: xy_move_container
                         canvas:
                             Color:
@@ -183,8 +183,8 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.75*app.height)
-                    width: dp(0.2625*app.width)
+                    height: app.get_scaled_height(360.0)
+                    width: app.get_scaled_width(210.0)
                     id: z_move_container
                     canvas:
                         Color:
@@ -202,11 +202,11 @@ Builder.load_string("""
             background_down: 'asmcnc/apps/maintenance_app/img/brush_monitor_tab_grey.png'
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "vertical" 
-                padding:[dp(0.0275)*app.width, dp(0.0416666666667)*app.height, dp(0.0275)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([22.0, 20.0, 22.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 canvas:
                     Color:
                         rgba: hex('#E5E5E5FF')
@@ -216,16 +216,16 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.95*app.width)
-                    height: dp(0.520833333333*app.height)
+                    width: app.get_scaled_width(760.0)
+                    height: app.get_scaled_height(250.0)
                     orientation: "horizontal" 
                     padding: 0
-                    spacing:0.025*app.width
+                    spacing: app.get_scaled_width(20.0)
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.520833333333*app.height)
-                        width: dp(0.35*app.width)
+                        height: app.get_scaled_height(250.0)
+                        width: app.get_scaled_width(280.0)
                         id: brush_use_container
                         canvas:
                             Color:
@@ -236,8 +236,8 @@ Builder.load_string("""
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.520833333333*app.height)
-                        width: dp(0.35*app.width)
+                        height: app.get_scaled_height(250.0)
+                        width: app.get_scaled_width(280.0)
                         id: brush_life_container
                         canvas:
                             Color:
@@ -248,8 +248,8 @@ Builder.load_string("""
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.520833333333*app.height)
-                        width: dp(0.2*app.width)
+                        height: app.get_scaled_height(250.0)
+                        width: app.get_scaled_width(160.0)
                         id: brush_save_container
                         canvas:
                             Color:
@@ -260,8 +260,8 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.166666666667*app.height)
-                    width: dp(0.95*app.width)
+                    height: app.get_scaled_height(80.0)
+                    width: app.get_scaled_width(760.0)
                     id: monitor_strip
                     canvas:
                         Color:
@@ -271,14 +271,14 @@ Builder.load_string("""
                             pos: self.pos
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.95*app.width)
-                        padding:[dp(0.0125)*app.width, dp(0.0104166666667)*app.height, dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(760.0)
+                        padding: app.get_scaled_tuple([10.0, 5.0, 5.0, 5.0])
                         orientation: 'horizontal'
                         LabelBase: 
                             id: brush_monitor_label
                             color: 0,0,0,1
-                            font_size: dp(0.0275*app.width)
+                            font_size: app.get_scaled_width(22.0)
                             markup: True
                             halign: "left"
                             valign: "middle"
@@ -288,8 +288,8 @@ Builder.load_string("""
 
                         BoxLayout:
                             size_hint: (None,None)
-                            height: dp(0.145833333333*app.height)
-                            width: dp(0.75*app.width)
+                            height: app.get_scaled_height(70.0)
+                            width: app.get_scaled_width(600.0)
                             id: brush_monitor_container
 
         # Spindle cooldown settings
@@ -301,11 +301,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "vertical" 
-                padding:[dp(0.0275)*app.width, dp(0.0416666666667)*app.height, dp(0.0275)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([22.0, 20.0, 22.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 canvas:
                     Color:
                         rgba: hex('#E5E5E5FF')
@@ -315,16 +315,16 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.95*app.width)
-                    height: dp(0.729166666667*app.height)
+                    width: app.get_scaled_width(760.0)
+                    height: app.get_scaled_height(350.0)
                     orientation: "horizontal" 
-                    padding: dp(0)
-                    spacing:dp(0.025)*app.width
+                    padding: 0
+                    spacing: app.get_scaled_width(20.0)
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.729166666667*app.height)
-                        width: dp(0.95*app.width)
+                        height: app.get_scaled_height(350.0)
+                        width: app.get_scaled_width(760.0)
                         id: spindle_settings_container
 
         # Z Misc settings (probe plate and time since lead screw lubrication)
@@ -335,11 +335,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "horizontal" 
-                padding:[dp(0.0275)*app.width, dp(0.0416666666667)*app.height, dp(0.0275)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.025*app.width
+                padding: app.get_scaled_tuple([22.0, 20.0, 22.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 canvas:
                     Color:
                         rgba: hex('#E5E5E5FF')
@@ -349,16 +349,16 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.725*app.width)
-                    height: dp(0.729166666667*app.height)
+                    width: app.get_scaled_width(580.0)
+                    height: app.get_scaled_height(350.0)
                     orientation: "vertical" 
-                    padding: dp(0)
-                    spacing:dp(0.0416666666667)*app.height
+                    padding: 0
+                    spacing: app.get_scaled_width(20.0)
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.270833333333*app.height)
-                        width: dp(0.725*app.width)
+                        height: app.get_scaled_height(130.0)
+                        width: app.get_scaled_width(580.0)
                         id: touchplate_offset_container
                         canvas:
                             Color:
@@ -369,8 +369,8 @@ Builder.load_string("""
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.416666666667*app.height)
-                        width: dp(0.725*app.width)
+                        height: app.get_scaled_height(200.0)
+                        width: app.get_scaled_width(580.0)
                         id: z_lubrication_reminder_container
                         canvas:
                             Color:
@@ -381,8 +381,8 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.729166666667*app.height)
-                    width: dp(0.2*app.width)
+                    height: app.get_scaled_height(350.0)
+                    width: app.get_scaled_width(160.0)
                     id: z_misc_save_container
                     canvas:
                         Color:
@@ -400,11 +400,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "vertical" 
-                padding:[dp(0.0275)*app.width, dp(0.0416666666667)*app.height, dp(0.0275)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([22.0, 20.0, 22.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 canvas:
                     Color:
                         rgba: color_provider.get_rgba("grey")
@@ -414,8 +414,8 @@ Builder.load_string("""
 
                 BoxLayout: 
                     id: general_settings_container
-                    height: dp(0.729166666667*app.height)
-                    width: dp(0.95*app.width)
+                    height: app.get_scaled_height(350.0)
+                    width: app.get_scaled_width(760.0)
                     canvas:
                         Color:
                             rgba: color_provider.get_rgba("white")
@@ -435,11 +435,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.005*app.width)
-                height: dp(0.8125*app.height)
+                width: app.get_scaled_width(804.0)
+                height: app.get_scaled_height(390.0)
                 orientation: "vertical" 
-                padding:[dp(0.0275)*app.width, dp(0.0416666666667)*app.height, dp(0.0275)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([22.0, 20.0, 22.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 canvas:
                     Color:
                         rgba: hex('#E5E5E5FF')
@@ -449,8 +449,8 @@ Builder.load_string("""
 
                 BoxLayout: 
                     id: spindle_health_check_container
-                    height: dp(0.729166666667*app.height)
-                    width: dp(0.95*app.width)
+                    height: app.get_scaled_height(350.0)
+                    width: app.get_scaled_width(760.0)
                     canvas:
                         Color:
                             rgba: 1,1,1,1
@@ -462,10 +462,10 @@ Builder.load_string("""
         size_hint: (None,None)
         pos: (dp(710.0/800.0)*app.width, dp(390.0/480.0)*app.height + (4 if app.height == 768 else 0))
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint: (None,None)
-            height: dp(0.1875*app.height)
-            width: dp(0.1125*app.width)
+            height: app.get_scaled_height(90.0)
+            width: app.get_scaled_width(90.0)
             background_color: [0,0,0,0]
             center: self.parent.center
             pos: self.parent.pos

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_life.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_life.py
@@ -24,19 +24,19 @@ Builder.load_string("""
     
     BoxLayout:
         size_hint: (None, None)
-        height: dp(0.520833333333*app.height)
-        width: dp(0.35*app.width)
+        height: app.get_scaled_height(250.0)
+        width: app.get_scaled_width(280.0)
         pos: self.parent.pos
         orientation: 'vertical'
-        padding:[dp(0.016625)*app.width, dp(0.0208333333333)*app.height, dp(0.016625)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([13.3, 10.0, 13.3, 10.0])
+        spacing: app.get_scaled_width(10.0)
 
         BoxLayout: 
             orientation: 'vertical'
-            spacing:dp(0.0104166666667)*app.height
+            spacing: app.get_scaled_width(5.0)
             size_hint: (None, None)
-            height: dp(0.208333333333*app.height)
-            width: dp(0.35*app.width)         
+            height: app.get_scaled_height(100.0)
+            width: app.get_scaled_width(280.0)
 
             LabelBase:
                 id: brush_reminder_label
@@ -50,26 +50,26 @@ Builder.load_string("""
 
             BoxLayout: 
                 orientation: 'horizontal'
-                padding:[0, dp(0.0104166666667)*app.height, 0, 0]
-                spacing:0.0125*app.width
+                padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
+                spacing: app.get_scaled_width(10.0)
                 size_hint: (None, None)
-                height: dp(0.110416666667*app.height)
-                width: dp(0.35*app.width) 
+                height: app.get_scaled_height(53.0)
+                width: app.get_scaled_width(280.0)
 
                 # Text input
                 TextInput:
                     id: brush_life
                     size_hint: (None, None)
-                    height: dp(0.104166666667*app.height)
-                    width: dp(0.15*app.width)
-                    font_size: dp(0.035*app.width)
+                    height: app.get_scaled_height(50.0)
+                    width: app.get_scaled_width(120.0)
+                    font_size: app.get_scaled_width(28.0)
                     input_filter: 'int'
                     multiline: False
 
                 LabelBase: 
                     id: hours_label
                     color: 0,0,0,1
-                    font_size: dp(0.035*app.width)
+                    font_size: app.get_scaled_width(28.0)
                     markup: True
                     halign: "left"
                     valign: "middle"
@@ -79,21 +79,21 @@ Builder.load_string("""
         GridLayout:
             cols: 2
             rows: 1
-            spacing:0.016625*app.width
+            spacing: app.get_scaled_width(13.3)
             size_hint: (None, None)
-            height: dp(0.25*app.height)
-            width: dp(0.316625*app.width)
+            height: app.get_scaled_height(120.0)
+            width: app.get_scaled_width(253.3)
 
             BoxLayout: 
                 size: self.parent.size
                 pos: self.parent.pos
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: restore_button
                     on_press: root.restore()
                     size_hint: (None,None)
-                    height: dp(0.25*app.height)
-                    width: dp(0.15*app.width)
+                    height: app.get_scaled_height(120.0)
+                    width: app.get_scaled_width(120.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos
@@ -112,12 +112,12 @@ Builder.load_string("""
                 size: self.parent.size
                 pos: self.parent.pos
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: reset_120
                     on_press: root.reset_to_120()
                     size_hint: (None,None)
-                    height: dp(0.25*app.height)
-                    width: dp(0.15*app.width)
+                    height: app.get_scaled_height(120.0)
+                    width: app.get_scaled_width(120.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_monitor.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_monitor.py
@@ -35,7 +35,7 @@ Builder.load_string("""
     LabelBase: 
         id: percentage
         color: 1,1,1,1
-        font_size: dp(0.0625*app.width)
+        font_size: app.get_scaled_width(50.0)
         markup: True
         halign: "right"
         valign: "middle"

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_save.py
@@ -19,9 +19,9 @@ Builder.load_string(
         orientation: 'vertical'
 
         BoxLayout:
-            padding:[dp(0.0625)*app.width, dp(0.0625)*app.height]
+            padding: app.get_scaled_tuple([50.0, 30.0])
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 on_press: root.get_info()
                 background_color: [0,0,0,0]
                 BoxLayout:
@@ -36,9 +36,9 @@ Builder.load_string(
 
         BoxLayout:
             size_hint_y: 1.2
-            padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+            padding: app.get_scaled_tuple([20.0, 10.0])
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 on_press: root.save()
                 background_color: [0,0,0,0]
                 BoxLayout:

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_brush_use.py
@@ -24,19 +24,19 @@ Builder.load_string("""
     
     BoxLayout:
         size_hint: (None, None)
-        height: dp(0.520833333333*app.height)
-        width: dp(0.35*app.width)
+        height: app.get_scaled_height(250.0)
+        width: app.get_scaled_width(280.0)
         pos: self.parent.pos
         orientation: 'vertical'
-        padding:[dp(0.016625)*app.width, dp(0.0208333333333)*app.height, dp(0.016625)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([13.3, 10.0, 13.3, 10.0])
+        spacing: app.get_scaled_width(10.0)
 
         BoxLayout: 
             orientation: 'vertical'
-            spacing:dp(0.0104166666667)*app.height
+            spacing: app.get_scaled_width(5.0)
             size_hint: (None, None)
-            height: dp(0.208333333333*app.height)
-            width: dp(0.35*app.width)         
+            height: app.get_scaled_height(100.0)
+            width: app.get_scaled_width(280.0)
 
             LabelBase:
                 id: brush_use_label
@@ -50,26 +50,26 @@ Builder.load_string("""
 
             BoxLayout: 
                 orientation: 'horizontal'
-                padding:[0, dp(0.0104166666667)*app.height, 0, 0]
-                spacing:0.0125*app.width
+                padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
+                spacing: app.get_scaled_width(10.0)
                 size_hint: (None, None)
-                height: dp(0.110416666667*app.height)
-                width: dp(0.35*app.width) 
+                height: app.get_scaled_height(53.0)
+                width: app.get_scaled_width(280.0)
 
                 # Text input
                 TextInput:
                     id: brush_use
                     size_hint: (None, None)
-                    height: dp(0.104166666667*app.height)
-                    width: dp(0.15*app.width)
-                    font_size: dp(0.035*app.width)
+                    height: app.get_scaled_height(50.0)
+                    width: app.get_scaled_width(120.0)
+                    font_size: app.get_scaled_width(28.0)
                     input_filter: 'int'
                     multiline: False
 
                 LabelBase:
                     id: hours_label
                     color: 0,0,0,1
-                    font_size: dp(0.035*app.width)
+                    font_size: app.get_scaled_width(28.0)
                     markup: True
                     halign: "left"
                     valign: "middle"
@@ -79,21 +79,21 @@ Builder.load_string("""
         GridLayout:
             cols: 2
             rows: 1
-            spacing:0.016625*app.width
+            spacing: app.get_scaled_width(13.3)
             size_hint: (None, None)
-            height: dp(0.25*app.height)
-            width: dp(0.316625*app.width)
+            height: app.get_scaled_height(120.0)
+            width: app.get_scaled_width(253.3)
 
             BoxLayout: 
                 size: self.parent.size
                 pos: self.parent.pos
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: restore_button
                     on_press: root.restore()
                     size_hint: (None,None)
-                    height: dp(0.25*app.height)
-                    width: dp(0.15*app.width)
+                    height: app.get_scaled_height(120.0)
+                    width: app.get_scaled_width(120.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos
@@ -112,12 +112,12 @@ Builder.load_string("""
                 size: self.parent.size
                 pos: self.parent.pos
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: reset_0
                     on_press: root.reset_to_0()
                     size_hint: (None,None)
-                    height: dp(0.25*app.height)
-                    width: dp(0.15*app.width)
+                    height: app.get_scaled_height(120.0)
+                    width: app.get_scaled_width(120.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_general_settings.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_general_settings.py
@@ -15,7 +15,7 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos
         orientation: 'vertical'
-        padding: [dp(0.025)*app.width, 0]
+        padding: app.get_scaled_tuple([20.0, 0.0])
 
         BoxLayout:
             size_hint_y: 0.4
@@ -28,7 +28,7 @@ Builder.load_string("""
                 Label:
                     id: dust_shoe_title_label
                     color: color_provider.get_rgba("black")
-                    font_size: str(0.03*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('24.0sp')
                     halign: "left"
                     markup: True
                     text_size: self.size
@@ -36,13 +36,13 @@ Builder.load_string("""
                 Label:
                     id: dust_shoe_info_label
                     color: color_provider.get_rgba("black")
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: "left"
                     markup: True
                     text_size: self.size
 
             BoxLayout:
-                padding: [dp(0.15)*app.width, 0, 0, 0]
+                padding: app.get_scaled_tuple([120.0, 0.0, 0.0, 0.0])
 
                 Switch:
                     id: dust_shoe_switch

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_laser_buttons.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_laser_buttons.py
@@ -28,8 +28,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos
         orientation: 'vertical'
-        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([10.0, 10.0])
+        spacing: app.get_scaled_width(10.0)
         
         GridLayout:
             cols: 2
@@ -54,11 +54,11 @@ Builder.load_string(
                 size: self.parent.size
                 pos: self.parent.pos 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: reset_button
                     size_hint: (None,None)
-                    height: dp(0.28125*app.height)
-                    width: dp(0.165*app.width)
+                    height: app.get_scaled_height(135.0)
+                    width: app.get_scaled_width(132.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos
@@ -78,11 +78,11 @@ Builder.load_string(
                 size: self.parent.size
                 pos: self.parent.pos 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: save_button
                     size_hint: (None,None)
-                    height: dp(0.28125*app.height)
-                    width: dp(0.165*app.width)
+                    height: app.get_scaled_height(135.0)
+                    width: app.get_scaled_width(132.0)
                     background_color: [0,0,0,0]
                     center: self.parent.center
                     pos: self.parent.pos

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_laser_switch.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_laser_switch.py
@@ -17,24 +17,24 @@ Builder.load_string(
     BoxLayout:
     
         size_hint: (None,None)
-        height: dp(0.145833333333*app.height)
-        width: dp(0.1875*app.width)
+        height: app.get_scaled_height(70.0)
+        width: app.get_scaled_width(150.0)
         pos: self.parent.pos
-        padding:[0, 0, 0, 0]
+        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
         
         GridLayout:
             cols: 2
             rows: 1
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
             size_hint: (None,None)
-            height: dp(0.145833333333*app.height)
-            width: dp(0.21875*app.width)
+            height: app.get_scaled_height(70.0)
+            width: app.get_scaled_width(175.0)
 
             BoxLayout: 
                 size_hint: (None, None)
                 pos: self.parent.pos
-                height: dp(0.145833333333*app.height)
-                width: dp(0.10625*app.width)
+                height: app.get_scaled_height(70.0)
+                width: app.get_scaled_width(85.0)
                 Switch:
                     id: laser_switch
                     background_color: [0,0,0,0]
@@ -45,9 +45,9 @@ Builder.load_string(
             BoxLayout: 
                 size_hint: (None, None)
                 pos: self.parent.pos
-                height: dp(0.145833333333*app.height)
-                width: dp(0.06875*app.width)
-                padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                height: app.get_scaled_height(70.0)
+                width: app.get_scaled_width(55.0)
+                padding: app.get_scaled_tuple([5.0, 5.0])
                 Image:
                     id: laser_image
                     source: "./asmcnc/apps/maintenance_app/img/laser_on.png"

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_health_check.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_health_check.py
@@ -13,19 +13,19 @@ Builder.load_string("""
 
     BoxLayout: 
         orientation: "horizontal"
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
 
         BoxLayout: 
             orientation: "vertical"
             size_hint_x: 0.88
-            spacing:0.00416666666667*app.height
+            spacing: app.get_scaled_width(2.0)
 
             LabelBase: 
                 id: title_text
                 size_hint_y: 0.15
                 text: "Spindle motor health check"
                 color: [0,0,0,1]
-                font_size: str(0.03*app.width) + 'sp'
+                font_size: app.get_scaled_sp('24.0sp')
                 halign: "left"
                 # valign: "top"
                 markup: True
@@ -36,7 +36,7 @@ Builder.load_string("""
                 size_hint_y: 0.85
                 text: ""
                 color: [0,0,0,1]
-                font_size: str(0.0225*app.width) + 'sp'
+                font_size: app.get_scaled_sp('18.0sp')
                 halign: "left"
                 valign: "top"
                 markup: True
@@ -44,7 +44,7 @@ Builder.load_string("""
 
         BoxLayout: 
             size_hint_x: 0.12
-            padding:[0, 0, 0, dp(0.104166666667)*app.height]
+            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 50.0])
             spacing: 0
             orientation: 'vertical'
 
@@ -56,10 +56,10 @@ Builder.load_string("""
 
             BoxLayout: 
                 size_hint_y: 0.1
-                padding:[dp(0.0125)*app.width, 0, 0, 0]
+                padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
 
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: switch
                     size_hint: (None, None)
                     size: (dp(app.get_scaled_width(64)), dp(app.get_scaled_height(29)))

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_save.py
@@ -20,9 +20,9 @@ Builder.load_string(
         orientation: 'vertical'
 
         BoxLayout:
-            padding:[dp(0.0625)*app.width, dp(0.0625)*app.height]
+            padding: app.get_scaled_tuple([50.0, 30.0])
 	        Button:
-	            font_size: str(0.01875 * app.width) + 'sp'
+	            font_size: app.get_scaled_sp('15.0sp')
 	            on_press: root.get_info()
 	            background_color: [0,0,0,0]
 	            BoxLayout:
@@ -37,9 +37,9 @@ Builder.load_string(
 
         BoxLayout:
             size_hint_y: 1.2
-            padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+            padding: app.get_scaled_tuple([20.0, 10.0])
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 on_press: root.save()
                 background_color: [0,0,0,0]
                 BoxLayout:

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_spindle_settings.py
@@ -23,10 +23,10 @@ Builder.load_string("""
 
     background_normal: ''
     background_color: [1,1,1,1]
-    height: dp(0.0833333333333*app.height)
+    height: app.get_scaled_height(40.0)
     color: 0,0,0,1
     halign: 'left'
-    font_size: str(15.0/800.0*app.width) + 'sp'
+    font_size: app.get_scaled_sp('15.0sp')
     markup: 'True'
 
 <SpindleSettingsWidget>
@@ -52,12 +52,12 @@ Builder.load_string("""
         orientation: 'vertical'
         pos: self.parent.pos
         size: self.parent.size
-        spacing:dp(0.03125)*app.height
+        spacing: app.get_scaled_width(15.0)
 
         BoxLayout:
             size_hint_y: 0.3
             orientation: 'horizontal'
-            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+            padding: app.get_scaled_tuple([5.0, 5.0])
 
             canvas:
                 Color:
@@ -76,7 +76,7 @@ Builder.load_string("""
                 allow_stretch: True
 
             BoxLayout:
-                padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                padding: app.get_scaled_tuple([5.0, 5.0])
 
                 Spinner:
                     id: spindle_brand
@@ -84,7 +84,7 @@ Builder.load_string("""
                     valign: 'middle'
                     markup: True
                     text: 'spinner'
-                    font_size: str(0.0375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('30.0sp')
                     text_size: self.size
                     multiline: False
                     color: 0,0,0,1
@@ -98,16 +98,16 @@ Builder.load_string("""
             orientation: 'horizontal'
             pos: self.parent.pos
             size: self.parent.size
-            spacing:dp(0.0416666666667)*app.height
+            spacing: app.get_scaled_width(20.0)
 
             BoxLayout:
                 orientation: 'vertical'
-                spacing:dp(0.03125)*app.height
+                spacing: app.get_scaled_width(15.0)
 
                 BoxLayout:
                     size_hint_y: 2
                     orientation: 'vertical'
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
 
                     canvas:
                         Color:
@@ -120,7 +120,7 @@ Builder.load_string("""
                         id: cooldown_settings_label
                         size_hint_y: 0.5
                         color: 0,0,0,1
-                        font_size: dp(0.03*app.width)
+                        font_size: app.get_scaled_width(24.0)
                         halign: "left"
                         valign: "middle"
                         markup: True
@@ -130,7 +130,7 @@ Builder.load_string("""
                         orientation: 'horizontal'
 
                         BoxLayout:
-                            padding:[dp(0.01625)*app.width, dp(0.0270833333333)*app.height]
+                            padding: app.get_scaled_tuple([13.0, 13.0])
 
                             Image:
                                 id: spindle_image
@@ -151,7 +151,7 @@ Builder.load_string("""
                             id: rpm_label
                             size_hint_x: 1.5
                             color: 0,0,0,1
-                            font_size: dp(0.0275*app.width)
+                            font_size: app.get_scaled_width(22.0)
                             markup: True
                             halign: "center"
                             valign: "middle"
@@ -164,7 +164,7 @@ Builder.load_string("""
                         orientation: 'horizontal'
 
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
 
                             Image:
                                 id: countdown_image
@@ -187,7 +187,7 @@ Builder.load_string("""
                             id: seconds_label
                             size_hint_x: 1.5
                             color: 0,0,0,1
-                            font_size: dp(0.0275*app.width)
+                            font_size: app.get_scaled_width(22.0)
                             markup: True
                             halign: "center"
                             valign: "middle"
@@ -197,11 +197,11 @@ Builder.load_string("""
 
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing:dp(0.01875)*app.width
+                    spacing: app.get_scaled_width(15.0)
 
                     BoxLayout:
                         orientation: 'horizontal'
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
 
                         canvas:
                             Color:
@@ -219,12 +219,12 @@ Builder.load_string("""
                             allow_stretch: True
 
                         BoxLayout:
-                            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, 0, dp(0.0270833333333)*app.height]
+                            padding: app.get_scaled_tuple([10.0, 10.0, 0.0, 13.0])
 
                             BoxLayout:
                                 size_hint: (None,None)
-                                height: dp(0.075*app.height)
-                                width: dp(0.1875*app.width)
+                                height: app.get_scaled_height(36.0)
+                                width: app.get_scaled_width(150.0)
 
                                 Image:
                                     source: "./asmcnc/apps/maintenance_app/img/stylus_text_logo.png"
@@ -247,7 +247,7 @@ Builder.load_string("""
                         id: spindle_data_container
                         size_hint_x: 0.75
                         orientation: 'horizontal'
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
 
                         canvas:
                             Color:
@@ -259,7 +259,7 @@ Builder.load_string("""
                         LabelBase:
                             id: get_data_label
                             color: 0,0,0,1
-                            font_size: dp(0.03625*app.width)
+                            font_size: app.get_scaled_width(29.0)
                             halign: "center"
                             valign: "middle"
                             text_size: self.size
@@ -269,7 +269,7 @@ Builder.load_string("""
                             size_hint_x: 0.5
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: get_data_button
                                 on_press: root.show_spindle_data_popup()
                                 background_normal: ''
@@ -298,40 +298,40 @@ Builder.load_string("""
             x: cooldown_speed_slider.pos[0]
             y: cooldown_speed_slider.pos[1] - cooldown_speed_slider.size[1] * 0.1
             size_hint: None, None
-            height: dp(0.0625*app.height)
-            width: dp(0.0375*app.width)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             color: hex('#888888ff')
-            font_size: dp(0.01625*app.width)
+            font_size: app.get_scaled_width(13.0)
 
         LabelBase:
             id: max_speed_label
             x: cooldown_speed_slider.pos[0] + cooldown_speed_slider.size[0] * 0.9
             y: cooldown_speed_slider.pos[1] - cooldown_speed_slider.size[1] * 0.1
             size_hint: None, None
-            height: dp(0.0625*app.height)
-            width: dp(0.0375*app.width)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             color: hex('#888888ff')
-            font_size: dp(0.01625*app.width)
+            font_size: app.get_scaled_width(13.0)
 
         LabelBase:
             id: min_time_label
             x: cooldown_time_slider.pos[0]
             y: cooldown_time_slider.pos[1] - cooldown_time_slider.size[1] * 0.1
             size_hint: None, None
-            height: dp(0.0625*app.height)
-            width: dp(0.0375*app.width)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             color: hex('#888888ff')
-            font_size: dp(0.01625*app.width)
+            font_size: app.get_scaled_width(13.0)
 
         LabelBase:
             id: max_time_label
             x: cooldown_time_slider.pos[0] + cooldown_time_slider.size[0] * 0.9
             y: cooldown_time_slider.pos[1] - cooldown_time_slider.size[1] * 0.1
             size_hint: None, None
-            height: dp(0.0625*app.height)
-            width: dp(0.0375*app.width)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             color: hex('#888888ff')
-            font_size: dp(0.01625*app.width)
+            font_size: app.get_scaled_width(13.0)
 
 
 

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_touchplate_offset.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_touchplate_offset.py
@@ -17,17 +17,17 @@ Builder.load_string("""
     
     BoxLayout:
         size_hint: (None, None)
-        height: dp(0.270833333333*app.height)
-        width: dp(0.725*app.width)
+        height: app.get_scaled_height(130.0)
+        width: app.get_scaled_width(580.0)
         pos: self.parent.pos
         orientation: 'vertical'
-        padding:[dp(0.01875)*app.width, dp(0.03125)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([15.0, 15.0])
+        spacing: app.get_scaled_width(10.0)
 
         LabelBase:
             id: touchplate_offset_label
             color: 0,0,0,1
-            font_size: dp(0.03*app.width)
+            font_size: app.get_scaled_width(24.0)
             markup: True
             halign: "left"
             valign: "middle"
@@ -36,18 +36,18 @@ Builder.load_string("""
 
         BoxLayout: 
             orientation: 'horizontal'
-            padding:[0, dp(0.0104166666667)*app.height, 0, 0]
-            spacing:0.0375*app.width
+            padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
+            spacing: app.get_scaled_width(30.0)
             size_hint: (None, None)
-            height: dp(0.125*app.height)
-            width: dp(0.725*app.width) 
+            height: app.get_scaled_height(60.0)
+            width: app.get_scaled_width(580.0)
 
             # Put the image here
             BoxLayout: 
                 size_hint: (None, None)
                 # pos: self.parent.pos
-                height: dp(0.125*app.height)
-                width: dp(0.18125*app.width)
+                height: app.get_scaled_height(60.0)
+                width: app.get_scaled_width(145.0)
 
                 Image:
                     id: touchplate_image
@@ -61,15 +61,15 @@ Builder.load_string("""
             TextInput:
                 id: touchplate_offset
                 size_hint: (None, None)
-                height: dp(0.104166666667*app.height)
-                width: dp(0.15*app.width)
-                font_size: dp(0.035*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(120.0)
+                font_size: app.get_scaled_width(28.0)
                 input_filter: 'float'
                 multiline: False
 
             LabelBase: 
                 color: 0,0,0,1
-                font_size: dp(0.035*app.width)
+                font_size: app.get_scaled_width(28.0)
                 markup: True
                 halign: "left"
                 valign: "middle"

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_xy_move.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_xy_move.py
@@ -21,8 +21,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([10.0, 10.0])
+        spacing: app.get_scaled_width(10.0)
 
         BoxLayout:
             padding: 0
@@ -30,7 +30,7 @@ Builder.load_string(
             pos: self.parent.pos 
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: speed_toggle
                 on_press: root.set_jog_speeds()
                 background_color: 1, 1, 1, 0 
@@ -55,12 +55,12 @@ Builder.load_string(
     
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                               
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -81,12 +81,12 @@ Builder.load_string(
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -106,7 +106,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -125,7 +125,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -146,12 +146,12 @@ Builder.load_string(
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos  
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
@@ -172,7 +172,7 @@ Builder.load_string(
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos 
 """

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_lubrication_reminder.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_lubrication_reminder.py
@@ -20,17 +20,17 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None, None)
-        height: dp(0.416666666667*app.height)
-        width: dp(0.725*app.width)
+        height: app.get_scaled_height(200.0)
+        width: app.get_scaled_width(580.0)
         pos: self.parent.pos
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([20.0, 20.0])
+        spacing: app.get_scaled_width(10.0)
 
         LabelBase:
             id: time_since_screw_lubricated_label
             color: 0,0,0,1
-            font_size: dp(0.03*app.width)
+            font_size: app.get_scaled_width(24.0)
             markup: True
             halign: "left"
             valign: "middle"
@@ -39,18 +39,18 @@ Builder.load_string("""
 
         BoxLayout: 
             orientation: 'horizontal'
-            padding:[0, dp(0.0104166666667)*app.height, 0, 0]
-            spacing:0.0125*app.width
+            padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
+            spacing: app.get_scaled_width(10.0)
             size_hint: (None, None)
-            height: dp(0.3125*app.height)
-            width: dp(0.725*app.width) 
+            height: app.get_scaled_height(150.0)
+            width: app.get_scaled_width(580.0)
 
             # Put the image here
             BoxLayout: 
                 size_hint: (None, None)
                 # pos: self.parent.pos
-                height: dp(0.24375*app.height)
-                width: dp(0.05*app.width)
+                height: app.get_scaled_height(117.0)
+                width: app.get_scaled_width(40.0)
 
                 Image:
                     id: lead_screw_image
@@ -63,12 +63,12 @@ Builder.load_string("""
             # Text input
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.25*app.height)
-                width: dp(0.4375*app.width)
+                height: app.get_scaled_height(120.0)
+                width: app.get_scaled_width(350.0)
                 LabelBase: 
                     id: hours_since_lubrication
                     color: 0,0,0,1
-                    font_size: dp(0.125*app.width)
+                    font_size: app.get_scaled_width(100.0)
                     markup: True
                     halign: "center"
                     valign: "bottom"
@@ -77,15 +77,15 @@ Builder.load_string("""
 
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.25*app.height)
-                width: dp(0.15*app.width)
+                height: app.get_scaled_height(120.0)
+                width: app.get_scaled_width(120.0)
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: reset_0
                     on_press: root.reset_to_0()
                     size_hint: (None,None)
-                    height: dp(0.25*app.height)
-                    width: dp(0.15*app.width)
+                    height: app.get_scaled_height(120.0)
+                    width: app.get_scaled_width(120.0)
                     background_color: [0,0,0,0]
                     BoxLayout:
                         size: self.parent.size

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_misc_save.py
@@ -19,9 +19,9 @@ Builder.load_string(
         orientation: 'vertical'
 
         BoxLayout:
-            padding:[dp(0.0625)*app.width, dp(0.0625)*app.height]
+            padding: app.get_scaled_tuple([50.0, 30.0])
 	        Button:
-	            font_size: str(0.01875 * app.width) + 'sp'
+	            font_size: app.get_scaled_sp('15.0sp')
 	            on_press: root.get_info()
 	            background_color: [0,0,0,0]
 	            BoxLayout:
@@ -36,9 +36,9 @@ Builder.load_string(
 
         BoxLayout:
             size_hint_y: 1.2
-            padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+            padding: app.get_scaled_tuple([20.0, 10.0])
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 on_press: root.save()
                 background_color: [0,0,0,0]
                 BoxLayout:

--- a/src/asmcnc/apps/maintenance_app/widget_maintenance_z_move.py
+++ b/src/asmcnc/apps/maintenance_app/widget_maintenance_z_move.py
@@ -21,12 +21,12 @@ Builder.load_string(
 
         size: self.parent.size
         pos: self.parent.pos      
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-        spacing:0.025*app.width
+        padding: app.get_scaled_tuple([20.0, 20.0])
+        spacing: app.get_scaled_width(20.0)
         orientation: 'horizontal'
         
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             BoxLayout:
@@ -34,11 +34,11 @@ Builder.load_string(
                 id: virtual_z_container
 
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release:
@@ -60,7 +60,7 @@ Builder.load_string(
                         allow_stretch: True   
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -82,14 +82,14 @@ Builder.load_string(
                         allow_stretch: True   
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_press: root.get_info()
                 BoxLayout:
-                    padding:[dp(0.009375)*app.width, dp(0.0416666666667)*app.height, dp(0.040625)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([7.5, 20.0, 32.5, 20.0])
                     size_hint: (None,None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.125*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(100.0)
                     pos: self.parent.pos
                     Image:
                         source: "./asmcnc/apps/shapeCutter_app/img/info_icon.png"

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_1.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_1.py
@@ -18,25 +18,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,22 +187,22 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"
                         
                         LabelBase:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.0225*app.width
+                            font_size: app.get_scaled_width(18.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -214,10 +214,10 @@ Builder.load_string("""
                             orientation: 'horizontal'
                             
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 size_hint: (None,None)
-                                height: dp(0.35*app.height)
-                                width: dp(0.21*app.width)
+                                height: app.get_scaled_height(168.0)
+                                width: app.get_scaled_width(168.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.calibrate()
@@ -235,7 +235,7 @@ Builder.load_string("""
                             LabelBase:
 #                                text: "Click the button below to calibrate if required."
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -245,23 +245,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -277,10 +277,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -294,10 +294,10 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_10.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_10.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,23 +187,23 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.191666666667)*app.height]
-                        spacing:0.0208333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 92.0])
+                        spacing: app.get_scaled_width(10.0)
                         orientation: "vertical"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -213,16 +213,16 @@ Builder.load_string(
                             
                         BoxLayout: #checklist 1
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -233,7 +233,7 @@ Builder.load_string(
                             Label: 
                                 text: "Home SmartBench"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -243,16 +243,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 2
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -263,7 +263,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure spoilboard if required"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -273,16 +273,16 @@ Builder.load_string(
                                 
                         BoxLayout: #checklist 3
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -293,7 +293,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure stock material"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -303,16 +303,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 4
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -323,7 +323,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clamp X beam"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -333,16 +333,16 @@ Builder.load_string(
                                                         
                         BoxLayout: #checklist 5
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 #                             
 #                             BoxLayout: 
 #                                 size_hint: (None,None)
-#                                 height: dp(22)
-#                                 width: dp(30)
-#                                 padding: (0,0,8,0)                        
+#                                 height: app.get_scaled_height(22.0)
+#                                 width: app.get_scaled_width(30.0)
+#                                 padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
 #                                 Image: 
 #                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
 #                                     center_x: self.parent.center_x
@@ -353,7 +353,7 @@ Builder.load_string(
 #                             Label: 
 #                                 text: "Fit cutter"
 #                                 color: 0,0,0,1
-#                                 font_size: 20
+#                                 font_size: app.get_scaled_width(20.0)
 #                                 markup: True
 #                                 halign: "left"
 #                                 valign: "top"
@@ -363,23 +363,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -395,10 +395,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -412,10 +412,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_11.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_11.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,22 +187,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, dp(0.0125)*app.width, dp(0.166666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 10.0, 80.0])
                         orientation: "vertical"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -213,7 +213,7 @@ Builder.load_string(
                         Label:
                             text: root.warning_message
                             color: 0,0,0,1
-                            font_size: 0.0275*app.width
+                            font_size: app.get_scaled_width(22.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -223,23 +223,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0458333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 22.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -255,10 +255,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -272,10 +272,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.208333333333*app.height)
-                            width: dp(0.125*app.width)
+                            height: app.get_scaled_height(100.0)
+                            width: app.get_scaled_width(100.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_12.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_12.py
@@ -21,25 +21,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -50,10 +50,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -64,10 +64,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -80,10 +80,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -96,10 +96,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -112,10 +112,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -131,8 +131,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -146,16 +146,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -165,21 +165,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -190,22 +190,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.21875)*app.width, 0, 0, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([175.0, 0.0, 0.0, 10.0])
                         orientation: "vertical"
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.625*app.height)
-                            width: dp(0.4975*app.width)                       
+                            height: app.get_scaled_height(300.0)
+                            width: app.get_scaled_width(398.0)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_12_1.png"
                                 center_x: self.parent.center_x
@@ -216,23 +216,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -248,10 +248,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -265,10 +265,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_13.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_13.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # text and pics
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_13_1.png"
                                 center_x: self.parent.center_x
@@ -231,23 +231,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_14.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_14.py
@@ -18,25 +18,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # text and pics
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             LabelBase:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string("""
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_14_1.png"
                                 center_x: self.parent.center_x
@@ -231,23 +231,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_15.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_15.py
@@ -20,25 +20,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -49,10 +49,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -63,10 +63,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -79,10 +79,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -95,10 +95,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -111,10 +111,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -130,8 +130,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -145,16 +145,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -164,21 +164,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -189,28 +189,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # text and pics
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -220,38 +220,38 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.5625*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.0375)*app.width, 0, dp(0.05)*app.width, 0]
+                            height: app.get_scaled_height(270.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([30.0, 0.0, 40.0, 0.0])
                                 
                             BoxLayout: # move widget
                                 id: xy_move_container
                                 size_hint: (None,None)
-                                height: dp(0.5625*app.height)
-                                width: dp(0.75625*app.width)
-                                padding:[0, 0, 0, 0]
+                                height: app.get_scaled_height(270.0)
+                                width: app.get_scaled_width(605.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                 orientation: "vertical"                           
                                       
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -267,10 +267,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -284,10 +284,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_16.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_16.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,23 +187,23 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.254166666667)*app.height]
-                        spacing:0.0208333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 122.0])
+                        spacing: app.get_scaled_width(10.0)
                         orientation: "vertical"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -213,16 +213,16 @@ Builder.load_string(
                             
                         BoxLayout: #checklist 1
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -233,7 +233,7 @@ Builder.load_string(
                             Label: 
                                 text: "Home SmartBench"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -243,16 +243,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 2
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -263,7 +263,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure spoilboard if required"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -273,16 +273,16 @@ Builder.load_string(
                                 
                         BoxLayout: #checklist 3
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -293,7 +293,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure stock material"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -303,16 +303,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 4
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -323,7 +323,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clamp X beam"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -333,16 +333,16 @@ Builder.load_string(
                                                         
                         BoxLayout: #checklist 5
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 #                             
 #                             BoxLayout: 
 #                                 size_hint: (None,None)
-#                                 height: dp(22)
-#                                 width: dp(30)
-#                                 padding: (0,0,8,0)                        
+#                                 height: app.get_scaled_height(22.0)
+#                                 width: app.get_scaled_width(30.0)
+#                                 padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
 #                                 Image: 
 #                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
 #                                     center_x: self.parent.center_x
@@ -353,7 +353,7 @@ Builder.load_string(
 #                             Label: 
 #                                 text: "Fit cutter"
 #                                 color: 0,0,0,1
-#                                 font_size: 20
+#                                 font_size: app.get_scaled_width(20.0)
 #                                 markup: True
 #                                 halign: "left"
 #                                 valign: "top"
@@ -363,23 +363,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -395,10 +395,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -412,10 +412,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_17.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_17.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,32 +187,32 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.0125)*app.width, 0, dp(0.03125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([10.0, 0.0, 25.0, 10.0])
                         orientation: "horizontal"
                         BoxLayout: # file load
                             size_hint: (None,None)
-                            height: dp(0.625*app.height)
-                            width: dp(0.375*app.width)
-                            padding:[0, 0, 0, dp(0.208333333333)*app.height]
+                            height: app.get_scaled_height(300.0)
+                            width: app.get_scaled_width(300.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 100.0])
                             orientation: "vertical"       
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.208333333333*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[0, 0, 0, 0]
+                                height: app.get_scaled_height(100.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                 Label: 
                                     text: root.profile_name
                                     color: 0,0,0,1
-                                    font_size: 0.025*app.width
+                                    font_size: app.get_scaled_width(20.0)
                                     markup: True
                                     halign: "center"
                                     valign: "middle"
@@ -221,14 +221,14 @@ Builder.load_string(
                                     pos: self.parent.pos                               
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.18125*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[dp(0.13125)*app.width, 0, dp(0.13125)*app.width, 0]
+                                height: app.get_scaled_height(87.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([105.0, 0.0, 105.0, 0.0])
                                 Button:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     size_hint: (None,None)
-                                    height: dp(0.18125*app.height)
-                                    width: dp(0.1125*app.width)
+                                    height: app.get_scaled_height(87.0)
+                                    width: app.get_scaled_width(90.0)
                                     on_press: root.load_file()
                                     background_color: hex('#F4433600')
                                     BoxLayout:
@@ -241,9 +241,9 @@ Builder.load_string(
                                             allow_stretch: True
                         BoxLayout: # document viewer
                             size_hint: (None,None)
-                            height: dp(0.625*app.height)
-                            width: dp(0.4375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(300.0)
+                            width: app.get_scaled_width(350.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             ScrollView:
                                 size_hint: (None, None)
                                 size: self.parent.size
@@ -254,27 +254,27 @@ Builder.load_string(
                                 RstDocument:
                                     text: root.display_profile
                                     background_color: hex('#FFFFFF')
-                                    base_font_size: str(31.0/800.0*app.width) + 'sp'
+                                    base_font_size: app.get_scaled_sp('31.0sp')
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -290,10 +290,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -307,10 +307,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_18.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_18.py
@@ -21,25 +21,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -50,10 +50,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -64,10 +64,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -80,10 +80,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -96,10 +96,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -112,10 +112,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -131,8 +131,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -146,16 +146,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -165,21 +165,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -190,28 +190,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -221,9 +221,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_18_1.png"
                                 center_x: self.parent.center_x
@@ -234,23 +234,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -266,10 +266,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -283,10 +283,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_19.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_19.py
@@ -20,25 +20,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -49,10 +49,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -63,10 +63,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -79,10 +79,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -95,10 +95,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -111,10 +111,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -130,8 +130,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -145,16 +145,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -164,21 +164,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -189,28 +189,28 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             LabelBase:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -220,9 +220,9 @@ Builder.load_string("""
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_19_1.png"
                                 center_x: self.parent.center_x
@@ -233,23 +233,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -265,10 +265,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -282,10 +282,10 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_2.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_2.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,23 +187,23 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.145833333333)*app.height]
-                        spacing:0.0208333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 70.0])
+                        spacing: app.get_scaled_width(10.0)
                         orientation: "vertical"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -213,16 +213,16 @@ Builder.load_string(
                             
                         BoxLayout: #checklist 1
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -233,7 +233,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clear SmartBench topside"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -243,16 +243,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 2
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -263,7 +263,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clean SmartBench axes"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -273,16 +273,16 @@ Builder.load_string(
                                 
                         BoxLayout: #checklist 3
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -293,7 +293,7 @@ Builder.load_string(
                             Label: 
                                 text: "Empty vacuum bag"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -303,16 +303,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 4
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -323,7 +323,7 @@ Builder.load_string(
                             Label: 
                                 text: "Fit vacuum hose"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -333,16 +333,16 @@ Builder.load_string(
                                                         
                         BoxLayout: #checklist 5
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -353,7 +353,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure power cords"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -363,16 +363,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 6
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_unchecked.png"
                                     center_x: self.parent.center_x
@@ -383,7 +383,7 @@ Builder.load_string(
                             Label: 
                                 text: "Lock Z head connections"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -393,23 +393,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -425,10 +425,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -442,10 +442,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_20.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_20.py
@@ -29,25 +29,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -58,10 +58,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -72,10 +72,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -88,10 +88,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -104,10 +104,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -120,10 +120,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -139,8 +139,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -154,16 +154,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -173,21 +173,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -198,63 +198,63 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
 
                         BoxLayout: #image & text entry box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.71875*app.width)
-                            padding:[0, 0, 0, dp(0.04375)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(575.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 21.0])
                             orientation: "horizontal"
                                     
                             BoxLayout:
                                 orientation: 'vertical'
                                 size_hint: (None,None)
-                                width: dp(0.40625*app.width)
-                                height: dp(0.53125*app.height)
-                                padding:[0, 0, 0, dp(0.1875)*app.height]
-                                spacing:0.0416666666667*app.height
+                                width: app.get_scaled_width(325.0)
+                                height: app.get_scaled_height(255.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 90.0])
+                                spacing: app.get_scaled_width(20.0)
                                 pos: self.parent.pos
                                 
                                 # BL horizontal
                                     # Toggle button
                                 BoxLayout:
                                     size_hint: (None,None)
-                                    height: dp(0.0666666666667*app.height)
-                                    width: dp(0.40625*app.width)
-                                    padding:[dp(0.27875)*app.width, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(32.0)
+                                    width: app.get_scaled_width(325.0)
+                                    padding: app.get_scaled_tuple([223.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                                     
 #                                     ToggleButton:
 #                                         id: unit_toggle
 #                                         size_hint: (None,None)
-#                                         height: dp(30)
-#                                         width: dp(75)
+#                                         height: app.get_scaled_height(30.0)
+#                                         width: app.get_scaled_width(75.0)
 #                                         background_color: hex('#F4433600')
 #                                         center: self.parent.center
 #                                         pos: self.parent.pos
 #                                         on_press: root.toggle_units()
 #         
 #                                         BoxLayout:
-#                                             height: dp(30)
-#                                             width: dp(75)
+#                                             height: app.get_scaled_height(30.0)
+#                                             width: app.get_scaled_width(75.0)
 #                                             canvas:
 #                                                 Rectangle: 
 #                                                     pos: self.parent.pos
@@ -264,7 +264,7 @@ Builder.load_string(
 #                                             id: unit_label
 #                                             text: "mm"
 #                                             color: 1,1,1,1
-#                                             font_size: 20
+#                                             font_size: app.get_scaled_width(20.0)
 #                                             markup: True
 #                                             halign: "center"
 #                                             valign: "middle"
@@ -274,8 +274,8 @@ Builder.load_string(
                                     Switch:
                                         id: unit_toggle
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.10375*app.width)
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(83.0)
                                         background_color: hex('#F4433600')
                                         center: self.parent.center
                                         pos: self.parent.pos
@@ -298,15 +298,15 @@ Builder.load_string(
                                                 pos: int(self.center_x - sp(0.05125*app.width) + self.active_norm_pos * sp(0.05125*app.width)), int(self.center_y - sp(0.0333333333333*app.height))
                                 BoxLayout: #dimension 1
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.40625*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(325.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Diameter (A):"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -316,16 +316,16 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(90.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: a_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
@@ -333,15 +333,15 @@ Builder.load_string(
                                 
                                 BoxLayout: #dimension 2
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.40625*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(325.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Cutting length (B):"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -351,16 +351,16 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(90.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: b_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
@@ -368,15 +368,15 @@ Builder.load_string(
                            
                                 BoxLayout: #dimension 3
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.40625*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(325.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Shoulder length (C):"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -386,25 +386,25 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(90.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: c_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''                           
                             BoxLayout: #image box
                                 size_hint: (None,None)
-                                height: dp(0.564583333333*app.height)
-                                width: dp(0.3125*app.width)
-                                padding:[dp(0.05625)*app.width, 0, dp(0.03125)*app.width, dp(0.0395833333333)*app.height]
+                                height: app.get_scaled_height(271.0)
+                                width: app.get_scaled_width(250.0)
+                                padding: app.get_scaled_tuple([45.0, 0.0, 25.0, 19.0])
                                 Image:
                                     source: "./asmcnc/apps/shapeCutter_app/img/dims_cutter.png"
                                     center_x: self.parent.center_x
@@ -418,23 +418,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -450,10 +450,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -467,10 +467,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_21.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_21.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.104166666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(50.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.541666666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(260.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_21_1.png"
                                 center_x: self.parent.center_x
@@ -231,23 +231,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_22.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_22.py
@@ -33,25 +33,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -62,10 +62,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -76,10 +76,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -92,10 +92,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -108,10 +108,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -124,10 +124,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -143,8 +143,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -158,16 +158,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -177,21 +177,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -202,33 +202,33 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, dp(0.375)*app.width, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 300.0, 0.0])
                             orientation: "vertical"                       
                             BoxLayout: #image box
                                 size_hint: (None,None)
-                                height: dp(0.114583333333*app.height)
-                                width: dp(0.36875*app.width)
+                                height: app.get_scaled_height(55.0)
+                                width: app.get_scaled_width(295.0)
                                 orientation: "horizontal"
                                 Label:
                                     text: root.user_instructions
                                     color: 0,0,0,1
-                                    font_size: 0.025*app.width
+                                    font_size: app.get_scaled_width(20.0)
                                     markup: True
                                     halign: "left"
                                     valign: "top"
@@ -238,15 +238,15 @@ Builder.load_string(
 
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.114583333333*app.height)
-                                    width: dp(0.10625*app.width)
-                                    padding:[dp(0.0025)*app.width, 0, 0, dp(0.0479166666667)*app.height]
+                                    height: app.get_scaled_height(55.0)
+                                    width: app.get_scaled_width(85.0)
+                                    padding: app.get_scaled_tuple([2.0, 0.0, 0.0, 23.0])
 
                                     Switch:
                                         id: tab_toggle
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.10375*app.width)
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(83.0)
                                         background_color: hex('#F4433600')
                                         center: self.parent.center
                                         pos: self.parent.pos
@@ -270,16 +270,16 @@ Builder.load_string(
 
                         BoxLayout: #image & text entry box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.0125)*app.width, 0, 0, dp(0.04375)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 21.0])
                             orientation: "horizontal"
                             
                             BoxLayout: #image box
                                 size_hint: (None,None)
-                                height: dp(0.53125*app.height)
-                                width: dp(0.525*app.width)
-                                padding:[dp(0.025)*app.width, 0, 0, dp(0.0229166666667)*app.height]
+                                height: app.get_scaled_height(255.0)
+                                width: app.get_scaled_width(420.0)
+                                padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 11.0])
                                 Image:
                                     id: main_image
                                     source: "./asmcnc/apps/shapeCutter_app/img/tabs_rect.png"
@@ -291,31 +291,31 @@ Builder.load_string(
                             BoxLayout:
                                 orientation: 'vertical'
                                 size_hint: (None,None)
-                                width: dp(0.2625*app.width)
-                                height: dp(0.6875*app.height)
-                                padding:[0, 0, 0, dp(0.1875)*app.height]
-                                spacing:0.0416666666667*app.height
+                                width: app.get_scaled_width(210.0)
+                                height: app.get_scaled_height(330.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 90.0])
+                                spacing: app.get_scaled_width(20.0)
                                 pos: self.parent.pos
                                 
                                 # Unit toggle
                                 BoxLayout:
                                     size_hint: (None,None)
-                                    height: dp(0.0666666666667*app.height)
-                                    width: dp(0.2625*app.width)
-                                    padding:[dp(0.0875)*app.width, 0, dp(0.0125)*app.width, 0]
+                                    height: app.get_scaled_height(32.0)
+                                    width: app.get_scaled_width(210.0)
+                                    padding: app.get_scaled_tuple([70.0, 0.0, 10.0, 0.0])
                                     orientation: "horizontal"
                                
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.15*app.width)
-                                        padding:[dp(0.04625)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(120.0)
+                                        padding: app.get_scaled_tuple([37.0, 0.0, 0.0, 0.0])
                                                                          
                                         Switch:
                                             id: unit_toggle
                                             size_hint: (None,None)
-                                            height: dp(0.0666666666667*app.height)
-                                            width: dp(0.10375*app.width)
+                                            height: app.get_scaled_height(32.0)
+                                            width: app.get_scaled_width(83.0)
                                             background_color: hex('#F4433600')
                                             center: self.parent.center
                                             pos: self.parent.pos
@@ -339,15 +339,15 @@ Builder.load_string(
                             
                                 BoxLayout: #dimension 1
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.2625*app.width)
-                                    padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(210.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "TD"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -357,31 +357,31 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.15*app.width)
-                                        padding:[dp(0.025)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(120.0)
+                                        padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: td_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''
                                 BoxLayout: #dimension 2
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.2625*app.width)
-                                    padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(210.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "TH"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -391,31 +391,31 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.15*app.width)
-                                        padding:[dp(0.025)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(120.0)
+                                        padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: th_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''                           
                                 BoxLayout: #dimension 3
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.2625*app.width)
-                                    padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(210.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "TW"
                                         color: 0,0,0,1
-                                        font_size: 0.03*app.width
+                                        font_size: app.get_scaled_width(24.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -425,39 +425,39 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.15*app.width)
-                                        padding:[dp(0.025)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(120.0)
+                                        padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: tw_dimension
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -473,10 +473,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -490,10 +490,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_23.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_23.py
@@ -31,25 +31,25 @@ Builder.load_string(
     
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -60,10 +60,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -74,10 +74,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -90,10 +90,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -106,10 +106,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -122,10 +122,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -141,8 +141,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -156,16 +156,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -175,21 +175,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -200,56 +200,56 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
 
                         BoxLayout: #image & text entry box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[0, 0, 0, dp(0.04375)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 21.0])
                             orientation: "horizontal"
                                     
                             BoxLayout:
                                 orientation: 'vertical'
                                 size_hint: (None,None)
-                                width: dp(0.74375*app.width)
-                                height: dp(0.53125*app.height)
-                                padding:[0, 0, 0, dp(0.104166666667)*app.height]
-                                spacing:0.0416666666667*app.height
+                                width: app.get_scaled_width(595.0)
+                                height: app.get_scaled_height(255.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 50.0])
+                                spacing: app.get_scaled_width(20.0)
                                 pos: self.parent.pos
                                 
                                 # BL horizontal
                                     # Toggle button
                                 BoxLayout:
                                     size_hint: (None,None)
-                                    height: dp(0.0666666666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[dp(0.4775)*app.width, 0, dp(0.1625)*app.width, 0]
+                                    height: app.get_scaled_height(32.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([382.0, 0.0, 130.0, 0.0])
                                     orientation: "horizontal"
                                                     
                       
                                     Switch:
                                         id: unit_toggle
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.10375*app.width)
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(83.0)
                                         background_color: hex('#F4433600')
                                         center: self.parent.center
                                         pos: self.parent.pos
@@ -273,15 +273,15 @@ Builder.load_string(
                             
                                 BoxLayout: #dimension 1
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "XY feed rate"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -291,29 +291,29 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: xy_feed
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             id: xy_feed_units
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -323,15 +323,15 @@ Builder.load_string(
                                 
                                 BoxLayout: #dimension 2
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Plunge rate"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -341,29 +341,29 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: z_feed
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''                           
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             id: z_feed_units
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -372,15 +372,15 @@ Builder.load_string(
                                             pos: self.parent.pos
                                 BoxLayout: #dimension 3
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Spindle speed (precision only)"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -390,29 +390,29 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: spindle_speed
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''                                                                
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             text: "RPM"
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -422,15 +422,15 @@ Builder.load_string(
 
                                 BoxLayout: # reminder
                                     size_hint: (None,None)
-                                    height: dp(0.125*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, dp(0.0208333333333)*app.height, dp(0.075)*app.width, 0]
+                                    height: app.get_scaled_height(60.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 10.0, 60.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "[b]Reminder: If you have manual speed control don't forget to set this on the dial.[/b]"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "top"
@@ -440,23 +440,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -472,10 +472,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -489,10 +489,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_24.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_24.py
@@ -31,25 +31,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -60,10 +60,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -74,10 +74,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -90,10 +90,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -106,10 +106,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -122,10 +122,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -141,8 +141,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -156,16 +156,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -175,21 +175,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -200,63 +200,63 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
 
                         BoxLayout: #image & text entry box
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[0, 0, 0, dp(0.04375)*app.height]
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 21.0])
                             orientation: "horizontal"
                                     
                             BoxLayout:
                                 orientation: 'vertical'
                                 size_hint: (None,None)
-                                width: dp(0.74375*app.width)
-                                height: dp(0.53125*app.height)
-                                padding:[0, 0, 0, dp(0.104166666667)*app.height]
-                                spacing:0.0416666666667*app.height
+                                width: app.get_scaled_width(595.0)
+                                height: app.get_scaled_height(255.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 50.0])
+                                spacing: app.get_scaled_width(20.0)
                                 pos: self.parent.pos
                                 
                                 # BL horizontal
                                     # Toggle button
                                 BoxLayout:
                                     size_hint: (None,None)
-                                    height: dp(0.0666666666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[dp(0.4775)*app.width, 0, dp(0.1625)*app.width, 0]
+                                    height: app.get_scaled_height(32.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([382.0, 0.0, 130.0, 0.0])
                                     orientation: "horizontal"
                                                     
 #                                     ToggleButton:
 #                                         id: unit_toggle
 #                                         size_hint: (None,None)
-#                                         height: dp(30)
-#                                         width: dp(75)
+#                                         height: app.get_scaled_height(30.0)
+#                                         width: app.get_scaled_width(75.0)
 #                                         background_color: hex('#F4433600')
 #                                         center: self.parent.center
 #                                         pos: self.parent.pos
 #                                         on_press: root.toggle_units()
 #         
 #                                         BoxLayout:
-#                                             height: dp(30)
-#                                             width: dp(75)
+#                                             height: app.get_scaled_height(30.0)
+#                                             width: app.get_scaled_width(75.0)
 #                                             canvas:
 #                                                 Rectangle: 
 #                                                     pos: self.parent.pos
@@ -266,7 +266,7 @@ Builder.load_string(
 #                                             id: unit_label
 #                                             text: "mm"
 #                                             color: 1,1,1,1
-#                                             font_size: 20
+#                                             font_size: app.get_scaled_width(20.0)
 #                                             markup: True
 #                                             halign: "center"
 #                                             valign: "middle"
@@ -276,8 +276,8 @@ Builder.load_string(
                                     Switch:
                                         id: unit_toggle
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.10375*app.width)
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(83.0)
                                         background_color: hex('#F4433600')
                                         center: self.parent.center
                                         pos: self.parent.pos
@@ -301,15 +301,15 @@ Builder.load_string(
                             
                                 BoxLayout: #dimension 1
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Stock bottom offset"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -319,30 +319,30 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: stock_bottom_offset
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             id: stock_bottom_offset_units
                                             text: "units"
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -352,15 +352,15 @@ Builder.load_string(
                                 
                                 BoxLayout: #dimension 2
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Step down"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -370,29 +370,29 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: step_down
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'float'
                                             multiline: False
                                             text: ''                           
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             id: step_down_units
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -401,15 +401,15 @@ Builder.load_string(
                                             pos: self.parent.pos
                                 BoxLayout: #dimension 3
                                     size_hint: (None,None)
-                                    height: dp(0.0729166666667*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, 0, dp(0.025)*app.width, 0]
+                                    height: app.get_scaled_height(35.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: "Finishing passes"
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "middle"
@@ -419,29 +419,29 @@ Builder.load_string(
                                                                   
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.14125*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, 0, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(113.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
                                                     
                                         TextInput: 
                                             id: finishing_passes
                                             valign: 'top'
                                             halign: 'center'
                                             text_size: self.size
-                                            font_size: str(0.025*app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('20.0sp')
                                             markup: True
                                             input_filter: 'int'
                                             multiline: False
                                             text: ''                                                                
                                     BoxLayout: 
                                         size_hint: (None,None)
-                                        height: dp(0.0729166666667*app.height)
-                                        width: dp(0.1375*app.width)
-                                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                        height: app.get_scaled_height(35.0)
+                                        width: app.get_scaled_width(110.0)
+                                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                         Label: 
                                             text: "passes"
                                             color: 0,0,0,1
-                                            font_size: 0.025*app.width
+                                            font_size: app.get_scaled_width(20.0)
                                             markup: True
                                             halign: "left"
                                             valign: "middle"
@@ -451,15 +451,15 @@ Builder.load_string(
 
                                 BoxLayout: # reminder
                                     size_hint: (None,None)
-                                    height: dp(0.125*app.height)
-                                    width: dp(0.74375*app.width)
-                                    padding:[0, dp(0.0208333333333)*app.height, dp(0.075)*app.width, 0]
+                                    height: app.get_scaled_height(60.0)
+                                    width: app.get_scaled_width(595.0)
+                                    padding: app.get_scaled_tuple([0.0, 10.0, 60.0, 0.0])
                                     orientation: "horizontal"
                                     
                                     Label: 
                                         text: ""
                                         color: 0,0,0,1
-                                        font_size: 0.025*app.width
+                                        font_size: app.get_scaled_width(20.0)
                                         markup: True
                                         halign: "left"
                                         valign: "top"
@@ -469,23 +469,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -501,10 +501,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -518,10 +518,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_25.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_25.py
@@ -24,25 +24,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -53,10 +53,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -67,10 +67,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -83,10 +83,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -99,10 +99,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -115,10 +115,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -134,8 +134,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -149,16 +149,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -168,21 +168,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -193,34 +193,34 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.0125)*app.width, 0, dp(0.03125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([10.0, 0.0, 25.0, 10.0])
                         orientation: "horizontal"
                         BoxLayout: # file save
                             size_hint: (None,None)
-                            height: dp(0.625*app.height)
-                            width: dp(0.375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(300.0)
+                            width: app.get_scaled_width(300.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"       
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.145833333333*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[0, 0, 0, dp(0.0104166666667)*app.height]
+                                height: app.get_scaled_height(70.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 5.0])
                                 orientation: "vertical"
 
 #                                 Label: 
 #                                     text: ""
 #                                     color: 0,0,0,1
-#                                     font_size: 20
+#                                     font_size: app.get_scaled_width(20.0)
 #                                     markup: True
 #                                     halign: "center"
 #                                     valign: "top"
@@ -230,29 +230,29 @@ Builder.load_string(
                                     
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.0833333333333*app.height)
-                                    width: dp(0.375*app.width)
-                                    padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                    height: app.get_scaled_height(40.0)
+                                    width: app.get_scaled_width(300.0)
+                                    padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                                 
                                     TextInput: 
                                         id: file_name
                                         valign: 'middle'
                                         halign: 'center'
                                         text_size: self.size
-                                        font_size: str(0.025*app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('20.0sp')
                                         markup: True
                                         multiline: False
                                         text: ''                           
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.35*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[dp(0.0825)*app.width, 0, dp(0.0825)*app.width, 0]
+                                height: app.get_scaled_height(168.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([66.0, 0.0, 66.0, 0.0])
                                 Button:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     size_hint: (None,None)
-                                    height: dp(0.35*app.height)
-                                    width: dp(0.21*app.width)
+                                    height: app.get_scaled_height(168.0)
+                                    width: app.get_scaled_width(168.0)
                                     on_press: root.save_file()
                                     background_color: hex('#F4433600')
                                     BoxLayout:
@@ -266,13 +266,13 @@ Builder.load_string(
                                             allow_stretch: True
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.129166666667*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[0, 0, 0, 0]
+                                height: app.get_scaled_height(62.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                 Label: 
                                     text: "You can save this profile later after the job too. "
                                     color: 0,0,0,1
-                                    font_size: 0.025*app.width
+                                    font_size: app.get_scaled_width(20.0)
                                     markup: True
                                     halign: "center"
                                     valign: "middle"
@@ -282,9 +282,9 @@ Builder.load_string(
                                             
                         BoxLayout: # document viewer
                             size_hint: (None,None)
-                            height: dp(0.625*app.height)
-                            width: dp(0.4375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(300.0)
+                            width: app.get_scaled_width(350.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             ScrollView:
                                 size_hint: (None, None)
                                 size: self.parent.size
@@ -295,27 +295,27 @@ Builder.load_string(
                                 RstDocument:
                                     text: root.display_profile
                                     background_color: hex('#FFFFFF')
-                                    base_font_size: str(31.0/800.0*app.width) + 'sp'
+                                    base_font_size: app.get_scaled_sp('31.0sp')
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -331,10 +331,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -348,10 +348,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_26.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_26.py
@@ -21,25 +21,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -50,10 +50,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -64,10 +64,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -80,10 +80,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -96,10 +96,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -112,10 +112,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -131,8 +131,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -146,16 +146,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -165,21 +165,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -190,22 +190,22 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, dp(0.0125)*app.width, dp(0.166666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 10.0, 80.0])
                         orientation: "vertical"
                         
                         LabelBase:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -216,7 +216,7 @@ Builder.load_string("""
                         LabelBase:
                             text: root.warning_message
                             color: 0,0,0,1
-                            font_size: 0.0275*app.width
+                            font_size: app.get_scaled_width(22.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -226,23 +226,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0458333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 22.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -258,10 +258,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -275,11 +275,11 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: homing_button
                             size_hint: (None,None)
-                            height: dp(0.208333333333*app.height)
-                            width: dp(0.125*app.width)
+                            height: app.get_scaled_height(100.0)
+                            width: app.get_scaled_width(100.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_27.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_27.py
@@ -21,25 +21,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -50,10 +50,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -64,10 +64,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -80,10 +80,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -96,10 +96,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -112,10 +112,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -131,8 +131,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -146,16 +146,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -165,21 +165,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -190,28 +190,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # text and pics
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.114583333333*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(55.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -220,16 +220,16 @@ Builder.load_string(
                                 pos: self.parent.pos
                         BoxLayout:
                             size_hint: (None,None)
-                            height: dp(0.53125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[0, 0, 0, dp(0.03125)*app.height]
-                            spacing:0.025*app.width
+                            height: app.get_scaled_height(255.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 15.0])
+                            spacing: app.get_scaled_width(20.0)
                             BoxLayout: #image box
                                 id: image_box
                                 size_hint: (None,None)
-                                height: dp(0.5*app.height)
-                                width: dp(0.625*app.width)
-                                padding:[dp(0.03125)*app.width, 0, 0, 0]
+                                height: app.get_scaled_height(240.0)
+                                width: app.get_scaled_width(500.0)
+                                padding: app.get_scaled_tuple([25.0, 0.0, 0.0, 0.0])
                                 Image:
                                     source: root.image_source
                                     center_x: self.parent.center_x
@@ -240,7 +240,7 @@ Builder.load_string(
                             Label:          
                                 text: "In the next step, you will need to centre the tool over the datum position."
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -251,23 +251,23 @@ Builder.load_string(
                                 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -283,10 +283,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -300,10 +300,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_28.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_28.py
@@ -29,25 +29,25 @@ Builder.load_string(
     
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -58,10 +58,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -72,10 +72,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -88,10 +88,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -104,10 +104,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -120,10 +120,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -139,8 +139,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -154,16 +154,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -173,21 +173,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -198,57 +198,57 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, 0, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # move widget
                         id: xy_move_container
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.35*app.width)
-                        padding:[dp(0.025)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(280.0)
+                        padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"                                         
                                             
                     BoxLayout: # bench widget
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.49375*app.width)
-                        padding:[0, 0, 0, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(395.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 10.0])
                         orientation: "vertical"
                         BoxLayout: 
                             id: virtual_bed_container
                             size_hint: (None,None)
-                            height: dp(0.541666666667*app.height)
-                            width: dp(0.49375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(260.0)
+                            width: app.get_scaled_width(395.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         BoxLayout: 
                             id: work_coords_container
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.49375*app.width)
-                            padding:[dp(0.009375)*app.width, dp(0.03125)*app.height, dp(0.021875)*app.width, dp(0.0104166666667)*app.height]
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(395.0)
+                            padding: app.get_scaled_tuple([7.5, 15.0, 17.5, 5.0])
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -264,10 +264,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -281,10 +281,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_29.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_29.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,22 +187,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.3125)*app.width, 0, 0, dp(0.0416666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([250.0, 0.0, 0.0, 20.0])
                         orientation: "vertical"
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.604166666667*app.height)
-                            width: dp(0.375*app.width)                      
+                            height: app.get_scaled_height(290.0)
+                            width: app.get_scaled_width(300.0)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_29_1.png"
                                 center_x: self.parent.center_x
@@ -213,23 +213,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -245,10 +245,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -262,10 +262,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_3.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_3.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,22 +187,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0416666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 20.0])
                         orientation: "horizontal"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -212,8 +212,8 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.604166666667*app.height)
-                            width: dp(0.57625*app.width)                       
+                            height: app.get_scaled_height(290.0)
+                            width: app.get_scaled_width(461.0)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_3_1.png"
                                 center_x: self.parent.center_x
@@ -224,23 +224,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -256,10 +256,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -273,10 +273,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_30.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_30.py
@@ -20,25 +20,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -49,10 +49,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -63,10 +63,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -79,10 +79,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -95,10 +95,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -111,10 +111,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -130,8 +130,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -145,16 +145,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -164,21 +164,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -189,22 +189,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0416666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 20.0])
                         orientation: "horizontal"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -214,8 +214,8 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.604166666667*app.height)
-                            width: dp(0.5*app.width)                       
+                            height: app.get_scaled_height(290.0)
+                            width: app.get_scaled_width(400.0)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/30_zdatum.png"
                                 center_x: self.parent.center_x
@@ -226,23 +226,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -258,10 +258,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -275,10 +275,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_31.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_31.py
@@ -31,25 +31,25 @@ Builder.load_string(
     
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -60,10 +60,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -74,10 +74,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -90,10 +90,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -106,10 +106,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -122,10 +122,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -141,8 +141,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -156,16 +156,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -175,21 +175,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -200,68 +200,68 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, 0, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # move widget
                         id: xy_move_container
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.35*app.width)
-                        padding:[dp(0.025)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(280.0)
+                        padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"                                         
                                             
                     BoxLayout: # Z move & common move widget
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.49375*app.width)
-                        padding:[0, 0, 0, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(395.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 10.0])
                         orientation: "vertical"
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.541666666667*app.height)
-                            width: dp(0.49375*app.width)
-                            padding:[dp(0.01875)*app.width, 0, dp(0.01875)*app.width, 0]
+                            height: app.get_scaled_height(260.0)
+                            width: app.get_scaled_width(395.0)
+                            padding: app.get_scaled_tuple([15.0, 0.0, 15.0, 0.0])
                             orientation: "horizontal"
                             BoxLayout: # common move
                                 id: z_set_go_container
                                 size_hint: (None, None)
-                                height: dp(0.541666666667*app.height)
-                                width: dp(0.20625*app.width)
+                                height: app.get_scaled_height(260.0)
+                                width: app.get_scaled_width(165.0)
                             BoxLayout: # Z move
                                 id: z_move_container
                                 size_hint: (None, None)
-                                height: dp(0.541666666667*app.height)
-                                width: dp(0.25*app.width)
+                                height: app.get_scaled_height(260.0)
+                                width: app.get_scaled_width(200.0)
                         
                         BoxLayout: 
                             id: work_coords_container
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.49375*app.width)
-                            padding:[0, dp(0.03125)*app.height, dp(0.05)*app.width, dp(0.0104166666667)*app.height]
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(395.0)
+                            padding: app.get_scaled_tuple([0.0, 15.0, 40.0, 5.0])
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -277,10 +277,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -294,10 +294,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_32.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_32.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,22 +187,22 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.3125)*app.width, 0, 0, dp(0.0416666666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([250.0, 0.0, 0.0, 20.0])
                         orientation: "vertical"
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.604166666667*app.height)
-                            width: dp(0.375*app.width)                      
+                            height: app.get_scaled_height(290.0)
+                            width: app.get_scaled_width(300.0)
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_29_1.png"
                                 center_x: self.parent.center_x
@@ -213,23 +213,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -245,10 +245,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -262,10 +262,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_33.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_33.py
@@ -26,25 +26,25 @@ Builder.load_string("""
     
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -55,10 +55,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -69,10 +69,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -85,10 +85,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -101,10 +101,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -117,10 +117,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -136,8 +136,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -151,16 +151,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -170,21 +170,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -195,28 +195,28 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, 0, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     # Text box layout for user instructions (at least 40 high)
                     BoxLayout: 
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.104166666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(50.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             LabelBase:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -226,29 +226,29 @@ Builder.load_string("""
 
                         BoxLayout:
                             size_hint: (None,None)
-                            height: dp(0.541666666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(260.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             orientation: "horizontal"
                      
                             BoxLayout: # two buttons
                                 size_hint: (None,None)
-                                height: dp(0.541666666667*app.height)
-                                width: dp(0.3125*app.width)
-                                padding:[dp(0.11875)*app.width, dp(0.03125)*app.height, dp(0.06875)*app.width, dp(0.0729166666667)*app.height]
-                                spacing:0.0208333333333*app.height
+                                height: app.get_scaled_height(260.0)
+                                width: app.get_scaled_width(250.0)
+                                padding: app.get_scaled_tuple([95.0, 15.0, 55.0, 35.0])
+                                spacing: app.get_scaled_width(10.0)
                                 orientation: "vertical"
                                 BoxLayout: # button
                                     size_hint: (None,None)
-                                    height: dp(0.208333333333*app.height)
-                                    width: dp(0.125*app.width)
-                                    padding:[0, 0, 0, 0]
+                                    height: app.get_scaled_height(100.0)
+                                    width: app.get_scaled_width(100.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                     Button:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         on_press: root.trace_job()
                                         background_color: 1, 1, 1, 0 
                                         BoxLayout:
-                                            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                            padding: app.get_scaled_tuple([10.0, 10.0])
                                             size: self.parent.size
                                             pos: self.parent.pos      
                                             Image:
@@ -259,15 +259,15 @@ Builder.load_string("""
                                                 allow_stretch: True                                    
                                 BoxLayout: # button
                                     size_hint: (None,None)
-                                    height: dp(0.208333333333*app.height)
-                                    width: dp(0.125*app.width)
-                                    padding:[0, 0, 0, 0]
+                                    height: app.get_scaled_height(100.0)
+                                    width: app.get_scaled_width(100.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                     Button:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         on_press: root.stop_jog()
                                         background_color: 1, 1, 1, 0 
                                         BoxLayout:
-                                            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                            padding: app.get_scaled_tuple([10.0, 10.0])
                                             size: self.parent.size
                                             pos: self.parent.pos      
                                             Image:
@@ -278,42 +278,42 @@ Builder.load_string("""
                                                 allow_stretch: True                                                    
                             BoxLayout: # bench widget
                                 size_hint: (None,None)
-                                height: dp(0.541666666667*app.height)
-                                width: dp(0.53125*app.width)
-                                padding:[0, 0, 0, 0]
+                                height: app.get_scaled_height(260.0)
+                                width: app.get_scaled_width(425.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                 orientation: "vertical"
                                 BoxLayout: 
                                     id: virtual_bed_container
                                     size_hint: (None,None)
-                                    height: dp(0.416666666667*app.height)
-                                    width: dp(0.53125*app.width)
-                                    padding:[0, 0, 0, 0]
+                                    height: app.get_scaled_height(200.0)
+                                    width: app.get_scaled_width(425.0)
+                                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                 BoxLayout: 
                                     id: work_coords_container
                                     size_hint: (None,None)
-                                    height: dp(0.125*app.height)
-                                    width: dp(0.53125*app.width)
-                                    padding:[dp(0.009375)*app.width, dp(0.0104166666667)*app.height, dp(0.021875)*app.width, dp(0.03125)*app.height]
+                                    height: app.get_scaled_height(60.0)
+                                    width: app.get_scaled_width(425.0)
+                                    padding: app.get_scaled_tuple([7.5, 5.0, 17.5, 15.0])
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -329,10 +329,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -346,10 +346,10 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_34.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_34.py
@@ -24,25 +24,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -53,10 +53,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -67,10 +67,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -83,10 +83,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -99,10 +99,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -115,10 +115,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -134,8 +134,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -149,16 +149,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -168,21 +168,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -193,24 +193,24 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                  
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"
                         ToggleButton:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: vacuum_toggle
                             on_press: root.set_vacuum()
                             background_color: 1, 1, 1, 0 
                             BoxLayout:
-                                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                padding: app.get_scaled_tuple([10.0, 10.0])
                                 size: self.parent.size
                                 pos: self.parent.pos      
                                 Image:
@@ -223,7 +223,7 @@ Builder.load_string("""
                         LabelBase:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.0225*app.width
+                            font_size: app.get_scaled_width(18.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -233,23 +233,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -265,11 +265,11 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: back_button
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -283,11 +283,11 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: next_button
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_35.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_35.py
@@ -23,25 +23,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -52,10 +52,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -66,10 +66,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -82,10 +82,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -98,10 +98,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -114,10 +114,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -133,8 +133,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -148,16 +148,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -167,21 +167,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -192,24 +192,24 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                  
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"
                         ToggleButton:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: spindle_toggle
                             on_press: root.set_spindle()
                             background_color: 1, 1, 1, 0 
                             BoxLayout:
-                                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                padding: app.get_scaled_tuple([10.0, 10.0])
                                 size: self.parent.size
                                 pos: self.parent.pos      
                                 Image:
@@ -222,7 +222,7 @@ Builder.load_string(
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.0225*app.width
+                            font_size: app.get_scaled_width(18.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -232,23 +232,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -264,11 +264,11 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: back_button
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -282,11 +282,11 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: next_button
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_36.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_36.py
@@ -22,25 +22,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -51,10 +51,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -65,10 +65,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -81,10 +81,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -97,10 +97,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -113,10 +113,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -132,8 +132,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -147,16 +147,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -166,21 +166,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -191,24 +191,24 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                  
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.0104166666667)*app.height]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 5.0])
                         orientation: "vertical"
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: spindle_toggle
                             on_press: root.start_job()
                             background_color: 1, 1, 1, 0 
                             BoxLayout:
-                                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                padding: app.get_scaled_tuple([10.0, 10.0])
                                 size: self.parent.size
                                 pos: self.parent.pos      
                                 Image:
@@ -221,7 +221,7 @@ Builder.load_string(
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.0225*app.width
+                            font_size: app.get_scaled_width(18.0)
                             markup: True
                             halign: "center"
                             valign: "top"
@@ -231,23 +231,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             #on_press: root.next_screen()
                             opacity: 0

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_37.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_37.py
@@ -21,16 +21,16 @@ Builder.load_string("""
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(800)
-            height: dp(90)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(142)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -41,8 +41,8 @@ Builder.load_string("""
                         allow_stretch: True
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(142)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -53,8 +53,8 @@ Builder.load_string("""
                         allow_stretch: True
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(142)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -67,8 +67,8 @@ Builder.load_string("""
                         allow_stretch: True
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(142)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -81,8 +81,8 @@ Builder.load_string("""
                         allow_stretch: True
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(142)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -95,8 +95,8 @@ Builder.load_string("""
                         allow_stretch: True
             Button:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(90)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 BoxLayout:
                     padding: 0
                     size: self.parent.size
@@ -109,9 +109,9 @@ Builder.load_string("""
                         allow_stretch: True                    
                     
         BoxLayout:
-            padding: 10
-            height: dp(800)
-            width: dp(480)
+            padding: app.get_scaled_width(10.0)
+            height: app.get_scaled_height(800.0)
+            width: app.get_scaled_width(480.0)
             canvas:
                 Rectangle: 
                     pos: self.pos

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_4.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_4.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.104166666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(50.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.416666666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.03125)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(200.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([25.0, 0.0, 0.0, 0.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_4_1.png"
                                 center_x: self.parent.center_x
@@ -229,15 +229,15 @@ Builder.load_string(
                                 allow_stretch: True
                         BoxLayout: #image number box
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.147875)*app.width, dp(0.0104166666667)*app.height, dp(0.116625)*app.width, dp(0.0520833333333)*app.height]
-                            spacing:0.23325*app.width
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([118.3, 5.0, 93.3, 25.0])
+                            spacing: app.get_scaled_width(186.6)
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -247,13 +247,13 @@ Builder.load_string(
                                     text: "1"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -263,13 +263,13 @@ Builder.load_string(
                                     text: "2"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -279,28 +279,28 @@ Builder.load_string(
                                     text: "3"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True                                       
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -316,10 +316,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -333,10 +333,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_5.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_5.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.0625*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(30.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.572916666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, dp(0.03125)*app.height]
+                            height: app.get_scaled_height(275.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 15.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_5_1.png"
                                 center_x: self.parent.center_x
@@ -231,23 +231,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_6.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_6.py
@@ -18,25 +18,25 @@ Builder.load_string("""
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string("""
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string("""
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string("""
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string("""
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         LabelBase:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string("""
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "horizontal"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.645833333333*app.height)
-                            width: dp(0.3875*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(310.0)
+                            width: app.get_scaled_width(310.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             LabelBase:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string("""
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.645833333333*app.height)
-                            width: dp(0.45625*app.width)
-                            padding:[dp(0.005)*app.width, 0, dp(0.0125)*app.width, dp(0.0416666666667)*app.height]
+                            height: app.get_scaled_height(310.0)
+                            width: app.get_scaled_width(365.0)
+                            padding: app.get_scaled_tuple([4.0, 0.0, 10.0, 20.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_6_1.png"
                                 center_x: self.parent.center_x
@@ -231,23 +231,23 @@ Builder.load_string("""
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -263,10 +263,10 @@ Builder.load_string("""
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,10 +280,10 @@ Builder.load_string("""
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_7.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_7.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.46875*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.025)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(225.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_7_1.png"
                                 center_x: self.parent.center_x
@@ -229,15 +229,15 @@ Builder.load_string(
                                 allow_stretch: True
                         BoxLayout: #image number box
                             size_hint: (None,None)
-                            height: dp(0.09375*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.2109375)*app.width, dp(0.000520833333333)*app.height, dp(0.1859375)*app.width, dp(0.0260416666667)*app.height]
-                            spacing:0.371875*app.width
+                            height: app.get_scaled_height(45.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([168.75, 0.25, 148.75, 12.5])
+                            spacing: app.get_scaled_width(297.5)
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -247,13 +247,13 @@ Builder.load_string(
                                     text: "1"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -263,28 +263,28 @@ Builder.load_string(
                                     text: "2"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True                            
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -300,10 +300,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -317,10 +317,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_8.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_8.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,28 +187,28 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: # text and pics
                         size_hint: (None,None)
-                        height: dp(0.6875*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(330.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: "vertical"
                     
                         BoxLayout: #text box
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.1)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"                       
                             Label:
                                 text: root.user_instructions
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "bottom"
@@ -218,9 +218,9 @@ Builder.load_string(
 
                         BoxLayout: #image box
                             size_hint: (None,None)
-                            height: dp(0.479166666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.05)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(230.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([40.0, 0.0, 0.0, 0.0])
                             Image:
                                 source: "./asmcnc/apps/shapeCutter_app/img/photo_8_1.png"
                                 center_x: self.parent.center_x
@@ -229,15 +229,15 @@ Builder.load_string(
                                 allow_stretch: True
                         BoxLayout: #image number box
                             size_hint: (None,None)
-                            height: dp(0.104166666667*app.height)
-                            width: dp(0.84375*app.width)
-                            padding:[dp(0.2171875)*app.width, dp(0.0104166666667)*app.height, dp(0.1796875)*app.width, dp(0.03125)*app.height]
-                            spacing:0.359375*app.width
+                            height: app.get_scaled_height(50.0)
+                            width: app.get_scaled_width(675.0)
+                            padding: app.get_scaled_tuple([173.75, 5.0, 143.75, 15.0])
+                            spacing: app.get_scaled_width(287.5)
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -247,13 +247,13 @@ Builder.load_string(
                                     text: "1"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True
                             BoxLayout: #photo numbers
                                 size_hint: (None,None)
                                 padding: 0
-                                height: dp(0.0625*app.height)
-                                width: dp(0.0375*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(30.0)
                                 canvas:
                                     Rectangle: 
                                         pos: self.pos
@@ -263,28 +263,28 @@ Builder.load_string(
                                     text: "2"
                                     valign: "middle"
                                     halign: "center"
-                                    font_size: 0.0275*app.width
+                                    font_size: app.get_scaled_width(22.0)
                                     markup: True                                       
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -300,10 +300,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -317,10 +317,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_9.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_9.py
@@ -18,25 +18,25 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.prepare()
                 BoxLayout:
                     padding: 0
@@ -47,10 +47,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.load()
                 BoxLayout:
                     padding: 0
@@ -61,10 +61,10 @@ Builder.load_string(
                         size: self.parent.size
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.define()
                 BoxLayout:
                     padding: 0
@@ -77,10 +77,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.position()
                 BoxLayout:
                     padding: 0
@@ -93,10 +93,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 on_press: root.check()
                 BoxLayout:
                     padding: 0
@@ -109,10 +109,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -128,8 +128,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -143,16 +143,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -162,21 +162,21 @@ Builder.load_string(
                             text: root.screen_number
                             valign: "middle"
                             halign: "center"
-                            font_size: 0.0325*app.width
+                            font_size: app.get_scaled_width(26.0)
                             markup: True
                                 
                                 
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -187,23 +187,23 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, dp(0.208333333333)*app.height]
-                        spacing:0.0208333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 100.0])
+                        spacing: app.get_scaled_width(10.0)
                         orientation: "vertical"
                         
                         Label:
                             text: root.user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -213,16 +213,16 @@ Builder.load_string(
                             
                         BoxLayout: #checklist 1
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -233,7 +233,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clear SmartBench topside"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -243,16 +243,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 2
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -263,7 +263,7 @@ Builder.load_string(
                             Label: 
                                 text: "Clean SmartBench axes"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -273,16 +273,16 @@ Builder.load_string(
                                 
                         BoxLayout: #checklist 3
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -293,7 +293,7 @@ Builder.load_string(
                             Label: 
                                 text: "Empty vacuum bag"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -303,16 +303,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 4
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -323,7 +323,7 @@ Builder.load_string(
                             Label: 
                                 text: "Fit vacuum hose"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -333,16 +333,16 @@ Builder.load_string(
                                                         
                         BoxLayout: #checklist 5
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
                             
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -353,7 +353,7 @@ Builder.load_string(
                             Label: 
                                 text: "Secure power cords"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -363,16 +363,16 @@ Builder.load_string(
 
                         BoxLayout: #checklist 6
                             size_hint: (None,None)
-                            height: dp(0.0458333333333*app.height)
-                            width: dp(0.74375*app.width)
-                            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
+                            height: app.get_scaled_height(22.0)
+                            width: app.get_scaled_width(595.0)
+                            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
                             orientation: "horizontal"
 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0458333333333*app.height)
-                                width: dp(0.0375*app.width)
-                                padding:[0, 0, dp(0.01)*app.width, 0]
+                                height: app.get_scaled_height(22.0)
+                                width: app.get_scaled_width(30.0)
+                                padding: app.get_scaled_tuple([0.0, 0.0, 8.0, 0.0])
                                 Image: 
                                     source: "./asmcnc/apps/shapeCutter_app/img/box_checked.png"
                                     center_x: self.parent.center_x
@@ -383,7 +383,7 @@ Builder.load_string(
                             Label: 
                                 text: "Lock Z head connections"
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -393,23 +393,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -425,10 +425,10 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -442,10 +442,10 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_aperture_island.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_aperture_island.py
@@ -17,8 +17,8 @@ Builder.load_string(
     image_is: image_is
         
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -34,14 +34,14 @@ Builder.load_string(
             
             BoxLayout: 
                 size_hint: (None, None) 
-                width: dp(1.0*app.width)
-                height: dp(0.1875*app.height)            
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(90.0)
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.1875*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(90.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Shape Cutter"
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "middle"
                     markup: True
@@ -52,49 +52,49 @@ Builder.load_string(
             
             BoxLayout: 
                 size_hint: (None, None) 
-                width: dp(1.0*app.width)
-                height: dp(0.6875*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(330.0)
                 orientation: "vertical"
                     
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(1.0*app.width)
-                    height: dp(0.177083333333*app.height)
-                    padding:[0, dp(0.0208333333333)*app.height, 0, 0]
+                    width: app.get_scaled_width(800.0)
+                    height: app.get_scaled_height(85.0)
+                    padding: app.get_scaled_tuple([0.0, 10.0, 0.0, 0.0])
                     spacing: 0
                     Label:
                         size_hint: (None,None)
-                        height: dp(0.15625*app.height)
-                        width: dp(1.0*app.width)
+                        height: app.get_scaled_height(75.0)
+                        width: app.get_scaled_width(800.0)
                         halign: "center"
                         valign: "bottom"
                         text: "Select a shape to define..."
                         color: 0,0,0,1
-                        font_size: 0.0325*app.width
+                        font_size: app.get_scaled_width(26.0)
                         markup: True
     
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(1.0*app.width)
-                    height: dp(0.46875*app.height)
-                    padding:[dp(0.1875)*app.width, 0, dp(0.1875)*app.width, 0]
+                    width: app.get_scaled_width(800.0)
+                    height: app.get_scaled_height(225.0)
+                    padding: app.get_scaled_tuple([150.0, 0.0, 150.0, 0.0])
                     spacing: 0
                     orientation: 'horizontal'
                     pos: self.parent.pos                
                     
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.3125*app.width)
-                        height: dp(0.46875*app.height)
-                        padding:[dp(0.02875)*app.width, 0, dp(0.025)*app.width, 0]
+                        width: app.get_scaled_width(250.0)
+                        height: app.get_scaled_height(225.0)
+                        padding: app.get_scaled_tuple([23.0, 0.0, 20.0, 0.0])
                         pos: self.parent.pos
                         
                         # aperture
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.46875*app.height)
-                            width: dp(0.25875*app.width)
+                            height: app.get_scaled_height(225.0)
+                            width: app.get_scaled_width(207.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -112,17 +112,17 @@ Builder.load_string(
                                     allow_stretch: True
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.3125*app.width)
-                        height: dp(0.46875*app.height)
-                        padding:[dp(0.025)*app.width, 0, dp(0.02875)*app.width, 0]
+                        width: app.get_scaled_width(250.0)
+                        height: app.get_scaled_height(225.0)
+                        padding: app.get_scaled_tuple([20.0, 0.0, 23.0, 0.0])
                         pos: self.parent.pos
                         
                         # island
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.46875*app.height)
-                            width: dp(0.25875*app.width)
+                            height: app.get_scaled_height(225.0)
+                            width: app.get_scaled_width(207.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -140,60 +140,60 @@ Builder.load_string(
                                     allow_stretch: True  
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(1.0*app.width)
-                    height: dp(0.0416666666667*app.height)
-                    padding:[dp(0.1875)*app.width, 0, dp(0.1875)*app.width, 0]
+                    width: app.get_scaled_width(800.0)
+                    height: app.get_scaled_height(20.0)
+                    padding: app.get_scaled_tuple([150.0, 0.0, 150.0, 0.0])
                     spacing: 0
                     orientation: 'horizontal'
                     pos: self.parent.pos
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.3125*app.width)
-                        height: dp(0.0416666666667*app.height)
-                        padding:[dp(0.02875)*app.width, 0, dp(0.025)*app.width, 0]
+                        width: app.get_scaled_width(250.0)
+                        height: app.get_scaled_height(20.0)
+                        padding: app.get_scaled_tuple([23.0, 0.0, 20.0, 0.0])
                         pos: self.parent.pos
                         Label:
                             size_hint: (None,None)
-                            height: dp(0.0416666666667*app.height)
-                            width: dp(0.25875*app.width)
+                            height: app.get_scaled_height(20.0)
+                            width: app.get_scaled_width(207.0)
                             halign: "center"
                             valign: "middle"
                             text: "Hole (cut an aperture)"
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.3125*app.width)
-                        height: dp(0.0416666666667*app.height)
-                        padding:[dp(0.025)*app.width, 0, dp(0.02875)*app.width, 0]
+                        width: app.get_scaled_width(250.0)
+                        height: app.get_scaled_height(20.0)
+                        padding: app.get_scaled_tuple([20.0, 0.0, 23.0, 0.0])
                         pos: self.parent.pos
                         Label:
                             size_hint: (None,None)
-                            height: dp(0.0416666666667*app.height)
-                            width: dp(0.25875*app.width)
+                            height: app.get_scaled_height(20.0)
+                            width: app.get_scaled_width(207.0)
                             halign: "center"
                             valign: "middle"
                             text: "Plate (cut an island)"
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             
             # Info button
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.125*app.height)
-                padding:[dp(0.025)*app.width, 0, 0, dp(0.0416666666667)*app.height]
-                spacing:0.85*app.width
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(60.0)
+                padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 20.0])
+                spacing: app.get_scaled_width(680.0)
                 orientation: 'horizontal'
                 pos: self.parent.pos
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: info_button
                     size_hint: (None,None)
-                    height: dp(0.0833333333333*app.height)
-                    width: dp(0.05*app.width)
+                    height: app.get_scaled_height(40.0)
+                    width: app.get_scaled_width(40.0)
                     background_color: hex('#F4433600')
                     opacity: 0
 #                     on_press: root.get_info()
@@ -209,11 +209,11 @@ Builder.load_string(
 #                             allow_stretch: True
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: exit_button
                     size_hint: (None,None)
-                    height: dp(0.0833333333333*app.height)
-                    width: dp(0.05*app.width)
+                    height: app.get_scaled_height(40.0)
+                    width: app.get_scaled_width(40.0)
                     background_color: hex('#F4433600')
                     opacity: 1
                     on_press: root.exit()

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_dimensions.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_dimensions.py
@@ -38,8 +38,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -54,26 +54,26 @@ Builder.load_string(
             # Header
             Label:
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Shape Cutter"
-                font_size: 0.0375*app.width
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.114583333333*app.height)
-                padding:[dp(0.1875)*app.width, 0, dp(0.1875)*app.width, 0]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(55.0)
+                padding: app.get_scaled_tuple([150.0, 0.0, 150.0, 0.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos
 
                 Label:
                     color: 0,0,0,1
-                    font_size: 0.03*app.width
+                    font_size: app.get_scaled_width(24.0)
                     markup: True
                     halign: "center"
                     valign: "bottom"
@@ -84,25 +84,25 @@ Builder.load_string(
 
             BoxLayout: 
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.6875*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(330.0)
                 orientation: "horizontal"
                 spacing: 0
                 padding: 0
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.84375*app.width)
-                    height: dp(0.697916666667*app.height)             
+                    width: app.get_scaled_width(675.0)
+                    height: app.get_scaled_height(335.0)
                     spacing: 0
                     padding: 0
                         
                     # Body
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.84375*app.width)
-                        height: dp(0.6875*app.height)
-                        padding:[dp(0.0075)*app.width, 0, dp(0.00875)*app.width, 0]
+                        width: app.get_scaled_width(675.0)
+                        height: app.get_scaled_height(330.0)
+                        padding: app.get_scaled_tuple([6.0, 0.0, 7.0, 0.0])
                         spacing: 0
                         orientation: 'horizontal'
                         pos: self.parent.pos
@@ -112,33 +112,33 @@ Builder.load_string(
                             id: text_entry_box
                             orientation: 'vertical'
                             size_hint: (None,None)
-                            width: dp(0.245*app.width)
-                            height: dp(0.6875*app.height)
-                            padding:[0, 0, 0, dp(0.0625)*app.height]
-                            spacing:0.0416666666667*app.height
+                            width: app.get_scaled_width(196.0)
+                            height: app.get_scaled_height(330.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 30.0])
+                            spacing: app.get_scaled_width(20.0)
                             pos: self.parent.pos
                             
                             # BL horizontal
                                 # Toggle button
                             BoxLayout:
                                 size_hint: (None,None)
-                                height: dp(0.0666666666667*app.height)
-                                width: dp(0.245*app.width)
-                                padding:[dp(0.07)*app.width, 0, dp(0.0125)*app.width, 0]
+                                height: app.get_scaled_height(32.0)
+                                width: app.get_scaled_width(196.0)
+                                padding: app.get_scaled_tuple([56.0, 0.0, 10.0, 0.0])
                                 orientation: "horizontal"
         
                                                               
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.0666666666667*app.height)
-                                    width: dp(0.15*app.width)
-                                    padding:[dp(0.04625)*app.width, 0, 0, 0]
+                                    height: app.get_scaled_height(32.0)
+                                    width: app.get_scaled_width(120.0)
+                                    padding: app.get_scaled_tuple([37.0, 0.0, 0.0, 0.0])
                                
                                     Switch:
                                         id: unit_toggle
                                         size_hint: (None,None)
-                                        height: dp(0.0666666666667*app.height)
-                                        width: dp(0.10375*app.width)
+                                        height: app.get_scaled_height(32.0)
+                                        width: app.get_scaled_width(83.0)
                                         background_color: hex('#F4433600')
                                         center: self.parent.center
                                         pos: self.parent.pos
@@ -165,15 +165,15 @@ Builder.load_string(
                             BoxLayout: #dimension 1
                                 id: dimension_1
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.245*app.width)
-                                padding:[dp(0.0375)*app.width, 0, dp(0.025)*app.width, 0]
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(196.0)
+                                padding: app.get_scaled_tuple([30.0, 0.0, 20.0, 0.0])
                                 orientation: "horizontal"
                                 
                                 Label: 
                                     text: root.dim_1
                                     color: 0,0,0,1
-                                    font_size: 0.03*app.width
+                                    font_size: app.get_scaled_width(24.0)
                                     markup: True
                                     halign: "left"
                                     valign: "middle"
@@ -184,16 +184,16 @@ Builder.load_string(
                                 BoxLayout:
                                     id: dimesion_1_input_box
                                     size_hint: (None,None)
-                                    height: dp(0.0833333333333*app.height)
-                                    width: dp(0.15*app.width)
-                                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                                    height: app.get_scaled_height(40.0)
+                                    width: app.get_scaled_width(120.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                 
                                     TextInput: 
                                         id: input_dim1
                                         valign: 'middle'
                                         halign: 'center'
                                         text_size: self.size
-                                        font_size: str(0.025*app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('20.0sp')
                                         markup: True
                                         input_filter: 'float'
                                         multiline: False
@@ -201,15 +201,15 @@ Builder.load_string(
 
                             BoxLayout: #dimension 2
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.245*app.width)
-                                padding:[dp(0.0375)*app.width, 0, dp(0.025)*app.width, 0]
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(196.0)
+                                padding: app.get_scaled_tuple([30.0, 0.0, 20.0, 0.0])
                                 orientation: "horizontal"
                                 
                                 Label: 
                                     text: root.dim_2
                                     color: 0,0,0,1
-                                    font_size: 0.03*app.width
+                                    font_size: app.get_scaled_width(24.0)
                                     markup: True
                                     halign: "left"
                                     valign: "middle"
@@ -219,16 +219,16 @@ Builder.load_string(
                                                               
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.0833333333333*app.height)
-                                    width: dp(0.15*app.width)
-                                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                                    height: app.get_scaled_height(40.0)
+                                    width: app.get_scaled_width(120.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                 
                                     TextInput: 
                                         id: input_dim2
                                         valign: 'middle'
                                         halign: 'center'
                                         text_size: self.size
-                                        font_size: str(0.025*app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('20.0sp')
                                         markup: True
                                         input_type: 'number'
                                         input_filter: 'float'
@@ -237,15 +237,15 @@ Builder.load_string(
 
                             BoxLayout: #dimension 3
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.245*app.width)
-                                padding:[dp(0.0375)*app.width, 0, dp(0.025)*app.width, 0]
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(196.0)
+                                padding: app.get_scaled_tuple([30.0, 0.0, 20.0, 0.0])
                                 orientation: "horizontal"
                                 
                                 Label: 
                                     text: root.dim_3
                                     color: 0,0,0,1
-                                    font_size: 0.03*app.width
+                                    font_size: app.get_scaled_width(24.0)
                                     markup: True
                                     halign: "left"
                                     valign: "middle"
@@ -255,16 +255,16 @@ Builder.load_string(
                                                               
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.0833333333333*app.height)
-                                    width: dp(0.15*app.width)
-                                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                                    height: app.get_scaled_height(40.0)
+                                    width: app.get_scaled_width(120.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                 
                                     TextInput: 
                                         id: input_dim3
                                         valign: 'middle'
                                         halign: 'center'
                                         text_size: self.size
-                                        font_size: str(0.025*app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('20.0sp')
                                         markup: True
                                         input_filter: 'float'
                                         multiline: False
@@ -272,15 +272,15 @@ Builder.load_string(
                                                                         
                             BoxLayout: #dimension 4
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.245*app.width)
-                                padding:[dp(0.0375)*app.width, 0, dp(0.025)*app.width, 0]
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(196.0)
+                                padding: app.get_scaled_tuple([30.0, 0.0, 20.0, 0.0])
                                 orientation: "horizontal"
                                 
                                 Label: 
                                     text: root.dim_4
                                     color: 0,0,0,1
-                                    font_size: 0.03*app.width
+                                    font_size: app.get_scaled_width(24.0)
                                     markup: True
                                     halign: "left"
                                     valign: "middle"
@@ -290,16 +290,16 @@ Builder.load_string(
                                                               
                                 BoxLayout: 
                                     size_hint: (None,None)
-                                    height: dp(0.0833333333333*app.height)
-                                    width: dp(0.15*app.width)
-                                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                                    height: app.get_scaled_height(40.0)
+                                    width: app.get_scaled_width(120.0)
+                                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                                                 
                                     TextInput: 
                                         id: input_dim4
                                         valign: 'top'
                                         halign: 'center'
                                         text_size: self.size
-                                        font_size: str(0.025*app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('20.0sp')
                                         markup: True
                                         input_filter: 'float'
                                         multiline: False
@@ -308,9 +308,9 @@ Builder.load_string(
                         # Image
                         BoxLayout:
                             size_hint: (None,None)
-                            width: dp(0.58*app.width)
-                            height: dp(0.6875*app.height)
-                            padding:[0, 0, 0, dp(0.0458333333333)*app.height]
+                            width: app.get_scaled_width(464.0)
+                            height: app.get_scaled_height(330.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 22.0])
                             pos: self.parent.pos
                             
                             # image box
@@ -327,8 +327,8 @@ Builder.load_string(
                                     allow_stretch: True  
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.84375*app.width)
-                        height: dp(0.00625*app.height)
+                        width: app.get_scaled_width(675.0)
+                        height: app.get_scaled_height(3.0)
                         padding: 0
                         spacing: 0
                         orientation: 'horizontal'
@@ -336,23 +336,23 @@ Builder.load_string(
                     
                 BoxLayout: #action box
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(0.15625*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, dp(0.04625)*app.width, dp(0.0708333333333)*app.height]
-                    spacing:0.0708333333333*app.height
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(125.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 37.0, 34.0])
+                    spacing: app.get_scaled_width(34.0)
                     orientation: "vertical"
                     
                     BoxLayout: 
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
-                        padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
+                        padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: info_button
                             size_hint: (None,None)
-                            height: dp(0.0833333333333*app.height)
-                            width: dp(0.05*app.width)
+                            height: app.get_scaled_height(40.0)
+                            width: app.get_scaled_width(40.0)
                             background_color: hex('#F4433600')
                             opacity: 1
                             on_press: root.get_info()
@@ -368,11 +368,11 @@ Builder.load_string(
                                     allow_stretch: True
         
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: back_button
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
                         background_color: hex('#F4433600')
                         on_press: root.go_back()
                         BoxLayout:
@@ -386,10 +386,10 @@ Builder.load_string(
                                 size: self.parent.width, self.parent.height
                                 allow_stretch: True
                     Button: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
                         background_color: hex('#F4433600')
                         on_press: root.check_dimensions()
                         BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_exit.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_exit.py
@@ -15,8 +15,8 @@ Builder.load_string(
 <ShapeCutterExitScreenClass>:
     
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -30,10 +30,10 @@ Builder.load_string(
                 
             Label:
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Leaving Shape Cutter..."
-                font_size: 0.0375*app.width
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
@@ -41,19 +41,19 @@ Builder.load_string(
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.8125*app.height)
-                padding:[0, dp(0.229166666667)*app.height, 0, dp(0.229166666667)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(390.0)
+                padding: app.get_scaled_tuple([0.0, 110.0, 0.0, 110.0])
                 spacing: 0
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.354166666667*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(170.0)
+                    width: app.get_scaled_width(800.0)
                     halign: "center"
                     valign: "middle"
                     text: "Bye!"
                     color: 0,0,0,1
-                    font_size: 0.0325*app.width
+                    font_size: app.get_scaled_width(26.0)
                     markup: True
 
 """

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_feedback.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_feedback.py
@@ -15,8 +15,8 @@ Builder.load_string("""
 <ShapeCutterFeedbackScreenClass>:
     
     BoxLayout:
-        height: dp(800)
-        width: dp(480)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -30,10 +30,10 @@ Builder.load_string("""
                 
             Label:
                 size_hint: (None,None)
-                height: dp(90)
-                width: dp(800)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Feedback"
-                font_size: 30
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
@@ -41,42 +41,42 @@ Builder.load_string("""
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(800)
-                height: dp(140)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(140.0)
                 padding: 0
                 spacing: 0
                 Label:
                     size_hint: (None,None)
-                    height: dp(170)
-                    width: dp(800)
+                    height: app.get_scaled_height(170.0)
+                    width: app.get_scaled_width(800.0)
                     halign: "center"
                     valign: "middle"
                     text: "Was your job successful?"
                     color: 0,0,0,1
-                    font_size: 26
+                    font_size: app.get_scaled_width(26.0)
                     markup: True
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(800)
-                height: dp(170)
-                padding: (180,0,180,30)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(170.0)
+                padding: app.get_scaled_tuple([180.0, 0.0, 180.0, 30.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos                
                 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(220)
-                    height: dp(171)
-                    padding: (28,0,20,0)
+                    width: app.get_scaled_width(220.0)
+                    height: app.get_scaled_height(171.0)
+                    padding: app.get_scaled_tuple([28.0, 0.0, 20.0, 0.0])
                     pos: self.parent.pos
                     
                     # thumbs up button
                     Button:
                         size_hint: (None,None)
-                        height: dp(171)
-                        width: dp(172)
+                        height: app.get_scaled_height(171.0)
+                        width: app.get_scaled_width(172.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -93,16 +93,16 @@ Builder.load_string("""
                                 allow_stretch: True
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(220)
-                    height: dp(171)
-                    padding: (20,0,28,0)
+                    width: app.get_scaled_width(220.0)
+                    height: app.get_scaled_height(171.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 28.0, 0.0])
                     pos: self.parent.pos
                     
                     # thumbs down button
                     Button:
                         size_hint: (None,None)
-                        height: dp(171)
-                        width: dp(172)
+                        height: app.get_scaled_height(171.0)
+                        width: app.get_scaled_width(172.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -119,9 +119,9 @@ Builder.load_string("""
                                 allow_stretch: True  
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(800)
-                height: dp(80)
-                padding: (740,0,0,20)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
+                padding: app.get_scaled_tuple([740.0, 0.0, 0.0, 20.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_filechooser.py
@@ -33,7 +33,7 @@ Builder.load_string(
 
     BoxLayout:
         padding: 0
-        spacing:0.0208333333333*app.height
+        spacing: app.get_scaled_width(10.0)
         size: root.size
         pos: root.pos
         orientation: "vertical"
@@ -41,7 +41,7 @@ Builder.load_string(
             orientation: 'horizontal'
             size: self.parent.size
             pos: self.parent.pos
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
             FileChooser:
                 size_hint_x: 5
                 id: filechooser_sc_params
@@ -55,16 +55,16 @@ Builder.load_string(
                 
         BoxLayout:
             size_hint_y: None
-            height: dp(100.0/480.0)*app.height
+            height: app.get_scaled_height(100.0)
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: toggle_view_button
                 size_hint_x: 1
                 on_press: root.switch_view()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -76,7 +76,7 @@ Builder.load_string(
                         allow_stretch: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -86,7 +86,7 @@ Builder.load_string(
                     root.refresh_filechooser() 
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -97,7 +97,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: delete_selected_button
                 disabled: True
                 size_hint_x: 1
@@ -109,7 +109,7 @@ Builder.load_string(
                     # root.delete_selected(filechooser_sc_params.selection[0])
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -120,7 +120,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: delete_all_button
                 disabled: False
                 size_hint_x: 1
@@ -131,7 +131,7 @@ Builder.load_string(
                     root.delete_popup(file_selection = 'all')
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -142,7 +142,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -152,7 +152,7 @@ Builder.load_string(
                     root.quit_to_home()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -163,7 +163,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: load_button
                 disabled: True
                 size_hint_x: 1
@@ -173,7 +173,7 @@ Builder.load_string(
                     root.return_to_SC17(filechooser_sc_params.selection[0])
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_landing.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_landing.py
@@ -17,8 +17,8 @@ Builder.load_string(
 <ShapeCutterLandingScreenClass>:
     
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -32,10 +32,10 @@ Builder.load_string(
                 
             Label:
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Welcome to Shape Cutter"
-                font_size: 0.0375*app.width
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
@@ -43,43 +43,43 @@ Builder.load_string(
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.291666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(140.0)
                 padding: 0
                 spacing: 0
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.354166666667*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(170.0)
+                    width: app.get_scaled_width(800.0)
                     halign: "center"
                     valign: "middle"
                     text: "Select a shape to cut..."
                     color: 0,0,0,1
-                    font_size: 0.0325*app.width
+                    font_size: app.get_scaled_width(26.0)
                     markup: True
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.354166666667*app.height)
-                padding:[dp(0.225)*app.width, 0, dp(0.225)*app.width, dp(0.0625)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(170.0)
+                padding: app.get_scaled_tuple([180.0, 0.0, 180.0, 30.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos                
                 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.275*app.width)
-                    height: dp(0.354166666667*app.height)
-                    padding:[dp(0.03125)*app.width, 0, dp(0.03375)*app.width, 0]
+                    width: app.get_scaled_width(220.0)
+                    height: app.get_scaled_height(170.0)
+                    padding: app.get_scaled_tuple([25.0, 0.0, 27.0, 0.0])
                     pos: self.parent.pos
                     
                     # Circle button
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.35*app.height)
-                        width: dp(0.21*app.width)
+                        height: app.get_scaled_height(168.0)
+                        width: app.get_scaled_width(168.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -96,17 +96,17 @@ Builder.load_string(
                                 allow_stretch: True
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.275*app.width)
-                    height: dp(0.354166666667*app.height)
-                    padding:[dp(0.03375)*app.width, 0, dp(0.03125)*app.width, 0]
+                    width: app.get_scaled_width(220.0)
+                    height: app.get_scaled_height(170.0)
+                    padding: app.get_scaled_tuple([27.0, 0.0, 25.0, 0.0])
                     pos: self.parent.pos
                     
                     # rectangle button
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.35*app.height)
-                        width: dp(0.21*app.width)
+                        height: app.get_scaled_height(168.0)
+                        width: app.get_scaled_width(168.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -124,18 +124,18 @@ Builder.load_string(
             # Info button
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
-                padding:[dp(0.025)*app.width, 0, 0, dp(0.0416666666667)*app.height]
-                spacing:0.85*app.width
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
+                padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 20.0])
+                spacing: app.get_scaled_width(680.0)
                 orientation: 'horizontal'
                 pos: self.parent.pos
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: info_button
                     size_hint: (None,None)
-                    height: dp(0.0833333333333*app.height)
-                    width: dp(0.05*app.width)
+                    height: app.get_scaled_height(40.0)
+                    width: app.get_scaled_width(40.0)
                     background_color: hex('#F4433600')
                     opacity: 1
                     on_press: root.get_info()
@@ -150,11 +150,11 @@ Builder.load_string(
                             size: self.parent.width, self.parent.height
                             allow_stretch: True
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: exit_button
                     size_hint: (None,None)
-                    height: dp(0.0833333333333*app.height)
-                    width: dp(0.05*app.width)
+                    height: app.get_scaled_height(40.0)
+                    width: app.get_scaled_width(40.0)
                     background_color: hex('#F4433600')
                     opacity: 1
                     on_press: root.exit()

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_post_job_save.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_post_job_save.py
@@ -21,8 +21,8 @@ Builder.load_string("""
     on_touch_down: root.on_touch()
     
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -37,46 +37,46 @@ Builder.load_string("""
             LabelBase:
                 color: 1,1,1,1
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Would you like to save this as a new profile?"
-                font_size: 0.0375*app.width
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
 
             BoxLayout: #Body
                 size_hint: (None,None)
-                height: dp(0.8125*app.height)
-                width: dp(1.0*app.width)
-                padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                height: app.get_scaled_height(390.0)
+                width: app.get_scaled_width(800.0)
+                padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                 orientation: "horizontal"
                 
                 BoxLayout: #text box
                     size_hint: (None,None)
-                    height: dp(0.8125*app.height)
-                    width: dp(0.84375*app.width)
-                    padding:[dp(0.0125)*app.width, 0, dp(0.03125)*app.width, dp(0.0208333333333)*app.height]
+                    height: app.get_scaled_height(390.0)
+                    width: app.get_scaled_width(675.0)
+                    padding: app.get_scaled_tuple([10.0, 0.0, 25.0, 10.0])
                     orientation: "horizontal"
                     BoxLayout: # file save
                         size_hint: (None,None)
-                        height: dp(0.791666666667*app.height)
-                        width: dp(0.375*app.width)
-                        padding:[0, dp(0.104166666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(380.0)
+                        width: app.get_scaled_width(300.0)
+                        padding: app.get_scaled_tuple([0.0, 50.0, 0.0, 0.0])
                         orientation: "vertical"
-                        spacing:0.0416666666667*app.height
+                        spacing: app.get_scaled_width(20.0)
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.208333333333*app.height)
-                            width: dp(0.375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(100.0)
+                            width: app.get_scaled_width(300.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             orientation: "vertical"
-                            spacing:0.0416666666667*app.height
+                            spacing: app.get_scaled_width(20.0)
 
                             LabelBase: 
                                 text: ''
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "center"
                                 valign: "top"
@@ -86,30 +86,30 @@ Builder.load_string("""
                                 
                             BoxLayout: 
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.375*app.width)
-                                padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(300.0)
+                                padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
                                             
                                 TextInput: 
                                     id: file_name
                                     valign: 'middle'
                                     halign: 'center'
                                     text_size: self.size
-                                    font_size: str(0.025*app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('20.0sp')
                                     markup: True
                                     multiline: False
                                     text: ''
                           
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.35*app.height)
-                            width: dp(0.375*app.width)
-                            padding:[dp(0.0825)*app.width, 0, dp(0.0825)*app.width, 0]
+                            height: app.get_scaled_height(168.0)
+                            width: app.get_scaled_width(300.0)
+                            padding: app.get_scaled_tuple([66.0, 0.0, 66.0, 0.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 size_hint: (None,None)
-                                height: dp(0.35*app.height)
-                                width: dp(0.21*app.width)
+                                height: app.get_scaled_height(168.0)
+                                width: app.get_scaled_width(168.0)
                                 on_press: root.save_file()
                                 background_color: hex('#F4433600')
                                 BoxLayout:
@@ -123,15 +123,15 @@ Builder.load_string("""
                                         allow_stretch: True
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.0833333333333*app.height)
-                            width: dp(0.375*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(40.0)
+                            width: app.get_scaled_width(300.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                         
                     BoxLayout: # document viewer
                         size_hint: (None,None)
-                        height: dp(0.625*app.height)
-                        width: dp(0.4375*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(300.0)
+                        width: app.get_scaled_width(350.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         ScrollView:
                             size_hint: (None, None)
                             size: self.parent.size
@@ -142,26 +142,26 @@ Builder.load_string("""
                             RstDocument:
                                 text: root.display_profile
                                 background_color: hex('#FFFFFF')                 
-                                base_font_size: str(31.0/800.0*app.width) + 'sp'
+                                base_font_size: app.get_scaled_sp('31.0sp')
                 BoxLayout: #action box
                     size_hint: (None,None)
-                    height: dp(0.645833333333*app.height)
-                    width: dp(0.15625*app.width)
-                    padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                    spacing:0.0708333333333*app.height
+                    height: app.get_scaled_height(310.0)
+                    width: app.get_scaled_width(125.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                    spacing: app.get_scaled_width(34.0)
                     orientation: "vertical"
                     
                     BoxLayout: 
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
-                        padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
+                        padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: info_button
                             size_hint: (None,None)
-                            height: dp(0.0833333333333*app.height)
-                            width: dp(0.05*app.width)
+                            height: app.get_scaled_height(40.0)
+                            width: app.get_scaled_width(40.0)
                             background_color: hex('#F4433600')
                             opacity: 0
                             on_press: root.get_info()
@@ -177,10 +177,10 @@ Builder.load_string("""
                                     allow_stretch: True
 
                     Button: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
                         background_color: hex('#F4433600')
                         opacity: 0
                         BoxLayout:
@@ -194,10 +194,10 @@ Builder.load_string("""
                                 size: self.parent.width, self.parent.height
                                 allow_stretch: True
                     Button: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.139583333333*app.height)
-                        width: dp(0.11*app.width)
+                        height: app.get_scaled_height(67.0)
+                        width: app.get_scaled_width(88.0)
                         background_color: hex('#F4433600')
                         on_press: root.next_screen()
                         BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_repeat.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_repeat.py
@@ -14,8 +14,8 @@ Builder.load_string(
 <ShapeCutterRepeatScreenClass>:
     
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas:
             Rectangle: 
                 pos: self.pos
@@ -29,10 +29,10 @@ Builder.load_string(
                 
             Label:
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(800.0)
                 text: "Would you like to do this again?"
-                font_size: 0.0375*app.width
+                font_size: app.get_scaled_width(30.0)
                 halign: "center"
                 valign: "bottom"
                 markup: True
@@ -40,43 +40,43 @@ Builder.load_string(
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.291666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(140.0)
                 padding: 0
                 spacing: 0
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.354166666667*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(170.0)
+                    width: app.get_scaled_width(800.0)
                     halign: "center"
                     valign: "middle"
                     text: ""
                     color: 0,0,0,1
-                    font_size: 0.0325*app.width
+                    font_size: app.get_scaled_width(26.0)
                     markup: True
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.354166666667*app.height)
-                padding:[dp(0.125)*app.width, 0, dp(0.125)*app.width, dp(0.0625)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(170.0)
+                padding: app.get_scaled_tuple([100.0, 0.0, 100.0, 30.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos                
                 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.25*app.width)
-                    height: dp(0.35625*app.height)
-                    padding:[dp(0.02)*app.width, 0, dp(0.02)*app.width, 0]
+                    width: app.get_scaled_width(200.0)
+                    height: app.get_scaled_height(171.0)
+                    padding: app.get_scaled_tuple([16.0, 0.0, 16.0, 0.0])
                     pos: self.parent.pos
                     
                     # Repeat
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.35625*app.height)
-                        width: dp(0.21*app.width)
+                        height: app.get_scaled_height(171.0)
+                        width: app.get_scaled_width(168.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -93,17 +93,17 @@ Builder.load_string(
                                 allow_stretch: True
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.25*app.width)
-                    height: dp(0.35625*app.height)
-                    padding:[dp(0.02)*app.width, 0, dp(0.02)*app.width, 0]
+                    width: app.get_scaled_width(200.0)
+                    height: app.get_scaled_height(171.0)
+                    padding: app.get_scaled_tuple([16.0, 0.0, 16.0, 0.0])
                     pos: self.parent.pos
                     
                     # New
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.35625*app.height)
-                        width: dp(0.21*app.width)
+                        height: app.get_scaled_height(171.0)
+                        width: app.get_scaled_width(168.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -120,17 +120,17 @@ Builder.load_string(
                                 allow_stretch: True
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.25*app.width)
-                    height: dp(0.35625*app.height)
-                    padding:[dp(0.02)*app.width, 0, dp(0.02)*app.width, 0]
+                    width: app.get_scaled_width(200.0)
+                    height: app.get_scaled_height(171.0)
+                    padding: app.get_scaled_tuple([16.0, 0.0, 16.0, 0.0])
                     pos: self.parent.pos
                     
                     # Next
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.35625*app.height)
-                        width: dp(0.21*app.width)
+                        height: app.get_scaled_height(171.0)
+                        width: app.get_scaled_width(168.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -147,9 +147,9 @@ Builder.load_string(
                                 allow_stretch: True  
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
-                padding:[dp(0.925)*app.width, 0, 0, dp(0.0416666666667)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
+                padding: app.get_scaled_tuple([740.0, 0.0, 0.0, 20.0])
                 spacing: 0
                 orientation: 'horizontal'
                 pos: self.parent.pos

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_tutorial.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_tutorial.py
@@ -30,26 +30,26 @@ Builder.load_string(
 
     BoxLayout:
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         padding: 0
         spacing: 0
         orientation: "vertical"
 
         BoxLayout:
             size_hint: (None,None)
-            width: dp(1.0*app.width)
-            height: dp(0.1875*app.height)
+            width: app.get_scaled_width(800.0)
+            height: app.get_scaled_height(90.0)
             padding: 0
             spacing: 0
             orientation: "horizontal"
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: prepare_tab
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 disabled: True
                 on_press: root.prepare()
                 BoxLayout:
@@ -63,11 +63,11 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: load_tab
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 disabled: True
                 on_press: root.load()
                 BoxLayout:
@@ -81,11 +81,11 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: define_tab
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 disabled: True
                 on_press: root.define()
                 BoxLayout:
@@ -99,11 +99,11 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: position_tab
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 disabled: True
                 on_press: root.position()
                 BoxLayout:
@@ -117,11 +117,11 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: check_tab
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1775*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(142.0)
                 disabled: True
                 on_press: root.check()
                 BoxLayout:
@@ -135,10 +135,10 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.1875*app.height)
-                width: dp(0.1125*app.width)
+                height: app.get_scaled_height(90.0)
+                width: app.get_scaled_width(90.0)
                 on_press: root.exit()
                 BoxLayout:
                     padding: 0
@@ -154,8 +154,8 @@ Builder.load_string(
         BoxLayout:
             size_hint: (None,None)
             padding: 0
-            height: dp(0.8125*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(390.0)
+            width: app.get_scaled_width(800.0)
             canvas:
                 Rectangle: 
                     pos: self.pos
@@ -169,16 +169,16 @@ Builder.load_string(
                     
                 BoxLayout: #Header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[dp(0.025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #Screen number
                         size_hint: (None,None)
                         padding: 0
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.05*app.width)
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(40.0)
                         canvas:
                             Rectangle: 
                                 pos: self.pos
@@ -187,14 +187,14 @@ Builder.load_string(
                         
                     BoxLayout: #Title
                         size_hint: (None,None)
-                        height: dp(0.125*app.height)
-                        width: dp(0.925*app.width)
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, 0, 0]
+                        height: app.get_scaled_height(60.0)
+                        width: app.get_scaled_width(740.0)
+                        padding: app.get_scaled_tuple([20.0, 20.0, 0.0, 0.0])
                         
                         Label:
                             text: root.title_label
                             color: 0,0,0,1
-                            font_size: 0.035*app.width
+                            font_size: app.get_scaled_width(28.0)
                             markup: True
                             halign: "left"
                             valign: "bottom"
@@ -205,21 +205,21 @@ Builder.load_string(
                     
                 BoxLayout: #Body
                     size_hint: (None,None)
-                    height: dp(0.6875*app.height)
-                    width: dp(1.0*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(330.0)
+                    width: app.get_scaled_width(800.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
                     orientation: "horizontal"
                     
                     BoxLayout: #text box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.84375*app.width)
-                        padding:[dp(0.1)*app.width, 0, 0, 0]
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(675.0)
+                        padding: app.get_scaled_tuple([80.0, 0.0, 0.0, 0.0])
                         
                         Label:
                             id: user_instructions
                             color: 0,0,0,1
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
                             valign: "top"
@@ -229,23 +229,23 @@ Builder.load_string(
 
                     BoxLayout: #action box
                         size_hint: (None,None)
-                        height: dp(0.645833333333*app.height)
-                        width: dp(0.15625*app.width)
-                        padding:[0, 0, 0, dp(0.0708333333333)*app.height]
-                        spacing:0.0708333333333*app.height
+                        height: app.get_scaled_height(310.0)
+                        width: app.get_scaled_width(125.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 34.0])
+                        spacing: app.get_scaled_width(34.0)
                         orientation: "vertical"
                         
                         BoxLayout: 
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
-                            padding:[dp(0.03)*app.width, 0, dp(0.03)*app.width, dp(0.0708333333333)*app.height]
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
+                            padding: app.get_scaled_tuple([24.0, 0.0, 24.0, 34.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: info_button
                                 size_hint: (None,None)
-                                height: dp(0.0833333333333*app.height)
-                                width: dp(0.05*app.width)
+                                height: app.get_scaled_height(40.0)
+                                width: app.get_scaled_width(40.0)
                                 background_color: hex('#F4433600')
                                 opacity: 1
                                 on_press: root.get_info()
@@ -261,11 +261,11 @@ Builder.load_string(
                                         allow_stretch: True
 
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: back_arrow
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.go_back()
                             BoxLayout:
@@ -280,11 +280,11 @@ Builder.load_string(
                                     size: self.parent.width, self.parent.height
                                     allow_stretch: True
                         Button: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: next_arrow
                             size_hint: (None,None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             on_press: root.next_screen()
                             BoxLayout:

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC15_xy_move.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC15_xy_move.py
@@ -34,14 +34,14 @@ Builder.load_string(
         BoxLayout:
             size_hint_y: None
             height: self.width
-            padding:[dp(0.1)*app.width, dp(0.125)*app.height, dp(0.05)*app.width, dp(0.125)*app.height]
+            padding: app.get_scaled_tuple([80.0, 60.0, 40.0, 60.0])
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: speed_toggle
                 on_press: root.set_jog_speeds()
                 background_color: 1, 1, 1, 0 
                 BoxLayout:
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size: self.parent.size
                     pos: self.parent.pos      
                     Image:
@@ -62,7 +62,7 @@ Builder.load_string(
 
 #             # go x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
 #                 Button:
@@ -85,7 +85,7 @@ Builder.load_string(
 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -107,7 +107,7 @@ Builder.load_string(
 
 #             # go y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
 #                 Button:
@@ -128,7 +128,7 @@ Builder.load_string(
 #                             allow_stretch: True  
                             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -148,7 +148,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -167,7 +167,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -189,7 +189,7 @@ Builder.load_string(
 
 #             # set x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
 #                 Button:
@@ -210,7 +210,7 @@ Builder.load_string(
 #                             allow_stretch: True               
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
@@ -231,7 +231,7 @@ Builder.load_string(
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos 
 #                 ToggleButton:
@@ -239,7 +239,7 @@ Builder.load_string(
 #                     on_press: root.set_jog_speeds()
 #                     background_color: 1, 1, 1, 0 
 #                     BoxLayout:
-#                         padding: 10
+#                         padding: app.get_scaled_width(10.0)
 #                         size: self.parent.size
 #                         pos: self.parent.pos      
 #                         Image:

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC28_xy_move.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC28_xy_move.py
@@ -30,8 +30,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([10.0, 10.0])
+        spacing: app.get_scaled_width(10.0)
         
         GridLayout:
             cols: 3
@@ -43,11 +43,11 @@ Builder.load_string(
 
             # go x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -67,7 +67,7 @@ Builder.load_string(
 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -89,11 +89,11 @@ Builder.load_string(
 
             # go y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -111,7 +111,7 @@ Builder.load_string(
                             allow_stretch: True  
                             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -131,7 +131,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -150,7 +150,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -172,11 +172,11 @@ Builder.load_string(
 
             # set x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -194,7 +194,7 @@ Builder.load_string(
                             allow_stretch: True               
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
@@ -216,11 +216,11 @@ Builder.load_string(
 
             # set y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -240,10 +240,10 @@ Builder.load_string(
                 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -263,12 +263,12 @@ Builder.load_string(
             BoxLayout:
                 size_hint_x: 3
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: speed_toggle
                     on_press: root.set_jog_speeds()
                     background_color: 1, 1, 1, 0 
                     BoxLayout:
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        padding: app.get_scaled_tuple([10.0, 10.0])
                         size: self.parent.size
                         pos: self.parent.pos      
                         Image:
@@ -279,7 +279,7 @@ Builder.load_string(
                             size: self.parent.width, self.parent.height
                             allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_xy_move.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_xy_move.py
@@ -27,8 +27,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([10.0, 10.0])
+        spacing: app.get_scaled_width(10.0)
         
         GridLayout:
             cols: 3
@@ -40,14 +40,14 @@ Builder.load_string(
 
             # go x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos          
             
 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -69,12 +69,12 @@ Builder.load_string(
 
             # go y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos
                             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -94,7 +94,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -113,7 +113,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -135,7 +135,7 @@ Builder.load_string(
 
             # set x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
 #                 Button:
@@ -156,7 +156,7 @@ Builder.load_string(
 #                             allow_stretch: True               
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
@@ -178,7 +178,7 @@ Builder.load_string(
 
             # set y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos
 #                 Button:
@@ -201,10 +201,10 @@ Builder.load_string(
                 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -225,7 +225,7 @@ Builder.load_string(
                 size_hint_x: 2
 #                 id: virtual_bed_container
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 disabled: True
                 opacity: 0

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_move.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_move.py
@@ -22,12 +22,12 @@ Builder.load_string(
 
         size: self.parent.size
         pos: self.parent.pos      
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-        spacing:0.0125*app.width
+        padding: app.get_scaled_tuple([20.0, 20.0])
+        spacing: app.get_scaled_width(10.0)
         orientation: 'horizontal'
         
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             BoxLayout:
@@ -36,11 +36,11 @@ Builder.load_string(
                 id: virtual_z_container
 
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release:
@@ -61,7 +61,7 @@ Builder.load_string(
                         allow_stretch: True   
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -83,7 +83,7 @@ Builder.load_string(
                         allow_stretch: True   
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_setgo.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC31_z_setgo.py
@@ -23,7 +23,7 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
 
-        spacing:0.0416666666667*app.height
+        spacing: app.get_scaled_width(20.0)
         
         orientation: "vertical"
         
@@ -40,12 +40,12 @@ Builder.load_string(
                     pos: self.pos 
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: speed_toggle
                 on_press: root.set_jog_speeds()
                 background_color: 1, 1, 1, 0 
                 BoxLayout:
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size: self.parent.size
                     pos: self.parent.pos      
                     Image:
@@ -57,7 +57,7 @@ Builder.load_string(
                         allow_stretch: True  
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -77,7 +77,7 @@ Builder.load_string(
                         allow_stretch: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 

--- a/src/asmcnc/apps/shapeCutter_app/screens/widget_sC_work_coordinates.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/widget_sC_work_coordinates.py
@@ -46,8 +46,8 @@ Builder.load_string(
             size: self.size
 
     BoxLayout:
-        padding:[dp(0.00125)*app.width, dp(0.00208333333333)*app.height]
-        spacing:0.0075*app.width
+        padding: app.get_scaled_tuple([1.0, 1.0])
+        spacing: app.get_scaled_width(6.0)
         orientation: "horizontal"
         size: self.parent.size
         pos: self.parent.pos
@@ -60,7 +60,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
         Label:
             size_hint_x: 0.1
             id: grbl_ym_label
@@ -69,7 +69,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
         Label:
             size_hint_x: 0.1
             id: grbl_zm_label
@@ -78,7 +78,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
 
         Label:
             size_hint_x: 0.1
@@ -88,7 +88,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
         Label:
             size_hint_x: 0.1
             id: grbl_yw_label
@@ -97,7 +97,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
         Label:
             size_hint_x: 0.1
             id: grbl_zw_label
@@ -106,7 +106,7 @@ Builder.load_string(
             halign: 'center'
             valign: 'middle'
             markup: True
-            font_size: 0.01625*app.width
+            font_size: app.get_scaled_width(13.0)
 """
 )
 

--- a/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_1.py
+++ b/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_1.py
@@ -23,8 +23,8 @@ Builder.load_string(
 	next_button : next_button
 
 	BoxLayout:
-		height: dp(1.66666666667*app.height)
-		width: dp(0.6*app.width)
+		height: app.get_scaled_height(800.0)
+		width: app.get_scaled_width(480.0)
 		canvas.before:
 			Color: 
 				rgba: hex('#e5e5e5ff')
@@ -50,11 +50,11 @@ Builder.load_string(
 				Label:
 					id: header_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -62,20 +62,20 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
-				padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height, dp(0.025)*app.width, dp(0.0375)*app.height]
-				spacing:dp(0.0208333333333)*app.height
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
+				padding: app.get_scaled_tuple([20.0, 10.0, 20.0, 18.0])
+				spacing: app.get_scaled_width(10.0)
 				orientation: 'vertical'
 
 				Label: 
 					id: we_will_collect
 					size_hint: (None, None)
-					height: dp(0.104166666667*app.height)
-					width: dp(0.925*app.width)
+					height: app.get_scaled_height(50.0)
+					width: app.get_scaled_width(740.0)
 					# color: hex('#f9f9f9ff') # white
 					color: hex('#333333ff') #grey
-					font_size: dp(0.0225*app.width)
+					font_size: app.get_scaled_width(18.0)
 					halign: "left"
 					valign: "top"
 					markup: True
@@ -85,18 +85,18 @@ Builder.load_string(
 					cols: 2
 					rows: 2
 					size_hint: (None, None)
-					height: dp(0.166666666667*app.height)
-					width: dp(0.925*app.width)
+					height: app.get_scaled_height(80.0)
+					width: app.get_scaled_width(740.0)
 
 					# Row 1 Col 1
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/green_tick.png"
 			                    allow_stretch: True
@@ -105,7 +105,7 @@ Builder.load_string(
 	                    	id: job_critical_events
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -113,13 +113,13 @@ Builder.load_string(
 
 					# Row 1 Col 2
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/green_tick.png"
 			                    allow_stretch: True
@@ -128,7 +128,7 @@ Builder.load_string(
 	                    	id: maintenance_data
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -136,13 +136,13 @@ Builder.load_string(
 
 					# Row 2 Col 1
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/green_tick.png"
 			                    allow_stretch: True
@@ -151,7 +151,7 @@ Builder.load_string(
 	                    	id: ip_address
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -159,13 +159,13 @@ Builder.load_string(
 
 					# Row 2 Col 2
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/green_tick.png"
 			                    allow_stretch: True
@@ -174,7 +174,7 @@ Builder.load_string(
 	                    	id: console_hostname
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -182,18 +182,18 @@ Builder.load_string(
 
 	            BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.0625*app.height)
-					width: dp(0.925*app.width)
-					padding:[0, 0, 0, 0]
+					height: app.get_scaled_height(30.0)
+					width: app.get_scaled_width(740.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
 					Label: 
 						id: we_wont_collect
 						size_hint: (None, None)
-						height: dp(0.0625*app.height)
-						width: dp(0.925*app.width)
+						height: app.get_scaled_height(30.0)
+						width: app.get_scaled_width(740.0)
 						# color: hex('#f9f9f9ff') # white
 						color: hex('#333333ff') #grey
-						font_size: dp(0.0225*app.width)
+						font_size: app.get_scaled_width(18.0)
 						halign: "left"
 						valign: "bottom"
 						markup: True
@@ -203,18 +203,18 @@ Builder.load_string(
 					cols: 2
 					rows: 2
 					size_hint: (None, None)
-					height: dp(0.166666666667*app.height)
-					width: dp(0.925*app.width)
+					height: app.get_scaled_height(80.0)
+					width: app.get_scaled_width(740.0)
 
 					# Row 1 Col 1
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/red_cross.png"
 			                    allow_stretch: True
@@ -223,7 +223,7 @@ Builder.load_string(
 	                    	id: g_code_files
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -231,13 +231,13 @@ Builder.load_string(
 
 					# Row 1 Col 2
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/red_cross.png"
 			                    allow_stretch: True
@@ -246,7 +246,7 @@ Builder.load_string(
 	                    	id: wifi_network_details
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -254,13 +254,13 @@ Builder.load_string(
 
 					# Row 2 Col 1
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 						BoxLayout: 
 							size_hint_x: None
-							width: dp(0.0375*app.width)
+							width: app.get_scaled_width(30.0)
 			                Image:
 			                    source: "./asmcnc/apps/start_up_sequence/data_consent_app/img/red_cross.png"
 			                    allow_stretch: True
@@ -269,7 +269,7 @@ Builder.load_string(
 	                    	id: serial_numbers
 	                    	# color: hex('#f9f9f9ff') # white
 	                    	color: hex('#333333ff') #grey
-	                    	font_size: dp(0.0225*app.width)
+	                    	font_size: app.get_scaled_width(18.0)
 	                    	halign: "left"
 	                    	valign: "middle"
 	                    	markup: True
@@ -277,30 +277,30 @@ Builder.load_string(
 
 					# Row 2 Col 2
 					BoxLayout: 
-						padding:[dp(0.0125)*app.width, 0]
-						spacing:dp(0.0125)*app.width
+						padding: app.get_scaled_tuple([10.0, 0.0])
+						spacing: app.get_scaled_width(10.0)
 						orientation: 'horizontal'
 
 
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						id: prev_screen_button
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -317,29 +317,29 @@ Builder.load_string(
 								allow_stretch: True
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_2.py
+++ b/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_2.py
@@ -14,8 +14,8 @@ Builder.load_string(
 	next_button : next_button
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#e5e5e5ff')
@@ -41,12 +41,12 @@ Builder.load_string(
                 Label:
                 	id: header_label
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Wi-Fi and Data Consent"
                     color: hex('#f9f9f9ff')
                     # color: hex('#333333ff') #grey
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
@@ -54,9 +54,9 @@ Builder.load_string(
             # BODY
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.620833333333*app.height)
-                padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height, dp(0.025)*app.width, 0]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(298.0)
+                padding: app.get_scaled_tuple([20.0, 10.0, 20.0, 0.0])
                 spacing: 0
                 orientation: 'horizontal'
                 Label: 
@@ -64,7 +64,7 @@ Builder.load_string(
 					size_hint: (1,1)
                     # color: hex('#f9f9f9ff') # white
                     color: hex('#333333ff') #grey
-                    font_size: dp(0.0225*app.width)
+                    font_size: app.get_scaled_width(18.0)
                     halign: "left"
                     valign: "top"
                     markup: True
@@ -73,21 +73,21 @@ Builder.load_string(
 
             # FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -104,29 +104,29 @@ Builder.load_string(
 								allow_stretch: True
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_3.py
+++ b/src/asmcnc/apps/start_up_sequence/data_consent_app/screens/wifi_and_data_consent_3.py
@@ -15,7 +15,7 @@ Builder.load_string(
 
 	RstDocument:
 		id: privacy_notice
-		base_font_size: dp(0.0375)*app.width
+		base_font_size: app.get_scaled_width(30.0)
 		underline_color: 'e5e5e5'
 		colors: root.color_dict
 
@@ -29,8 +29,8 @@ Builder.load_string(
 	accept_button : accept_button
 
 	BoxLayout:
-		height: dp(1.66666666667*app.height)
-		width: dp(0.6*app.width)
+		height: app.get_scaled_height(800.0)
+		width: app.get_scaled_width(480.0)
 		canvas.before:
 			Color: 
 				rgba: hex('#e5e5e5ff')
@@ -56,12 +56,12 @@ Builder.load_string(
 				Label:
 					id: header_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "Wi-Fi and Data Consent"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -69,10 +69,10 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.6*app.height)
-				padding:[dp(0.01875)*app.width, dp(0.0104166666667)*app.height, dp(0.01875)*app.width, dp(0.0104166666667)*app.height]
-				spacing:0.0104166666667*app.height
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(288.0)
+				padding: app.get_scaled_tuple([15.0, 5.0, 15.0, 5.0])
+				spacing: app.get_scaled_width(5.0)
 				orientation: 'vertical'
 
 				BoxLayout: 
@@ -83,14 +83,14 @@ Builder.load_string(
 						Rectangle:
 							pos: self.pos
 							size: self.size
-					padding:[dp(0.00125)*app.width, dp(0.00208333333333)*app.height]
+					padding: app.get_scaled_tuple([1.0, 1.0])
 					ScrollPrivacyNotice:
 						id: scroll_privacy_notice
 
 				BoxLayout: 
 					size_hint: (1,1)
 					orientation: 'horizontal'
-					padding:[dp(0.025)*app.width, 0]
+					padding: app.get_scaled_tuple([20.0, 0.0])
 					# canvas:
 					#	# Test to see box
 					#     Color:
@@ -104,7 +104,7 @@ Builder.load_string(
 						size_hint: (0.7,1)
 						# color: hex('#f9f9f9ff') # white
 						color: hex('#333333ff') #grey
-						font_size: dp(0.0225*app.width)
+						font_size: app.get_scaled_width(18.0)
 						halign: "center"
 						valign: "middle"
 						markup: True
@@ -120,21 +120,21 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.075*app.width)
-					# padding: [0, 0, 184.5, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(60.0)
+					# padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -151,21 +151,21 @@ Builder.load_string(
 								allow_stretch: True
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.825*app.width)
-					padding:[dp(0.0075)*app.width, 0, dp(0.0075)*app.width, dp(0.0875)*app.height]
-					spacing:dp(0.0825)*app.width
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(660.0)
+					padding: app.get_scaled_tuple([6.0, 0.0, 6.0, 42.0])
+					spacing: app.get_scaled_width(66.0)
 					Button:
 						id: decline_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
 						background_disabled_normal: "./asmcnc/apps/start_up_sequence/data_consent_app/img/standard_button_disabled.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.decline_terms()
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
@@ -176,12 +176,12 @@ Builder.load_string(
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
 						background_disabled_normal: "./asmcnc/apps/start_up_sequence/data_consent_app/img/standard_button_disabled.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.accept_terms()
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
@@ -189,9 +189,9 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.075*app.width)
-					# padding: [193.5, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(60.0)
+					# padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_incorrect_shutdown.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_incorrect_shutdown.py
@@ -89,7 +89,7 @@ Builder.load_string("""
                         text_size: self.parent.size
                         markup: True
                         color: hex('333333ff')
-                        line_height: 1.5
+                        line_height: app.get_scaled_height(1.5)
                         
                 Image:
                     size_hint: (0.2,1)

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_pro_plus_safety.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_pro_plus_safety.py
@@ -30,13 +30,13 @@ Builder.load_string(
                 text: 'Safety Information: PrecisionPro +'
                 halign: 'center'
                 valign: 'middle'
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
                 text_size: self.size
 
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: 7
-            padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height, dp(0.025)*app.width, 0]
+            padding: app.get_scaled_tuple([20.0, 10.0, 20.0, 0.0])
 
             canvas: 
                 Color:
@@ -48,7 +48,7 @@ Builder.load_string(
             Label:
                 id: context
                 size_hint_y: 0.41
-                font_size: dp(0.0225*app.width)
+                font_size: app.get_scaled_width(18.0)
                 color: 0,0,0,1
                 halign: 'center'
                 valign: 'middle'
@@ -63,7 +63,7 @@ Builder.load_string(
                 cols: 2
 
                 BoxLayout:
-                    padding:[dp(0.0125)*app.width, 0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     Image:                         
                         source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         center_x: self.parent.center_x
@@ -73,7 +73,7 @@ Builder.load_string(
 
                 Label:
                     id: clamp_warning_label
-                    font_size: dp(0.0225*app.width)
+                    font_size: app.get_scaled_width(18.0)
                     color: 0,0,0,1
                     halign: 'left'
                     valign: 'middle'
@@ -82,7 +82,7 @@ Builder.load_string(
                     text: "The Spindle motor MUST be clamped securely BEFORE plugging in the Spindle motor cables."
 
                 BoxLayout:
-                    padding:[dp(0.0125)*app.width, 0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     Image:                         
                         source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         center_x: self.parent.center_x
@@ -92,7 +92,7 @@ Builder.load_string(
 
                 Label:
                     id: rpm_warning_label
-                    font_size: dp(0.0225*app.width)
+                    font_size: app.get_scaled_width(18.0)
                     color: 0,0,0,1
                     halign: 'left'
                     valign: 'middle'
@@ -103,21 +103,21 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint_y: 0.29
-                padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
                 size_hint: (None, None)
-                height: dp(0.254166666667*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(122.0)
+                width: app.get_scaled_width(800.0)
                 orientation: 'horizontal'
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.254166666667*app.height)
-                    width: dp(0.305625*app.width)
-                    padding:[0, 0, dp(0.230625)*app.width, 0]
+                    height: app.get_scaled_height(122.0)
+                    width: app.get_scaled_width(244.5)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.108333333333*app.height)
-                        width: dp(0.075*app.width)
+                        height: app.get_scaled_height(52.0)
+                        width: app.get_scaled_width(60.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -134,29 +134,29 @@ Builder.load_string(
                                 allow_stretch: True
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.254166666667*app.height)
-                    width: dp(0.36375*app.width)
-                    padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+                    height: app.get_scaled_height(122.0)
+                    width: app.get_scaled_width(291.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
                     Button:
                         id: continue_button
                         background_normal: "./asmcnc/skavaUI/img/next.png"
                         background_down: "./asmcnc/skavaUI/img/next.png"
-                        border: [dp(14.5)]*4
+                        border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                         size_hint: (None,None)
-                        width: dp(0.36375*app.width)
-                        height: dp(0.164583333333*app.height)
+                        width: app.get_scaled_width(291.0)
+                        height: app.get_scaled_height(79.0)
                         on_press: root.next_screen()
                         text: 'Next...'
-                        font_size: str(0.0375*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('30.0sp')
                         color: hex('#f9f9f9ff')
                         markup: True
                         center: self.parent.center
                         pos: self.parent.pos
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.254166666667*app.height)
-                    width: dp(0.305625*app.width)
-                    padding:[dp(0.241875)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(122.0)
+                    width: app.get_scaled_width(244.5)
+                    padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_reboot_to_apply_settings.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_reboot_to_apply_settings.py
@@ -19,8 +19,8 @@ Builder.load_string(
 	next_button : next_button
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 		canvas:
 			Color:
@@ -46,11 +46,11 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -58,18 +58,18 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
 				orientation: 'vertical'
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.416666666667*app.height)
-					padding:[dp(0.025)*app.width, 0]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(200.0)
+					padding: app.get_scaled_tuple([20.0, 0.0])
 					size_hint: (None,None)
 					Label:
 						id: success_label
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						text_size: self.size
 						valign: 'top'
 						halign: 'center'
@@ -77,21 +77,21 @@ Builder.load_string(
 						color: hex('#333333ff')
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -109,29 +109,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_release_notes.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_release_notes.py
@@ -22,10 +22,10 @@ Builder.load_string(
 
     release_notes: release_notes
     BoxLayout:
-        padding:[0, dp(0.03125)*app.height, 0, 0]
+        padding: app.get_scaled_tuple([0.0, 15.0, 0.0, 0.0])
         RstDocument:
             id: release_notes
-            base_font_size: dp(0.0375)*app.width
+            base_font_size: app.get_scaled_width(30.0)
             underline_color: 'e5e5e5'
             colors: root.color_dict
 
@@ -48,7 +48,7 @@ Builder.load_string(
 
     BoxLayout:
         orientation: 'vertical'
-        padding:[0, dp(0.0104166666667)*app.height, 0, 0]
+        padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 0.0])
 
         BoxLayout:
             size_hint_y: 0.4
@@ -56,15 +56,15 @@ Builder.load_string(
             BoxLayout:
                 size_hint_y: 0.6
                 orientation: 'horizontal'
-                padding:[dp(0.01875)*app.width, 0]
-                spacing:dp(0.0125)*app.width
+                padding: app.get_scaled_tuple([15.0, 0.0])
+                spacing: app.get_scaled_width(10.0)
                 Image:
                     size_hint_x: 0.06
                     source: "./asmcnc/skavaUI/img/green_tick.png"
                     allow_stretch: True
                 Label:
                     id: version_number_label
-                    font_size: str(0.0375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('30.0sp')
                     color: hex('#333333')
                     text_size: self.size
                     size: self.texture_size
@@ -73,16 +73,16 @@ Builder.load_string(
             Label:
                 id: please_read_label
                 size_hint_y: 0.4
-                padding:[dp(0.01875)*app.width, 0]
+                padding: app.get_scaled_tuple([15.0, 0.0])
                 color: hex('#333333')
-                font_size: str(0.0225*app.width) + 'sp'
+                font_size: app.get_scaled_sp('18.0sp')
                 text_size: self.size
                 size: self.texture_size
 
         BoxLayout:
             id: release_notes_and_links
-            padding:[dp(0.01875)*app.width, dp(0.00416666666667)*app.height, dp(0.025)*app.width, 0]
-            spacing:dp(0.01875)*app.width
+            padding: app.get_scaled_tuple([15.0, 2.0, 20.0, 0.0])
+            spacing: app.get_scaled_width(15.0)
 
             ScrollReleaseNotes:
                 id: scroll_release_notes
@@ -98,7 +98,7 @@ Builder.load_string(
                     id: url_label
                     size_hint_y: 0.6
                     color: hex('#333333')
-                    font_size: str(0.01625*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('13.0sp')
                     height: self.texture_size[1]
                     text_size: self.size
                     markup: True
@@ -106,13 +106,13 @@ Builder.load_string(
                     halign: "left"
 
         BoxLayout:
-            padding:[dp(0.3125)*app.width, dp(0.00416666666667)*app.height, dp(0.3125)*app.width, dp(0.0208333333333)*app.height]
+            padding: app.get_scaled_tuple([250.0, 2.0, 250.0, 10.0])
             size_hint_y: 0.25
 
             Button:
                 id: next_button
                 # text: 'Next...'
-                font_size: str(0.0375*app.width) + 'sp'
+                font_size: app.get_scaled_sp('30.0sp')
                 background_normal: "./asmcnc/skavaUI/img/next.png"
                 on_press: root.next_screen()
                 color: hex('f9f9f9ff')

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_safety_warning.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_safety_warning.py
@@ -52,7 +52,7 @@ Builder.load_string(
         BoxLayout:
             size_hint_y: 0.9
             orientation: 'vertical'
-            padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height, dp(0.05)*app.width, dp(0.0416666666667)*app.height]
+            padding: app.get_scaled_tuple([40.0, 40.0, 40.0, 20.0])
             size: self.parent.size
             pos: self.parent.pos
       
@@ -67,7 +67,7 @@ Builder.load_string(
                     id: header_label
                     text: '[color=333333][b]Safety Warning[/b][/color]'
                     markup: True
-                    font_size: str(0.03625*app.width) + 'sp' 
+                    font_size: app.get_scaled_sp('29.0sp')
                     valign: 'middle'
                     halign: 'center'
                     size:self.texture_size
@@ -77,20 +77,20 @@ Builder.load_string(
             BoxLayout:
                 size_hint_y: 4.1
     
-                padding:[dp(0.01875)*app.width, 0]
+                padding: app.get_scaled_tuple([15.0, 0.0])
                 orientation: 'vertical'
                 BoxLayout:
                     orientation: 'horizontal'    
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r1_c1
                             size_hint_x: 6
                             halign: 'left'
@@ -104,14 +104,14 @@ Builder.load_string(
                             
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r1_c2
                             size_hint_x: 6
                             text: '[color=333333]Always wear ear defenders, eye protection and a dust mask[/color]'
@@ -126,14 +126,14 @@ Builder.load_string(
                     orientation: 'horizontal'
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r2_c1
                             size_hint_x: 6
                             text: '[color=333333]Risk of injury from rotating tools and axis motion[/color]'
@@ -146,14 +146,14 @@ Builder.load_string(
     
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r2_c2
                             size_hint_x: 6
                             text: '[color=333333]Never put hands into moving machinery[/color]'
@@ -169,14 +169,14 @@ Builder.load_string(
                     orientation: 'horizontal'
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r3_c1
                             size_hint_x: 6
                             text: '[color=333333]Danger to life by magnetic fields - do not use near a pacemaker[/color]'
@@ -188,14 +188,14 @@ Builder.load_string(
                             color: hex('#333333ff')
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r3_c2
                             size_hint_x: 6
                             text: '[color=333333]Ensure the machine is powered from an earthed supply[/color]'
@@ -210,14 +210,14 @@ Builder.load_string(
                     orientation: 'horizontal'
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r4_c1
                             size_hint_x: 6
                             text: '[color=333333]Never leave the machine unattended while power is on[/color]'
@@ -229,14 +229,14 @@ Builder.load_string(
                             color: hex('#333333ff')
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.025*app.width
+                        spacing: app.get_scaled_width(20.0)
                         Image:
                             size_hint_x: 1
                             keep_ratio: True
                             allow_stretch: True                           
                             source: "./asmcnc/skavaUI/img/popup_error_visual.png"
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: label_r4_c2
                             size_hint_x: 6
                             text: '[color=333333]Ensure all plugs are fully inserted and secured[/color]'
@@ -254,17 +254,17 @@ Builder.load_string(
 
                 Button:
                     id: confirm_button
-                    width: dp(0.875*app.width)
-                    height: dp(0.1875*app.height)
+                    width: app.get_scaled_width(700.0)
+                    height: app.get_scaled_height(90.0)
                     on_press: root.next_screen()
                     markup: True
-                    font_size: str(0.03*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('24.0sp')
                     text_size: self.size
                     valign: "middle"
                     halign: "center"
                     background_normal: "./asmcnc/skavaUI/img/blank_long_button.png"
                     background_down: "./asmcnc/skavaUI/img/blank_long_button.png"
-                    border: [dp(30.0/800)*app.width, dp(30.0/480)*app.height, dp(30.0/800)*app.width, dp(30.0/480)*app.height]
+                    border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
               
 
 """

--- a/src/asmcnc/apps/start_up_sequence/screens/screen_starting_smartbench.py
+++ b/src/asmcnc/apps/start_up_sequence/screens/screen_starting_smartbench.py
@@ -31,7 +31,7 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.1125)*app.width, dp(0.104166666667)*app.height]
+        padding: app.get_scaled_tuple([90.0, 50.0])
         spacing: 0
         size_hint_x: 1
 
@@ -42,7 +42,7 @@ Builder.load_string(
             Label:
                 id: starting_label
                 text_size: self.size
-                font_size: str(0.05*app.width) + 'sp'
+                font_size: app.get_scaled_sp('40.0sp')
                 halign: 'center'
                 valign: 'middle'
                 markup: 'True'

--- a/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_1.py
+++ b/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_1.py
@@ -30,8 +30,8 @@ Builder.load_string(
 
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 
 		canvas:
@@ -59,12 +59,12 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "SmartBench Warranty Registration"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -72,22 +72,22 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
 				orientation: 'vertical'
 
 
 				Button:
-				    font_size: str(0.01875 * app.width) + 'sp'
+				    font_size: app.get_scaled_sp('15.0sp')
 					size_hint_x: None
-					width: dp(0.065*app.width)
+					width: app.get_scaled_width(52.0)
 					background_color: hex('##e5e5e5')
 					background_normal: ''
 					on_press: root.go_to_factory_settings()
 
 				Label:
 					id: scan_qr_code
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					text_size: self.size
 					valign: 'bottom'
 					halign: 'center'
@@ -96,16 +96,16 @@ Builder.load_string(
 
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.416666666667*app.height)
-					padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, dp(0.025)*app.width, 0]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(200.0)
+					padding: app.get_scaled_tuple([20.0, 20.0, 20.0, 0.0])
 					size_hint: (None,None)
 					spacing: 0
 
 					Label:
 						id: instructions_label
 						size_hint_y: 0.3
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						# text: "[color=333333ff]To submit your details and receive your activation code, go to[/color]"
 						text_size: self.size
 						valign: 'middle'
@@ -115,16 +115,16 @@ Builder.load_string(
 
 					BoxLayout:
 						orientation: 'horizontal'
-						width: dp(1.0*app.width)
-						height: dp(0.275*app.height)
-						# padding: [20, 0]
+						width: app.get_scaled_width(800.0)
+						height: app.get_scaled_height(132.0)
+						# padding: app.get_scaled_tuple([20.0, 0.0])
 						size_hint: (None,None)
 						spacing: 0
 
 						BoxLayout:
-							padding:[dp(0.0125)*app.width, 0, 0, 0]
-							width: dp(0.2025*app.width)
-							height: dp(0.275*app.height)
+							padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
+							width: app.get_scaled_width(162.0)
+							height: app.get_scaled_height(132.0)
 							size_hint: (None,None)
 							Image:
 								source: "./asmcnc/apps/start_up_sequence/warranty_app/img/registration-qr-code.png"
@@ -135,14 +135,14 @@ Builder.load_string(
 
 						BoxLayout:
 							orientation: 'vertical'
-							width: dp(0.7475*app.width)
-							height: dp(0.275*app.height)
-							padding:[0, 0, 0, 0]
+							width: app.get_scaled_width(598.0)
+							height: app.get_scaled_height(132.0)
+							padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 							size_hint: (None,None)
 
 							Label:
 								size_hint_y: 0.4
-								font_size: str(0.0275*app.width) + 'sp'
+								font_size: app.get_scaled_sp('22.0sp')
 								text: "[color=333333ff]https://www.yetitool.com/support/Register-Your-Product[/color]"
 								text_size: self.size
 								valign: 'middle'
@@ -154,7 +154,7 @@ Builder.load_string(
 							Label:
 								id: cant_use_web_label
 								size_hint_y: 0.3
-								font_size: str(0.025*app.width) + 'sp'
+								font_size: app.get_scaled_sp('20.0sp')
 								# text: "[color=333333ff]Can't use the web form?"
 								text_size: self.size
 								valign: 'bottom'
@@ -165,7 +165,7 @@ Builder.load_string(
 							Label:
 								id: contact_us_at_support
 								size_hint_y: 0.3
-								font_size: str(0.025*app.width) + 'sp'
+								font_size: app.get_scaled_sp('20.0sp')
 								# text: "[color=333333ff]Contact us at https://www.yetitool.com/support[/color]"
 								text_size: self.size
 								valign: 'middle'
@@ -175,23 +175,23 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						id: prev_screen_button
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -210,20 +210,20 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
@@ -231,15 +231,15 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.240625)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([192.5, 0.0, 0.0, 0.0])
 
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.065*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(52.0)
 						background_color: hex('##e5e5e5')
 						background_normal: ''
 						on_press: root.quit_to_console()

--- a/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_2.py
+++ b/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_2.py
@@ -21,8 +21,8 @@ Builder.load_string(
 
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 
 		canvas:
@@ -50,12 +50,12 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "SmartBench Warranty Registration"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -63,13 +63,13 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
 				orientation: 'vertical'
 				
 				Label:
 					id: your_serial_number_label
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					# text: "[color=333333ff]Your serial number is[/color]"
 					text_size: self.size
 					valign: 'bottom'
@@ -79,14 +79,14 @@ Builder.load_string(
 
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.416666666667*app.height)
-					padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(200.0)
+					padding: app.get_scaled_tuple([20.0, 20.0])
 					size_hint: (None,None)
 					Label:
 						id: serial_number_label
 						size_hint_y: 1
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						text_size: self.size
 						valign: 'middle'
 						halign: 'center'
@@ -95,22 +95,22 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
 					    id: prev_screen_button
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -128,29 +128,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_3.py
+++ b/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_3.py
@@ -34,8 +34,8 @@ Builder.load_string(
 
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 
 		canvas:
@@ -64,12 +64,12 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "SmartBench Warranty Registration"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -77,13 +77,13 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
 				orientation: 'vertical'
 				
 				Label:
 					id: enter_your_activation_code_label
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					# text: "[color=333333ff]Enter your activation code:[/color]"
 					text_size: self.size
 					valign: 'bottom'
@@ -93,19 +93,19 @@ Builder.load_string(
 
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.15625*app.height)
-					padding:[dp(0.25)*app.width, 0]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(75.0)
+					padding: app.get_scaled_tuple([200.0, 0.0])
 					size_hint: (None,None)
 					TextInput: 
 						id: activation_code
 						valign: 'middle'
 						halign: 'center'
-						height: dp(0.104166666667*app.height)
-						width: dp(0.5*app.width) 
+						height: app.get_scaled_height(50.0)
+						width: app.get_scaled_width(400.0)
 						size_hint: (None,None)
 						text_size: self.size
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						markup: True
 						multiline: False
 						text: ''
@@ -113,13 +113,13 @@ Builder.load_string(
 						color: hex('#333333ff')
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.260416666667*app.height)
-					padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(125.0)
+					padding: app.get_scaled_tuple([20.0, 20.0])
 					size_hint: (None,None)
 					Label:
 						id: error_message_top
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text: "Please check your activation code."
 						text_size: self.size
 						valign: 'bottom'
@@ -129,7 +129,7 @@ Builder.load_string(
 						opacity: 0
 					Label:
 						id: error_message_bottom
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text: "Stuck on this screen? Contact us at https://www.yetitool.com/support"
 						text_size: self.size
 						valign: 'bottom'
@@ -140,21 +140,21 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -172,29 +172,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen(False)
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 
 """

--- a/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_4.py
+++ b/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_4.py
@@ -18,8 +18,8 @@ Builder.load_string(
 
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 
 		canvas:
@@ -47,12 +47,12 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "SmartBench Warranty Registration"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -60,20 +60,20 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
 				orientation: 'vertical'
 
 				BoxLayout:
 					orientation: 'vertical'
-					width: dp(1.0*app.width)
-					height: dp(0.416666666667*app.height)
-					padding:[dp(0.025)*app.width, 0]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(200.0)
+					padding: app.get_scaled_tuple([20.0, 0.0])
 					size_hint: (None,None)
 
 					Label:
 						id: success_label
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						text_size: self.size
 						valign: 'top'
 						halign: 'center'
@@ -83,20 +83,20 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					# Button:
 					#     size_hint: (None,None)
-					#     height: dp(52)
-					#     width: dp(60)
+					#     height: app.get_scaled_height(52.0)
+					#     width: app.get_scaled_width(60.0)
 					#     background_color: hex('#F4433600')
 					#     center: self.parent.center
 					#     pos: self.parent.pos
@@ -114,29 +114,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_5.py
+++ b/src/asmcnc/apps/start_up_sequence/warranty_app/screens/screen_warranty_registration_5.py
@@ -22,8 +22,8 @@ Builder.load_string(
 
 	BoxLayout: 
 		size_hint: (None,None)
-		width: dp(1.0*app.width)
-		height: dp(1.0*app.height)
+		width: app.get_scaled_width(800.0)
+		height: app.get_scaled_height(480.0)
 		orientation: 'vertical'
 		canvas:
 			Color:
@@ -49,11 +49,11 @@ Builder.load_string(
 				Label:
 					id: title_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -61,14 +61,14 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
-				padding:[dp(0.0375)*app.width, dp(0.0208333333333)*app.height]
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
+				padding: app.get_scaled_tuple([30.0, 10.0])
 				orientation: 'vertical'
 				
 				Label:
 					id: cnc_academy_info
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					text_size: self.size
 					valign: 'bottom'
 					halign: 'center'
@@ -78,16 +78,16 @@ Builder.load_string(
 
 				BoxLayout:
 					orientation: 'horizontal'
-					width: dp(1.0*app.width)
-					height: dp(0.416666666667*app.height)
-					padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height, dp(0.025)*app.width, 0]
+					width: app.get_scaled_width(800.0)
+					height: app.get_scaled_height(200.0)
+					padding: app.get_scaled_tuple([20.0, 20.0, 20.0, 0.0])
 					size_hint: (None,None)
 					spacing: 0
 					BoxLayout:
 						id: qr_code_container
-						padding:[dp(0.0125)*app.width, 0, 0, 0]
-						# width: dp(162)
-						# height: dp(180)
+						padding: app.get_scaled_tuple([10.0, 0.0, 0.0, 0.0])
+						# width: app.get_scaled_width(162.0)
+						# height: app.get_scaled_height(180.0)
 						# size_hint: (None,None)
 						size_hint_x: 0.21
 						Image:
@@ -103,7 +103,7 @@ Builder.load_string(
 						BoxLayout:
 							id: cnc_academy_logo_container
 							size_hint_y: 0.75
-							padding:[dp(0.0125)*app.width, dp(0.00416666666667)*app.height, dp(0.0125)*app.width, 0]
+							padding: app.get_scaled_tuple([10.0, 2.0, 10.0, 0.0])
 
 							Image:
 								id: cnc_academy_logo
@@ -115,7 +115,7 @@ Builder.load_string(
 						Label:
 							id: url_label
 							size_hint_y: 0.25
-							font_size: str(0.03125*app.width) + 'sp'
+							font_size: app.get_scaled_sp('25.0sp')
 							text_size: self.size
 							valign: 'top'
 							halign: 'center'
@@ -124,21 +124,21 @@ Builder.load_string(
 							color: hex('#333333ff')
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -156,29 +156,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/apps/start_up_sequence/welcome_to_smartbench_app/screens/screen_language_select.py
+++ b/src/asmcnc/apps/start_up_sequence/welcome_to_smartbench_app/screens/screen_language_select.py
@@ -47,8 +47,8 @@ Builder.load_string(
 	next_button : next_button
 
 	BoxLayout:
-		height: dp(1.66666666667*app.height)
-		width: dp(0.6*app.width)
+		height: app.get_scaled_height(800.0)
+		width: app.get_scaled_width(480.0)
 		canvas.before:
 			Color: 
 				rgba: hex('#e5e5e5ff')
@@ -74,12 +74,12 @@ Builder.load_string(
 				Label:
 					id: header_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					text: "Welcome to SmartBench"
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -87,10 +87,10 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
-				padding:[dp(0.0375)*app.width, dp(0.0208333333333)*app.height]
-				spacing:dp(0.0208333333333)*app.height
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
+				padding: app.get_scaled_tuple([30.0, 10.0])
+				spacing: app.get_scaled_width(10.0)
 				orientation: 'vertical'
 
 	            GridLayout:
@@ -98,7 +98,7 @@ Builder.load_string(
 	                cols: 9
 	                rows: 3
 	                cols_minimum: {0: dp(15), 1: dp(50), 2: dp(170), 3: dp(15), 4: dp(50), 5: dp(170), 6: dp(15), 7: dp(50), 8: dp(170)}
-	                spacing:0.00625*app.width
+	                spacing: app.get_scaled_width(5.0)
 
 
 	                # ROW 1
@@ -115,7 +115,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_1_col_1
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -134,7 +134,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_1_col_2
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -153,7 +153,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_1_col_3
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -174,7 +174,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_2_col_1
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -193,7 +193,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_2_col_2
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -212,7 +212,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_2_col_3
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -233,7 +233,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_3_col_1
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -251,7 +251,7 @@ Builder.load_string(
 	                Label: 
 	                	id: row_3_col_2
 	                	valign: "middle"
-						font_size: str(0.025*app.width) + 'sp'
+						font_size: app.get_scaled_sp('20.0sp')
 						text_size: self.size
 						markup: True
 						halign: "left"
@@ -275,7 +275,7 @@ Builder.load_string(
 	    #             	id: row_3_col_3
 	    #             	text: "Suomalainen (FI)"
 	    #             	valign: "middle"
-					# 	font_size: '20sp'
+					# 	font_size: app.get_scaled_sp('20sp')
 					# 	text_size: self.size
 					# 	markup: True
 					# 	halign: "left"
@@ -283,33 +283,33 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
@@ -318,9 +318,9 @@ Builder.load_string(
 						disabled: True
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 
 

--- a/src/asmcnc/apps/start_up_sequence/welcome_to_smartbench_app/screens/screen_welcome.py
+++ b/src/asmcnc/apps/start_up_sequence/welcome_to_smartbench_app/screens/screen_welcome.py
@@ -22,8 +22,8 @@ Builder.load_string(
 	next_button : next_button
 
 	BoxLayout:
-		height: dp(1.66666666667*app.height)
-		width: dp(0.6*app.width)
+		height: app.get_scaled_height(800.0)
+		width: app.get_scaled_width(480.0)
 		canvas.before:
 			Color: 
 				rgba: hex('#e5e5e5ff')
@@ -49,11 +49,11 @@ Builder.load_string(
 				Label:
 					id: header_label
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(1.0*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(800.0)
 					color: hex('#f9f9f9ff')
 					# color: hex('#333333ff') #grey
-					font_size: dp(0.0375*app.width)
+					font_size: app.get_scaled_width(30.0)
 					halign: "center"
 					valign: "bottom"
 					markup: True
@@ -61,16 +61,16 @@ Builder.load_string(
 			# BODY
 			BoxLayout:
 				size_hint: (None,None)
-				width: dp(1.0*app.width)
-				height: dp(0.620833333333*app.height)
-				padding:[dp(0.0375)*app.width, dp(0.0208333333333)*app.height]
-				spacing:dp(0.0208333333333)*app.height
+				width: app.get_scaled_width(800.0)
+				height: app.get_scaled_height(298.0)
+				padding: app.get_scaled_tuple([30.0, 10.0])
+				spacing: app.get_scaled_width(10.0)
 				orientation: 'vertical'
 
 				Label:
 					id: thankyou_label
 					size_hint_y: 0.25
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					text_size: self.size
 					valign: 'bottom'
 					halign: 'center'
@@ -80,7 +80,7 @@ Builder.load_string(
 				Label:
 					id: next_steps_label
 					size_hint_y: 0.5
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					text_size: self.size
 					valign: 'middle'
 					halign: 'center'
@@ -91,7 +91,7 @@ Builder.load_string(
 				Label:
 					id: minutes_label
 					size_hint_y: 0.25
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					text_size: self.size
 					valign: 'top'
 					halign: 'center'
@@ -101,21 +101,21 @@ Builder.load_string(
 
 			# FOOTER
 			BoxLayout: 
-				padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+				padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 				size_hint: (None, None)
-				height: dp(0.254166666667*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(122.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[0, 0, dp(0.230625)*app.width, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 					Button:
-					    font_size: str(0.01875 * app.width) + 'sp'
+					    font_size: app.get_scaled_sp('15.0sp')
 						size_hint: (None,None)
-						height: dp(0.108333333333*app.height)
-						width: dp(0.075*app.width)
+						height: app.get_scaled_height(52.0)
+						width: app.get_scaled_width(60.0)
 						background_color: hex('#F4433600')
 						center: self.parent.center
 						pos: self.parent.pos
@@ -133,29 +133,29 @@ Builder.load_string(
 
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.36375*app.width)
-					padding:[0, 0, 0, dp(0.0666666666667)*app.height]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(291.0)
+					padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 32.0])
 					Button:
 						id: next_button
 						background_normal: "./asmcnc/skavaUI/img/next.png"
 						background_down: "./asmcnc/skavaUI/img/next.png"
-						border: [dp(14.5)]*4
+						border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 						size_hint: (None,None)
-						width: dp(0.36375*app.width)
-						height: dp(0.164583333333*app.height)
+						width: app.get_scaled_width(291.0)
+						height: app.get_scaled_height(79.0)
 						on_press: root.next_screen()
 						text: 'Next...'
-						font_size: str(0.0375*app.width) + 'sp'
+						font_size: app.get_scaled_sp('30.0sp')
 						color: hex('#f9f9f9ff')
 						markup: True
 						center: self.parent.center
 						pos: self.parent.pos
 				BoxLayout: 
 					size_hint: (None, None)
-					height: dp(0.254166666667*app.height)
-					width: dp(0.305625*app.width)
-					padding:[dp(0.241875)*app.width, 0, 0, 0]
+					height: app.get_scaled_height(122.0)
+					width: app.get_scaled_width(244.5)
+					padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 
 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_calibration_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_calibration_test.py
@@ -107,36 +107,36 @@ Builder.load_string(
                     size_hint_x: 0.7
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Back'
                         on_press: root.back_to_fac_settings()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: home_button
                         text: 'Home'
                         on_press: root.home()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: x0y0_jog_button
                         text: 'X0Y0'
                         on_press: root.zero_x_and_y()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: x7y0_jog_button
                         text: 'X-700Y0'
                         on_press: root.mid_x_and_zero_y()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: z0_jog_button
                         text: 'Z0'
                         on_press: root.zero_Z()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'STOP'
                     background_color: [1,0,0,1]
                     on_press: root.stop()
@@ -151,7 +151,7 @@ Builder.load_string(
                     cols: 2
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: unweighted_test_button
                         text: 'Run XYZ 0kg'
                         on_press: root.run_unweighted_test()
@@ -168,7 +168,7 @@ Builder.load_string(
                     cols: 2
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: x_load_button
                         text: 'Run X (7.5kg)'
                         on_press: root.run_x_procedure(None)
@@ -185,7 +185,7 @@ Builder.load_string(
                     cols: 2
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: y_load_button
                         text: 'Run Y (7.5kg)'
                         on_press: root.run_y_procedure(None)
@@ -202,11 +202,11 @@ Builder.load_string(
                     cols: 2
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     # Button:
@@ -223,7 +223,7 @@ Builder.load_string(
                     #     allow_stretch: True
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: data_send_button
                     text: 'Send data to database'
                     on_press: root.send_all_data()
@@ -233,7 +233,7 @@ Builder.load_string(
                     cols: 2
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: data_send_label
                         text: 'Sent data?'
                     
@@ -250,11 +250,11 @@ Builder.load_string(
                 size_hint_y: 0.1
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Unweighted'
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Weighted'
 
             BoxLayout:
@@ -269,7 +269,7 @@ Builder.load_string(
                     ## Y axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y+: '
                         halign: 'right'
                         markup: True
@@ -278,7 +278,7 @@ Builder.load_string(
 
                     Label:
                         id: y_peak_posve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -287,7 +287,7 @@ Builder.load_string(
 
                     Label:
                         id: y_axis_fw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -295,7 +295,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y-: '
                         halign: 'right'
                         markup: True
@@ -304,7 +304,7 @@ Builder.load_string(
 
                     Label:
                         id: y_peak_negve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -314,7 +314,7 @@ Builder.load_string(
 
                     Label:
                         id: y_axis_bw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -333,7 +333,7 @@ Builder.load_string(
                     ## Y1 axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y1+:'
                         halign: 'right'
                         markup: True
@@ -342,7 +342,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_peak_posve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -351,7 +351,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_fw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -359,7 +359,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y1-:'
                         halign: 'right'
                         markup: True
@@ -368,7 +368,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_peak_negve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -377,7 +377,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_bw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -395,7 +395,7 @@ Builder.load_string(
                     ## Y2 axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y2+:'
                         halign: 'right'
                         markup: True
@@ -404,7 +404,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_peak_posve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -413,7 +413,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_fw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -421,7 +421,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y2-:'
                         halign: 'right'
                         markup: True
@@ -430,7 +430,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_peak_negve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -439,7 +439,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_bw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -457,7 +457,7 @@ Builder.load_string(
                     ## X axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'X+:'
                         halign: 'right'
                         markup: True
@@ -466,7 +466,7 @@ Builder.load_string(
 
                     Label:
                         id: x_peak_posve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx'
                         halign: 'left'
                         markup: True
@@ -475,7 +475,7 @@ Builder.load_string(
 
                     Label:
                         id: x_fw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx - xxx'
                         markup: True
                         valign: 'middle'
@@ -483,7 +483,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'X-:'
                         halign: 'right'
                         markup: True
@@ -492,7 +492,7 @@ Builder.load_string(
 
                     Label:
                         id: x_peak_negve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx'
                         halign: 'left'
                         markup: True
@@ -501,7 +501,7 @@ Builder.load_string(
 
                     Label:
                         id: x_bw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx - xxx'
                         markup: True
                         valign: 'middle'
@@ -520,7 +520,7 @@ Builder.load_string(
                     ## Z axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Z-:'
                         halign: 'right'
                         markup: True
@@ -529,7 +529,7 @@ Builder.load_string(
 
                     Label:
                         id: z_peak_negve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'zzz'
                         halign: 'left'
                         markup: True
@@ -538,7 +538,7 @@ Builder.load_string(
 
                     Label:
                         id: z_fw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'zzz - zzz'
                         markup: True
                         valign: 'middle'
@@ -546,7 +546,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Z+:'
                         halign: 'right'
                         markup: True
@@ -555,7 +555,7 @@ Builder.load_string(
 
                     Label:
                         id: z_peak_posve
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'zzz'
                         halign: 'left'
                         markup: True
@@ -564,7 +564,7 @@ Builder.load_string(
 
                     Label:
                         id: z_bw_range
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'zzz - zzz'
                         markup: True
                         valign: 'middle'
@@ -588,7 +588,7 @@ Builder.load_string(
                     ## Y axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y+:'
                         halign: 'right'
                         markup: True
@@ -597,7 +597,7 @@ Builder.load_string(
 
                     Label:
                         id: y_peak_posve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -606,7 +606,7 @@ Builder.load_string(
 
                     Label:
                         id: y_axis_fw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -614,7 +614,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y-:'
                         halign: 'right'
                         markup: True
@@ -623,7 +623,7 @@ Builder.load_string(
 
                     Label:
                         id: y_peak_negve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -632,7 +632,7 @@ Builder.load_string(
 
                     Label:
                         id: y_axis_bw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -650,7 +650,7 @@ Builder.load_string(
                     ## Y1 axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y1+:'
                         halign: 'right'
                         markup: True
@@ -659,7 +659,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_peak_posve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -668,7 +668,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_fw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -676,7 +676,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y1-:'
                         halign: 'right'
                         markup: True
@@ -685,7 +685,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_peak_negve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -694,7 +694,7 @@ Builder.load_string(
 
                     Label:
                         id: y1_bw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -712,7 +712,7 @@ Builder.load_string(
                     ## Y2 axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y2+:'
                         halign: 'right'
                         markup: True
@@ -721,7 +721,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_peak_posve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -730,7 +730,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_fw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -738,7 +738,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Y2-:'
                         halign: 'right'
                         markup: True
@@ -747,7 +747,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_peak_negve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy'
                         halign: 'left'
                         markup: True
@@ -756,7 +756,7 @@ Builder.load_string(
 
                     Label:
                         id: y2_bw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'yyy - yyy'
                         markup: True
                         valign: 'middle'
@@ -774,7 +774,7 @@ Builder.load_string(
                     ## X axis
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'X+:'
                         halign: 'right'
                         markup: True
@@ -783,7 +783,7 @@ Builder.load_string(
 
                     Label:
                         id: x_peak_posve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx'
                         halign: 'left'
                         markup: True
@@ -792,7 +792,7 @@ Builder.load_string(
 
                     Label:
                         id: x_fw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx - xxx'
                         markup: True
                         valign: 'middle'
@@ -800,7 +800,7 @@ Builder.load_string(
                         halign: 'center'
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'X-:'
                         halign: 'right'
                         markup: True
@@ -809,7 +809,7 @@ Builder.load_string(
 
                     Label:
                         id: x_peak_negve_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx'
                         halign: 'left'
                         markup: True
@@ -818,7 +818,7 @@ Builder.load_string(
 
                     Label:
                         id: x_bw_range_weighted
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'xxx - xxx'
                         markup: True
                         valign: 'middle'
@@ -837,15 +837,15 @@ Builder.load_string(
                     ## Z axis
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     # Label:
@@ -872,19 +872,19 @@ Builder.load_string(
                     #     halign: 'center'
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     Label: 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
 
                     # Label:

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_current_adjustment.py
@@ -58,15 +58,15 @@ Builder.load_string(
                         id: xy_move_container
                         pos_hint: {'center_x': .5, 'center_y': .5}
                         size_hint: (None,None)
-                        height: dp(0.75*app.height)
-                        width: dp(0.3375*app.width)
+                        height: app.get_scaled_height(360.0)
+                        width: app.get_scaled_width(270.0)
         
                     BoxLayout:
                         size_hint_y: 0.1
-                        padding:[0, dp(0.0625)*app.height, dp(0.1875)*app.width, 0]
+                        padding: app.get_scaled_tuple([0.0, 30.0, 150.0, 0.0])
         
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Factory Settings'
                             on_press: root.back_to_fac_settings()
         
@@ -80,7 +80,7 @@ Builder.load_string(
                             rows:2
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 size_hint_y: 0.2
                                 text: 'Active Current Adjustment'
         
@@ -89,26 +89,26 @@ Builder.load_string(
         
                         BoxLayout:
                             size_hint_x: 0.3
-                            # padding: [0, dp(25), 0, dp(25)]
+                            # padding: app.get_scaled_tuple([0.0, 25.0, 0.0, 25.0])
                             orientation: 'vertical'
         
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Home'
                                 on_press: root.home()
         
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Reset Currents'
                                 on_press: root.reset_currents()
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'GRBL Reset'
                                 on_press: root.grbl_reset()
 
                             Label: 
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: protocol_status
                                 text: ""
 
@@ -124,115 +124,115 @@ Builder.load_string(
                             Label
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG X'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG X1'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG X2'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG Y1'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG Y2'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'SG Z'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Realtime'
         
                             Label:
                                 id: rt_x_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: rt_x1_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: rt_x2_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: rt_y1_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: rt_y2_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: rt_z_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Peak'
         
                             Label:
                                 id: peak_x_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: peak_x1_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: peak_x2_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: peak_y1_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: peak_y2_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                             Label:
                                 id: peak_z_sg
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '-'
         
                         BoxLayout:
                             orientation: 'vertical'
                             size_hint_x: 0.3
-                            padding:[0, dp(0.0520833333333)*app.height, 0, dp(0.0520833333333)*app.height]
+                            padding: app.get_scaled_tuple([0.0, 25.0, 0.0, 25.0])
         
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Clear'
                                 on_press: root.clear_sg_vals()
         
                             ToggleButton:
                                 id: raw_sg_toggle_button
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'Show raw'
                                 on_press: root.toggle_raw_sg_values()
         
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: 'STORE PARAMS'
                                 on_press: root.confirm_store_values()
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_general_measurement.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_general_measurement.py
@@ -27,13 +27,13 @@ Builder.load_string(
 
             Label: 
                 id: plot_title
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
 
             Image:
                 id: load_graph
                 size_hint: None, None
-                height: dp(0.739583333333*app.height)
-                width: dp(0.875*app.width)
+                height: app.get_scaled_height(355.0)
+                width: app.get_scaled_width(700.0)
                 x: dp(5)
                 y: dp(5)
                 allow_stretch: True
@@ -42,30 +42,30 @@ Builder.load_string(
         BoxLayout: 
             orientation: "vertical"
             size_hint_x: None
-            width: dp(0.125*app.width)
+            width: app.get_scaled_width(100.0)
             
             GridLayout: 
                 size_hint_y: None
-                height: dp(0.208333333333*app.height)
+                height: app.get_scaled_height(100.0)
                 cols: 2
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "BACK"
                     on_press: root.back_to_fac_settings()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Start"
                     on_press: root.start_measurement()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Stop"
                     on_press: root.stop_measurement()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Clear"
                     on_press: root.clear_measurement()
 
@@ -73,67 +73,67 @@ Builder.load_string(
                 cols: 2
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "y axis"
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "x axis"
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "t"
                     on_press: root.set_index("X", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "SG X"
                     on_press: root.set_index("Y", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "F"
                     on_press: root.set_index("X", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "SG Y"
                     on_press: root.set_index("Y", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "x pos"
                     on_press: root.set_index("X", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "SG Z"
                     on_press: root.set_index("Y", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "y pos"
                     on_press: root.set_index("X", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "SG Y1"
                     on_press: root.set_index("Y", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "z pos"
                     on_press: root.set_index("X", self)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "SG Y2"
                     on_press: root.set_index("Y", self)
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: None
-                height: dp(0.0833333333333*app.height)
+                height: app.get_scaled_height(40.0)
                 text: "PLOT"
                 on_press: root.display_results()
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_overnight_test.py
@@ -101,41 +101,41 @@ Builder.load_string(
 
                     Button:
                         id: back_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Back'
                         on_press: root.back_to_fac_settings()
 
                     Button:
                         id: home_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Home'
                         on_press: root.home()
                         background_color: [0,0,1,1]
 
                     Button:
                         id: overnight_test_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'START'
                         on_press: root.start_full_overnight_test()
                         background_color: [0,1,0,1]
 
                     Button:
                         id: cal_and_post_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'CAL+POST'
                         background_color: [0,1,1,1]
                         on_press: root.start_cal_and_post_cal()
 
                     Button:
                         id: stop_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'STOP'
                         background_color: [1,0,0,1]
                         on_press: root.stop()
                         background_normal: ''
 
                 Label: 
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Overnight test stages"
                     markup: True
                     text_size: self.size
@@ -151,7 +151,7 @@ Builder.load_string(
 
                         Button:
                             id: six_hour_wear_in_button
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: '6 hour wear-in'
                             size_hint_x: 0.7
                             on_press: root.start_six_hour_wear_in()
@@ -174,7 +174,7 @@ Builder.load_string(
 
                         Button:
                             id: recalibration_button
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 're-calibration'
                             size_hint_x: 0.7
                             on_press: root.start_recalibration()
@@ -195,7 +195,7 @@ Builder.load_string(
 
                         Button:
                             id: fully_calibrated_run_button
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'post-calibration run'
                             size_hint_x: 0.7
                             on_press: root.start_fully_calibrated_final_run()
@@ -213,7 +213,7 @@ Builder.load_string(
                                 allow_stretch: True
 
                 Label: 
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Data sends"
                     markup: True
                     text_size: self.size
@@ -229,7 +229,7 @@ Builder.load_string(
 
                         Button:
                             id: retry_six_hour_wear_in_data_send
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Retry'
                             size_hint_x: 0.7
                             on_press: root.send_six_hour_wear_in_data()
@@ -251,7 +251,7 @@ Builder.load_string(
 
                         Button:
                             id: retry_recalibration_data_send
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Retry'
                             size_hint_x: 0.7
                             on_press: root.send_recalibration_data()
@@ -272,7 +272,7 @@ Builder.load_string(
 
                         Button:
                             id: retry_fully_calibrated_run_data_send
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Retry'
                             size_hint_x: 0.7
                             on_press: root.send_fully_calibrated_final_run_data()
@@ -294,7 +294,7 @@ Builder.load_string(
                 size_hint_y: 0.5
 
                 Label: 
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Peak testing'
                     size_hint_y: 0.11
 
@@ -308,10 +308,10 @@ Builder.load_string(
                         cols: 5
                         rows: 5
                         size_hint_y: 0.5
-                        spacing:[0.00625*app.width, 0]
+                        spacing: app.get_scaled_tuple([5.0, 0.0])
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y+:  '
                             halign: 'right'
                             markup: True
@@ -320,7 +320,7 @@ Builder.load_string(
 
                         Label:
                             id: y_wear_in_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -328,7 +328,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y-:  '
                             halign: 'right'
                             markup: True
@@ -337,7 +337,7 @@ Builder.load_string(
 
                         Label:
                             id: y_wear_in_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -353,7 +353,7 @@ Builder.load_string(
                             allow_stretch: True
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y1+:  '
                             halign: 'right'
                             markup: True
@@ -362,7 +362,7 @@ Builder.load_string(
 
                         Label:
                             id: y1_wear_in_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -370,7 +370,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y1-:  '
                             halign: 'right'
                             markup: True
@@ -379,7 +379,7 @@ Builder.load_string(
 
                         Label:
                             id: y1_wear_in_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -396,7 +396,7 @@ Builder.load_string(
 
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y2+:  '
                             halign: 'right'
                             markup: True
@@ -405,7 +405,7 @@ Builder.load_string(
 
                         Label:
                             id: y2_wear_in_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -413,7 +413,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y2-:  '
                             halign: 'right'
                             markup: True
@@ -422,7 +422,7 @@ Builder.load_string(
 
                         Label:
                             id: y2_wear_in_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -438,7 +438,7 @@ Builder.load_string(
                             allow_stretch: True
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'X+:  '
                             halign: 'right'
                             markup: True
@@ -447,7 +447,7 @@ Builder.load_string(
 
                         Label:
                             id: x_wear_in_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'xxx'
                             halign: 'left'
                             markup: True
@@ -455,7 +455,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'X-:  '
                             halign: 'right'
                             markup: True
@@ -464,7 +464,7 @@ Builder.load_string(
 
                         Label:
                             id: x_wear_in_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'xxx'
                             halign: 'left'
                             markup: True
@@ -481,7 +481,7 @@ Builder.load_string(
                             allow_stretch: True
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Z-:  '
                             halign: 'right'
                             markup: True
@@ -490,7 +490,7 @@ Builder.load_string(
 
                         Label:
                             id: z_wear_in_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'zzz'
                             halign: 'left'
                             markup: True
@@ -498,7 +498,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Z+:  '
                             halign: 'right'
                             markup: True
@@ -507,7 +507,7 @@ Builder.load_string(
 
                         Label:
                             id: z_wear_in_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'zzz'
                             halign: 'left'
                             markup: True
@@ -535,10 +535,10 @@ Builder.load_string(
                         cols: 5
                         rows: 5
                         size_hint_y: 0.5
-                        spacing:[0.00625*app.width, 0]
+                        spacing: app.get_scaled_tuple([5.0, 0.0])
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y+:  '
                             halign: 'right'
                             markup: True
@@ -547,7 +547,7 @@ Builder.load_string(
 
                         Label:
                             id: y_fully_calibrated_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -555,7 +555,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y-:  '
                             halign: 'right'
                             markup: True
@@ -564,7 +564,7 @@ Builder.load_string(
 
                         Label:
                             id: y_fully_calibrated_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -581,7 +581,7 @@ Builder.load_string(
 
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y1+:  '
                             halign: 'right'
                             markup: True
@@ -590,7 +590,7 @@ Builder.load_string(
 
                         Label:
                             id: y1_fully_calibrated_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -599,7 +599,7 @@ Builder.load_string(
 
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y1-:  '
                             halign: 'right'
                             markup: True
@@ -608,7 +608,7 @@ Builder.load_string(
 
                         Label:
                             id: y1_fully_calibrated_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -625,7 +625,7 @@ Builder.load_string(
 
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y2+:  '
                             halign: 'right'
                             markup: True
@@ -634,7 +634,7 @@ Builder.load_string(
 
                         Label:
                             id: y2_fully_calibrated_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -642,7 +642,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Y2-:  '
                             halign: 'right'
                             markup: True
@@ -651,7 +651,7 @@ Builder.load_string(
 
                         Label:
                             id: y2_fully_calibrated_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'yyy'
                             halign: 'left'
                             markup: True
@@ -667,7 +667,7 @@ Builder.load_string(
                             allow_stretch: True
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'X+:  '
                             halign: 'right'
                             markup: True
@@ -676,7 +676,7 @@ Builder.load_string(
 
                         Label:
                             id: x_fully_calibrated_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'xxx'
                             halign: 'left'
                             markup: True
@@ -684,7 +684,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'X-:  '
                             halign: 'right'
                             markup: True
@@ -693,7 +693,7 @@ Builder.load_string(
 
                         Label:
                             id: x_fully_calibrated_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'xxx'
                             halign: 'left'
                             markup: True
@@ -709,7 +709,7 @@ Builder.load_string(
                             allow_stretch: True
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Z-:  '
                             halign: 'right'
                             markup: True
@@ -718,7 +718,7 @@ Builder.load_string(
 
                         Label:
                             id: z_fully_calibrated_peak_neg
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'zzz'
                             halign: 'left'
                             markup: True
@@ -726,7 +726,7 @@ Builder.load_string(
                             text_size: self.size
 
                         Label:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'Z+:  '
                             halign: 'right'
                             markup: True
@@ -735,7 +735,7 @@ Builder.load_string(
 
                         Label:
                             id: z_fully_calibrated_peak_pos
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'zzz'
                             halign: 'left'
                             markup: True

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_serial_numbers.py
@@ -45,12 +45,12 @@ Builder.load_string(
                 markup: 'True'
                 halign: 'left'
                 valign: 'middle'
-                padding:[dp(0.0125)*app.width, 0]
+                padding: app.get_scaled_tuple([10.0, 0.0])
                 size_hint_x: 0.5
-                font_size: dp(0.025*app.width)
+                font_size: app.get_scaled_width(20.0)
 
             BoxLayout:
-                padding:[dp(0.0125)*app.width, 0]
+                padding: app.get_scaled_tuple([10.0, 0.0])
                 size_hint_x: 0.5
                 orientation: 'horizontal'
 
@@ -60,11 +60,11 @@ Builder.load_string(
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: squareness_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
         GridLayout:
@@ -79,11 +79,11 @@ Builder.load_string(
 
                 Label:
                     text: 'ZHead Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: zhead_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
             GridLayout:
@@ -92,11 +92,11 @@ Builder.load_string(
 
                 Label:
                     text: 'LB Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: lb_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
             GridLayout:
@@ -105,11 +105,11 @@ Builder.load_string(
 
                 Label:
                     text: 'UB Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: ub_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
             GridLayout:
@@ -118,11 +118,11 @@ Builder.load_string(
 
                 Label:
                     text: 'Console Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: console_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
             GridLayout:
@@ -131,11 +131,11 @@ Builder.load_string(
 
                 Label:
                     text: 'YBench Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: ybench_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
             GridLayout:
@@ -144,11 +144,11 @@ Builder.load_string(
 
                 Label:
                     text: 'Spindle Serial'
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
 
                 TextInput:
                     id: spindle_serial_input
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     multiline: False
 
 
@@ -156,14 +156,14 @@ Builder.load_string(
         Label:
             id: error_label
             text: 'Ensure all fields are entered accurately'
-            font_size: dp(0.0375*app.width)
+            font_size: app.get_scaled_width(30.0)
             size_hint_y: 0.3
 
         Button:
             id: main_button
             on_press: root.validate_and_download()
             text: 'Download'
-            font_size: dp(0.0375*app.width)
+            font_size: app.get_scaled_width(30.0)
             size_hint_y: 0.2
                 
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_set_thresholds.py
@@ -31,124 +31,124 @@ Builder.load_string(
         BoxLayout:
             size_hint_y: 5
             orientation: 'vertical'
-            padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-            spacing:dp(0.0625)*app.height
+            padding: app.get_scaled_tuple([30.0, 30.0])
+            spacing: app.get_scaled_width(30.0)
 
             GridLayout:
                 size_hint_y: 1.5
                 cols: 7
                 rows: 3
-                spacing:dp(0.0125)*app.width
+                spacing: app.get_scaled_width(10.0)
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'X:'
 
                 TextInput:
                     id: x_threshold_input
-                    font_size: str(32.0 / 1280 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('20.0sp')
                     input_filter: 'int'
                     multiline: False
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set'
                     on_press: root.set_threshold('X', x_threshold_input.text)
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Stored:'
 
                 Label:
                     id: x_stored_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'                    
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: '?'
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set:'
 
                 Label:
                     id: x_set_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: ''
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Y:'
 
                 TextInput:
                     id: y_threshold_input
-                    font_size: str(32.0 / 1280 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('20.0sp')
                     input_filter: 'int'
                     multiline: False
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set'
                     on_press: root.set_threshold('Y', y_threshold_input.text)
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Stored:'
 
                 Label:
                     id: y_stored_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: '?'
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set:'
 
                 Label:
                     id: y_set_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: ''
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Z:'
 
                 TextInput:
                     id: z_threshold_input
-                    font_size: str(32.0 / 1280 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('20.0sp')
                     input_filter: 'int'
                     multiline: False
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set'
                     on_press: root.set_threshold('Z', z_threshold_input.text)
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Stored:'
 
                 Label:
                     id: z_stored_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: '?'
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Set:'
 
                 Label:
                     id: z_set_threshold
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: ''
 
             BoxLayout:
                 orientation: 'vertical'
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Store params'
                     on_press: root.store_parameters()
 
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             text: 'Factory settings'
             on_press: root.back_to_fac_settings()
 

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/screen_stall_jig.py
@@ -66,14 +66,14 @@ Builder.load_string(
 
                 Button:
                     id: back_button
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 1
                     text: "<< Back"
                     on_press: root.back_to_fac_settings()
 
                 Button: 
                     id: run_button
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 1
                     background_normal: ""
                     background_color: root.pass_green
@@ -82,7 +82,7 @@ Builder.load_string(
 
                 Button:
                     id: result_label
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 1
                     background_normal: ""
                     background_down: ""
@@ -90,7 +90,7 @@ Builder.load_string(
 
                 Button: 
                     id: reset_test_button
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 1
                     text: "RESET CURRENT SUB-TEST"
                     on_press: root.reset_current_sub_test()
@@ -101,7 +101,7 @@ Builder.load_string(
 
                     Button:
                         id: send_data_button 
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_x: 2
                         disabled: True
                         text: "SEND DATA"
@@ -109,13 +109,13 @@ Builder.load_string(
 
                     ToggleButton: 
                         id: unlock_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_x: 1
                         text: "unlock"
                         on_press: root.enable_data_send()
                 Label:
                     id: test_status_label
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 1
 
             BoxLayout: 
@@ -137,11 +137,11 @@ Builder.load_string(
                     #     id: reset_tmc_regs
                     #     text: "RESET FW SETTINGS"
                     #     on_press: root.reset_tmcs()
-                    #     font_size: '12sp'
+                    #     font_size: app.get_scaled_sp('12sp')
 
                 BoxLayout:
                     size_hint_y: 4
-                    padding:[0, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([0.0, 10.0])
 
                     BoxLayout:
                         id: move_container
@@ -152,7 +152,7 @@ Builder.load_string(
 
                     Button:
                         id: home_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_x: 0.5
                         text: "HOME"
                         background_normal: ""
@@ -161,7 +161,7 @@ Builder.load_string(
 
                     Button:
                         id: grbl_reset_button
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_x: 0.5
                         text: "GRBL RESET"
                         on_press: root.grbl_reset()

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/widget_current_adjustment.py
@@ -22,7 +22,7 @@ Builder.load_string("""
             on_press: root.current_up()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding: 2
+                padding: app.get_scaled_width(2.0)
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:
@@ -38,7 +38,7 @@ Builder.load_string("""
         TextInput:
             id: current_current_label
             markup: True
-            font_size: "30sp"
+            font_size: app.get_scaled_sp('30sp')
             on_text_validate: root.set_current(self.text)
             input_filter: 'int'
             multiline: False
@@ -47,7 +47,7 @@ Builder.load_string("""
             on_press: root.current_down()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding: 2
+                padding: app.get_scaled_width(2.0)
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:

--- a/src/asmcnc/apps/systemTools_app/screens/calibration/widget_sg_status_bar.py
+++ b/src/asmcnc/apps/systemTools_app/screens/calibration/widget_sg_status_bar.py
@@ -51,8 +51,8 @@ Builder.load_string("""
             size: self.size
 
     BoxLayout:
-        padding: 1
-        spacing: 6
+        padding: app.get_scaled_width(1.0)
+        spacing: app.get_scaled_width(6.0)
         orientation: "horizontal"
         size: self.parent.size
         pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -26,11 +26,11 @@ Builder.load_string(
 
     background_normal: ''
     background_color: [1,1,1,1]
-    height: dp(0.0833333333333*app.height)
+    height: app.get_scaled_height(40.0)
     color: 0,0,0,1
     halign: 'left'
     markup: 'True'
-    font_size: 0.0225*app.width
+    font_size: app.get_scaled_width(18.0)
     font_name: 'KRFont'
 
 <BetaTestingScreen>
@@ -44,8 +44,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#e5e5e5ff')
@@ -55,7 +55,7 @@ Builder.load_string(
 
         BoxLayout:
             padding: 0
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -68,29 +68,29 @@ Builder.load_string(
                         size: self.size
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Beta Testing"
                     color: hex('#f9f9f9ff')
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
                    
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.666666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(320.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.75*app.width)
-                    height: dp(0.666666666667*app.height)
-                    padding:[dp(0.05)*app.width, dp(0.0416666666667)*app.height]
-                    spacing:0.0416666666667*app.height
+                    width: app.get_scaled_width(600.0)
+                    height: app.get_scaled_height(320.0)
+                    padding: app.get_scaled_tuple([40.0, 20.0])
+                    spacing: app.get_scaled_width(20.0)
                     orientation: 'vertical'
 
                     GridLayout:
@@ -103,7 +103,7 @@ Builder.load_string(
                         Label
                             text: 'Run developer branch:'
                             color: [0,0,0,1]
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             halign: "left"
                             markup: True
                             text_size: self.size
@@ -112,10 +112,10 @@ Builder.load_string(
                             id: user_branch
                             text: 'branch'
                             multiline: False
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Checkout and pull (uses wifi)'
                         on_press: root.checkout_branch()
 
@@ -129,7 +129,7 @@ Builder.load_string(
                         Label:
                             text: 'Latest beta version:'
                             color: [0,0,0,1]
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
 
@@ -137,33 +137,33 @@ Builder.load_string(
                             id: beta_version
                             text: 'beta_version_no'
                             color: [0,0,0,1]
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             halign: "left"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Update to beta'
                         on_press: root.update_to_latest_beta()
 
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.2375*app.width)
-                    height: dp(0.666666666667*app.height)
+                    width: app.get_scaled_width(190.0)
+                    height: app.get_scaled_height(320.0)
                     padding: 0
                     spacing: 0
                     orientation: 'vertical'
 
                     Spinner:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: language_button
                         size_hint: (None,None)
-                        height: dp(0.0729166666667*app.height)
-                        width: dp(0.225*app.width)
+                        height: app.get_scaled_height(35.0)
+                        width: app.get_scaled_width(180.0)
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: ""
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         center: self.parent.center
                         pos: self.parent.pos
                         text: 'Choose language...'
@@ -174,33 +174,33 @@ Builder.load_string(
 
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.240625*app.width)
-                        height: dp(0.25*app.height)
+                        width: app.get_scaled_width(192.5)
+                        height: app.get_scaled_height(120.0)
                         orientation: 'horizontal'
-                        padding:[dp(0.025)*app.width, dp(0.0625)*app.height]
+                        padding: app.get_scaled_tuple([20.0, 30.0])
                         ToggleButton:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: usb_toggle
                             text: 'USB'
                             group: 'wifi-usb'
                         ToggleButton:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: wifi_toggle
                             text: 'WIFI'
                             group: 'wifi-usb'
                             state: 'down'
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.240625*app.width)
-                        height: dp(0.25*app.height)
-                        padding:[dp(0.1021875)*app.width, dp(0.09375)*app.height]
+                        width: app.get_scaled_width(192.5)
+                        height: app.get_scaled_height(120.0)
+                        padding: app.get_scaled_tuple([81.75, 45.0])
                         spacing: 0
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.0625*app.height)
-                            width: dp(0.03625*app.width)
+                            height: app.get_scaled_height(30.0)
+                            width: app.get_scaled_width(29.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -218,29 +218,29 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([10.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.108333333333*app.height)
-                            width: dp(0.075*app.width)
+                            height: app.get_scaled_height(52.0)
+                            width: app.get_scaled_width(60.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -258,29 +258,29 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.775*app.width)
-                    height: dp(0.166666666667*app.height)
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    width: app.get_scaled_width(620.0)
+                    height: app.get_scaled_height(80.0)
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     spacing: 0
                     orientation: 'vertical'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.02375)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([19.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.06375*app.width)
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(51.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_build_info.py
@@ -31,11 +31,11 @@ Builder.load_string(
 
     background_normal: ''
     background_color: [1,1,1,1]
-    height: dp(0.0833333333333*app.height)
+    height: app.get_scaled_height(40.0)
     color: 0,0,0,1
     halign: 'left'
     markup: 'True'
-    font_size: 0.0225*app.width
+    font_size: app.get_scaled_width(18.0)
     font_name: 'KRFont'
 
 <BuildInfoScreen>
@@ -74,8 +74,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#e5e5e5ff')
@@ -85,7 +85,7 @@ Builder.load_string(
 
         BoxLayout:
             padding: 0
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -99,12 +99,12 @@ Builder.load_string(
                 Label:
                     id: header
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "System Information"
                     color: hex('#f9f9f9ff')
                     # color: hex('#333333ff') #grey
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
@@ -112,21 +112,21 @@ Builder.load_string(
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(0.975*app.width)
-                height: dp(0.666666666667*app.height)
-                padding:[dp(0.025)*app.width, 0]
+                width: app.get_scaled_width(780.0)
+                height: app.get_scaled_height(320.0)
+                padding: app.get_scaled_tuple([20.0, 0.0])
                 spacing: 0
                 orientation: 'horizontal'
 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint: (None, None)
-                    height: dp(0.729166666667*app.height)
-                    width: dp(0.6875*app.width)
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    height: app.get_scaled_height(350.0)
+                    width: app.get_scaled_width(550.0)
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: smartbench_name
                         background_color: hex('#e5e5e5ff')
                         background_normal: ""
@@ -135,19 +135,19 @@ Builder.load_string(
                         on_press: root.open_rename()
                         focus_next: smartbench_name_input
                         size_hint_y: None
-                        height: dp(0.0833333333333*app.height)
+                        height: app.get_scaled_height(40.0)
 
                         BoxLayout:
                             pos: self.parent.pos
                             size: self.parent.size
                             orientation: 'horizontal'
-                            spacing:dp(0.025)*app.width
-                            padding:[0, dp(0.00625)*app.height]
+                            spacing: app.get_scaled_width(20.0)
+                            padding: app.get_scaled_tuple([0.0, 3.0])
 
                             BoxLayout:
                                 size_hint_y: None
-                                height: dp(0.0708333333333*app.height)
-                                padding:[dp(0.005)*app.width, 0]
+                                height: app.get_scaled_height(34.0)
+                                padding: app.get_scaled_tuple([4.0, 0.0])
                                 canvas:
                                     Color:
                                         rgba: hex('#f9f9f9ff')
@@ -162,7 +162,7 @@ Builder.load_string(
                                     halign: "left"
                                     valign: "middle"
                                     markup: True
-                                    font_size: 0.0375*app.width
+                                    font_size: app.get_scaled_width(30.0)
                                     color: hex('#333333ff')
                                     shorten_from: 'right'
                                     shorten: True
@@ -170,13 +170,13 @@ Builder.load_string(
 
                             BoxLayout: 
                                 size_hint_x: None
-                                width: dp(0.0375*app.width)
+                                width: app.get_scaled_width(30.0)
                                 Image:
                                     source: "./asmcnc/apps/systemTools_app/img/tiny_pencil.png"
                                     allow_stretch: True
 
                     TextInput:
-                        padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                        padding: app.get_scaled_tuple([4.0, 2.0])
                         id: smartbench_name_input
                         text: 'My SmartBench'
                         color: hex('#333333ff')
@@ -184,11 +184,11 @@ Builder.load_string(
                         halign: "left"
                         valign: "middle"
                         markup: True
-                        font_size: 0.03*app.width
+                        font_size: app.get_scaled_width(24.0)
                         size_hint_y: None
-                        height: dp(0.0*app.height)
+                        height: 0
                         size_hint_x: None
-                        width: dp(0.625*app.width)
+                        width: app.get_scaled_width(500.0)
                         opacity: 0
                         on_text_validate: root.save_new_name()
                         # unfocus_on_touch: True
@@ -196,15 +196,15 @@ Builder.load_string(
                         multiline: False
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: smartbench_location
                         size_hint_x: None
-                        width: dp(0.625*app.width)
+                        width: app.get_scaled_width(500.0)
                         background_color: hex('#e5e5e5ff')
                         background_normal: ""
                         background_down: ""
                         size_hint_y: None
-                        height: dp(0.0625*app.height)
+                        height: app.get_scaled_height(30.0)
                         opacity: 1
                         on_press: root.open_rename_location()
                         focus_next: smartbench_location_input
@@ -213,13 +213,13 @@ Builder.load_string(
                             pos: self.parent.pos
                             size: self.parent.size
                             orientation: 'horizontal'
-                            spacing:dp(0.025)*app.width
-                            padding:[0, dp(0.00208333333333)*app.height]
+                            spacing: app.get_scaled_width(20.0)
+                            padding: app.get_scaled_tuple([0.0, 1.0])
 
                             BoxLayout:
                                 size_hint_y: None
-                                height: dp(0.0583333333333*app.height)
-                                padding:[dp(0.005)*app.width, 0]
+                                height: app.get_scaled_height(28.0)
+                                padding: app.get_scaled_tuple([4.0, 0.0])
                                 canvas:
                                     Color:
                                         rgba: hex('#f9f9f9ff')
@@ -233,19 +233,19 @@ Builder.load_string(
                                     halign: "left"
                                     valign: "middle"
                                     markup: True
-                                    font_size: 0.03*app.width
+                                    font_size: app.get_scaled_width(24.0)
                                     shorten_from: 'right'
                                     shorten: True
 
                             BoxLayout: 
                                 size_hint_x: None
-                                width: dp(0.03*app.width)
+                                width: app.get_scaled_width(24.0)
                                 Image:
                                     source: "./asmcnc/apps/systemTools_app/img/tiny_pencil.png"
                                     allow_stretch: True
 
                     TextInput:
-                        padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                        padding: app.get_scaled_tuple([4.0, 2.0])
                         id: smartbench_location_input
                         text: 'SmartBench location'
                         color: hex('#333333ff')
@@ -253,11 +253,11 @@ Builder.load_string(
                         halign: "left"
                         valign: "middle"
                         markup: True
-                        font_size: 0.025*app.width
+                        font_size: app.get_scaled_width(20.0)
                         size_hint_y: None
-                        height: dp(0.0*app.height)
+                        height: 0
                         size_hint_x: None
-                        width: dp(0.625*app.width)
+                        width: app.get_scaled_width(500.0)
                         opacity: 0
                         on_text_validate: root.save_new_location()
                         # unfocus_on_touch: True
@@ -272,8 +272,8 @@ Builder.load_string(
                         cols: 2
                         rows: 9
                         size_hint: (None, None)
-                        height: dp(0.520833333333*app.height)
-                        width: dp(0.6875*app.width)
+                        height: app.get_scaled_height(250.0)
+                        width: app.get_scaled_width(550.0)
                         cols_minimum: {0: dp(230), 1: dp(320)}
 
                         Label:
@@ -284,7 +284,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
 
                         Label:
                             id: smartbench_model
@@ -294,7 +294,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
 
                         Label:
                             id: serial_number_header
@@ -304,7 +304,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label:
                             id: machine_serial_number_label
                             color: hex('#333333ff')
@@ -313,7 +313,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
 
                         Label:
                             id: console_serial_number_header
@@ -322,7 +322,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label:
                             id: console_serial_number
                             text: '-'
@@ -331,7 +331,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: software_header
                             text: '[b]Software[/b]'
@@ -340,7 +340,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label:
                             id: sw_version_label
                             color: hex('#333333ff')
@@ -350,7 +350,7 @@ Builder.load_string(
                             markup: True
                             text_size: self.size
                             markup: 'True'
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: platform_header
                             text: '[b]Platform[/b]'
@@ -359,7 +359,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: pl_version_label
                             color: hex('#333333ff')
@@ -369,7 +369,7 @@ Builder.load_string(
                             markup: True
                             text_size: self.size
                             markup: 'True'
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: firmware_header
                             text: '[b]Firmware[/b]'
@@ -378,7 +378,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: fw_version_label
                             color: hex('#333333ff')
@@ -388,7 +388,7 @@ Builder.load_string(
                             markup: True
                             text_size: self.size
                             markup: 'True'
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: zhead_header
                             text: '[b]Z head[/b]'
@@ -397,7 +397,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: zh_version_label
                             color: hex('#333333ff')
@@ -407,7 +407,7 @@ Builder.load_string(
                             markup: True
                             text_size: self.size
                             markup: 'True'
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: hardware_header
                             text: '[b]Hardware[/b]'
@@ -416,7 +416,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "middle"
                             markup: True
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                         Label: 
                             id: hw_version_label
                             color: hex('#333333ff')
@@ -426,25 +426,25 @@ Builder.load_string(
                             markup: True
                             text_size: self.size
                             markup: 'True'
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.2625*app.width)
-                    height: dp(0.583333333333*app.height)
+                    width: app.get_scaled_width(210.0)
+                    height: app.get_scaled_height(280.0)
                     padding: 0
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
                     orientation: 'vertical'
 
                     Spinner:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: language_button
                         size_hint: (None,None)
-                        height: dp(0.0729166666667*app.height)
-                        width: dp(0.225*app.width)
+                        height: app.get_scaled_height(35.0)
+                        width: app.get_scaled_width(180.0)
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: ""
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         center: self.parent.center
                         pos: self.parent.pos
                         text: 'Choose language...'
@@ -454,14 +454,14 @@ Builder.load_string(
                         on_text: root.choose_language()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: data_and_wifi_button
                         size_hint: (None,None)
-                        height: dp(0.0729166666667*app.height)
-                        width: dp(0.225*app.width)
+                        height: app.get_scaled_height(35.0)
+                        width: app.get_scaled_width(180.0)
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: "./asmcnc/apps/systemTools_app/img/word_button.png"
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         center: self.parent.center
                         pos: self.parent.pos
                         on_press: root.open_data_consent_app()
@@ -469,14 +469,14 @@ Builder.load_string(
                         markup: True
                         
                     ToggleButton:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: toggle_ssh_button
                         size_hint: (None,None)
-                        height: dp(0.0729166666667*app.height)
-                        width: dp(0.225*app.width)
+                        height: app.get_scaled_height(35.0)
+                        width: app.get_scaled_width(180.0)
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: "./asmcnc/apps/systemTools_app/img/word_button.png"
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         center: self.parent.center
                         pos: self.parent.pos
                         on_press: root.toggle_ssh()
@@ -484,14 +484,14 @@ Builder.load_string(
                         markup: True
 
                     ToggleButton:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: advanced_button
                         size_hint: (None,None)
-                        height: dp(0.0729166666667*app.height)
-                        width: dp(0.225*app.width)
+                        height: app.get_scaled_height(35.0)
+                        width: app.get_scaled_width(180.0)
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: "./asmcnc/apps/systemTools_app/img/word_button.png"
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         center: self.parent.center
                         pos: self.parent.pos
                         on_press: root.do_show_more_info()
@@ -500,12 +500,12 @@ Builder.load_string(
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.2625*app.width)
-                        padding:[0, 0]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(210.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0])
 
                         Label: 
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             id: show_more_info
                             text: ''
                             opacity: 0
@@ -513,29 +513,29 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([10.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.108333333333*app.height)
-                            width: dp(0.075*app.width)
+                            height: app.get_scaled_height(52.0)
+                            width: app.get_scaled_width(60.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -553,29 +553,29 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.775*app.width)
-                    height: dp(0.166666666667*app.height)
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    width: app.get_scaled_width(620.0)
+                    height: app.get_scaled_height(80.0)
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     spacing: 0
                     orientation: 'vertical'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.02375)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([19.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.06375*app.width)
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(51.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_developer_temp.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_developer_temp.py
@@ -29,7 +29,7 @@ Builder.load_string(
         size_hint_y: None
         height: self.texture_size[1]
         text_size: self.width, None
-        font_size: str(0.0125*app.width) + 'sp'
+        font_size: app.get_scaled_sp('10.0sp')
         text: root.text
         max_lines: 60
 
@@ -48,7 +48,7 @@ Builder.load_string(
         size_hint_y: None
         height: self.texture_size[1]
         text_size: self.width, None
-        font_size: str(0.015*app.width) + 'sp'
+        font_size: app.get_scaled_sp('12.0sp')
         text: root.text
         max_lines: 20
 
@@ -59,8 +59,8 @@ Builder.load_string(
     gCodeInput: gCodeInput
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: [226 / 255., 226 / 255., 226 / 255., 1.]
@@ -69,8 +69,8 @@ Builder.load_string(
                 pos: self.pos
 
         BoxLayout:
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-            spacing:0.0208333333333*app.height
+            padding: app.get_scaled_tuple([10.0, 10.0])
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -83,29 +83,29 @@ Builder.load_string(
                         size: self.size
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.145833333333*app.height)
-                    width: dp(0.975*app.width)
+                    height: app.get_scaled_height(70.0)
+                    width: app.get_scaled_width(780.0)
                     text: "Developer"
                     color: [0,0,0,1]
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
        
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(0.975*app.width)
-                height: dp(0.5*app.height)
+                width: app.get_scaled_width(780.0)
+                height: app.get_scaled_height(240.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.721875*app.width)
-                    height: dp(0.5*app.height)
-                    padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                    spacing:0.0416666666667*app.height
+                    width: app.get_scaled_width(577.5)
+                    height: app.get_scaled_height(240.0)
+                    padding: app.get_scaled_tuple([20.0, 20.0])
+                    spacing: app.get_scaled_width(20.0)
                     orientation: 'vertical'
                     canvas:
                         Color:
@@ -121,75 +121,75 @@ Builder.load_string(
                         rows: 4
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: "Update test"
                             on_press: root.open_update_testing()
                                     
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                                        
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                             
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                                        
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                             
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                                        
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                             
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
                             
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: ''
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.240625*app.width)
-                    height: dp(0.5*app.height)
-                    padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                    width: app.get_scaled_width(192.5)
+                    height: app.get_scaled_height(240.0)
+                    padding: app.get_scaled_tuple([20.0, 20.0])
                     spacing: 0
                     orientation: 'vertical'
                     canvas:
@@ -213,10 +213,10 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(0.975*app.width)
-                height: dp(0.270833333333*app.height)
+                width: app.get_scaled_width(780.0)
+                height: app.get_scaled_height(130.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
                 canvas:
                     Color:
@@ -227,21 +227,21 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.240625*app.width)
-                    height: dp(0.270833333333*app.height)
+                    width: app.get_scaled_width(192.5)
+                    height: app.get_scaled_height(130.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.270833333333*app.height)
-                        width: dp(0.240625*app.width)
-                        padding:[dp(0.0653125)*app.width, dp(0.0645833333333)*app.height, dp(0.0653125)*app.width, dp(0.0645833333333)*app.height]
+                        height: app.get_scaled_height(130.0)
+                        width: app.get_scaled_width(192.5)
+                        padding: app.get_scaled_tuple([52.25, 31.0, 52.25, 31.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.141666666667*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(68.0)
+                            width: app.get_scaled_width(88.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -259,9 +259,9 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.48125*app.width)
-                    height: dp(0.270833333333*app.height)
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    width: app.get_scaled_width(385.0)
+                    height: app.get_scaled_height(130.0)
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     spacing: 0
                     orientation: 'vertical'
 
@@ -270,22 +270,22 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.240625*app.width)
-                    height: dp(0.270833333333*app.height)
+                    width: app.get_scaled_width(192.5)
+                    height: app.get_scaled_height(130.0)
                     padding: 0
-                    spacing: 0    
+                    spacing: 0
 
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.270833333333*app.height)
-                        width: dp(0.240625*app.width)
-                        padding:[dp(0.0503125)*app.width, dp(0.01875)*app.height, dp(0.0503125)*app.width, dp(0.01875)*app.height]
+                        height: app.get_scaled_height(130.0)
+                        width: app.get_scaled_width(192.5)
+                        padding: app.get_scaled_tuple([40.25, 9.0, 40.25, 9.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.233333333333*app.height)
-                            width: dp(0.14*app.width)
+                            height: app.get_scaled_height(112.0)
+                            width: app.get_scaled_width(112.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_factory_settings.py
@@ -63,8 +63,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#f9f9f9ff')
@@ -74,7 +74,7 @@ Builder.load_string(
 
         BoxLayout:
             padding: 0
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -87,31 +87,31 @@ Builder.load_string(
                         size: self.size
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Factory settings"
                     color: hex('#f9f9f9ff')
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
                    
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.666666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(320.0)
                 orientation: 'horizontal'
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.721875*app.width)
-                    height: dp(0.666666666667*app.height)
+                    width: app.get_scaled_width(577.5)
+                    height: app.get_scaled_height(320.0)
                     padding: 0
-                    spacing:0.0208333333333*app.height
+                    spacing: app.get_scaled_width(10.0)
                     orientation: 'vertical'
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.721875*app.width)
-                        height: dp(0.479166666667*app.height)
+                        width: app.get_scaled_width(577.5)
+                        height: app.get_scaled_height(230.0)
                         padding: 0
                         spacing: 0
                         orientation: 'vertical'
@@ -121,25 +121,25 @@ Builder.load_string(
                             pos: self.parent.pos
                             cols: 0
                             rows: 4
-                            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-                            spacing:0.0104166666667*app.height
+                            padding: app.get_scaled_tuple([10.0, 10.0])
+                            spacing: app.get_scaled_width(5.0)
                             BoxLayout: 
                                 orientation: 'vertical'
-                                spacing:0.0104166666667*app.height
+                                spacing: app.get_scaled_width(5.0)
                                 
                                 BoxLayout:
                                     orientation: 'horizontal'
-                                    spacing:0.00625*app.width
+                                    spacing: app.get_scaled_width(5.0)
                                     
                                     Spinner:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         id: smartbench_model
                                         text: 'Choose model'
                                         values: root.latest_machine_model_values
                                         on_text: root.set_smartbench_model()
                                     
                                     ToggleButton:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         id: smartbench_model_button
                                         text: 'Show all models'
                                         on_press: root.show_all_smartbench_models()
@@ -147,7 +147,7 @@ Builder.load_string(
                                     
                             BoxLayout: 
                                 orientation: 'vertical'
-                                spacing:0.0104166666667*app.height
+                                spacing: app.get_scaled_width(5.0)
 
 
                                 GridLayout: 
@@ -155,10 +155,10 @@ Builder.load_string(
                                     pos: self.parent.pos
                                     cols: 4
                                     rows: 0
-                                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
-                                    spacing:0.0125*app.width
+                                    padding: app.get_scaled_tuple([5.0, 5.0])
+                                    spacing: app.get_scaled_width(10.0)
                                     Label:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         text: '[b]Serial number[/b]'
                                         color: [0,0,0,1]
                                         markup: True
@@ -167,7 +167,7 @@ Builder.load_string(
 
                                         TextInput:
                                             id: serial_prefix
-                                            font_size: str(15.0/800.0 * app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('15.0sp')
                                             text: 'YS6'
                                             color: [0,0,0,1]
                                             markup: True
@@ -175,7 +175,7 @@ Builder.load_string(
                                             size_hint_x: 0.3
                                             multiline: False
                                         Label:
-                                            font_size: str(0.01875 * app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('15.0sp')
                                             text: ''
                                             color: [0,0,0,1]
                                             markup: True
@@ -183,7 +183,7 @@ Builder.load_string(
 
                                         TextInput:
                                             id: serial_number_input
-                                            font_size: str(15.0/800.0 * app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('15.0sp')
                                             text: '0000'
                                             color: [0,0,0,1]
                                             markup: True
@@ -193,7 +193,7 @@ Builder.load_string(
                                             multiline: False
 
                                         Label:
-                                            font_size: str(0.01875 * app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('15.0sp')
                                             text: '.'
                                             color: [0,0,0,1]
                                             markup: True
@@ -201,7 +201,7 @@ Builder.load_string(
 
                                         TextInput:
                                             id: product_number_input
-                                            font_size: str(15.0/800.0 * app.width) + 'sp'
+                                            font_size: app.get_scaled_sp('15.0sp')
                                             text: '00'
                                             color: [0,0,0,1]
                                             markup: True
@@ -211,12 +211,12 @@ Builder.load_string(
                                             multiline: False
 
                                     Button:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         text: 'UPDATE'
                                         on_press: root.update_serial_number()
 
                                     Label:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         id: machine_serial
                                         text: 'machine serial'
                                         color: [0,0,0,1]
@@ -224,24 +224,24 @@ Builder.load_string(
 
                             BoxLayout: 
                                 orientation: 'vertical'
-                                spacing:0.0104166666667*app.height
+                                spacing: app.get_scaled_width(5.0)
 
                                 GridLayout: 
                                     size: self.parent.size
                                     pos: self.parent.pos
                                     cols: 4
                                     rows: 0
-                                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
-                                    spacing:0.0125*app.width
+                                    padding: app.get_scaled_tuple([5.0, 5.0])
+                                    spacing: app.get_scaled_width(10.0)
 
                                     Label:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         text: '[b]Touchplate offset[/b]'
                                         color: [0,0,0,1]
                                         markup: True
                                     TextInput:
                                         id: z_touch_plate_entry
-                                        font_size: str(15.0/800.0 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         text: ''
                                         color: [0,0,0,1]
                                         markup: True
@@ -249,12 +249,12 @@ Builder.load_string(
                                         input_filter: 'float'
                                         multiline: False
                                     Button:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         text: 'UPDATE'
                                         on_press: root.update_z_touch_plate_thickness()
     
                                     Label:
-                                        font_size: str(0.01875 * app.width) + 'sp'
+                                        font_size: app.get_scaled_sp('15.0sp')
                                         id: machine_touchplate_thickness
                                         text: 'machine_tp'
                                         color: [0,0,0,1]
@@ -263,21 +263,21 @@ Builder.load_string(
                         BoxLayout:
                             size_hint_y: 0.3
                             orientation: 'horizontal'
-                            spacing:dp(0.0125)*app.width
+                            spacing: app.get_scaled_width(10.0)
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 text: '$54 info'
                                 on_press: root.setting_54_info()
 
                             ToggleButton:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: setting_54_toggle
                                 text: 'Set $54=1'
                                 on_press: root.toggle_setting_54()
 
                             Label:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: setting_54_label
                                 size_hint_x: 0.7
                                 text: '$54 = N/A'
@@ -286,9 +286,9 @@ Builder.load_string(
 
                     BoxLayout:
                         size_hint: (None,None)
-                        width: dp(0.721875*app.width)
-                        height: dp(0.166666666667*app.height)
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        width: app.get_scaled_width(577.5)
+                        height: app.get_scaled_height(80.0)
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         spacing: 0
                         orientation: 'vertical'
 
@@ -298,10 +298,10 @@ Builder.load_string(
                             cols: 3
                             rows: 0
                             padding: 0
-                            spacing:0.0125*app.width
+                            spacing: app.get_scaled_width(10.0)
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: console_update_button
                                 text: 'Full Console Update (wifi)'
                                 on_press: root.full_console_update()
@@ -312,20 +312,20 @@ Builder.load_string(
                                 cols: 0
                                 rows: 3
                                 padding: 0
-                                spacing:0.0025*app.width
+                                spacing: app.get_scaled_width(2.0)
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     text: 'Current'
                                     color: [0,0,0,1]
                                     markup: True
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     id: software_version_label
                                     text: 'SW'
                                     color: [0,0,0,1]
                                     markup: True
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     id: platform_version_label
                                     text: 'PL'
                                     color: [0,0,0,1]
@@ -336,20 +336,20 @@ Builder.load_string(
                                 cols: 0
                                 rows: 3
                                 padding: 0
-                                spacing:0.0025*app.width
+                                spacing: app.get_scaled_width(2.0)
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     text: 'Available'
                                     color: [0,0,0,1]
                                     markup: True
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     id: latest_software_version
                                     text: 'SW'
                                     color: [0,0,0,1]
                                     markup: True
                                 Label:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     id: latest_platform_version
                                     text: 'PL'
                                     color: [0,0,0,1]
@@ -358,9 +358,9 @@ Builder.load_string(
                 GridLayout:
                     cols: 2
                     rows: 8
-                    spacing:0.0025*app.width
+                    spacing: app.get_scaled_width(2.0)
                     ToggleButton:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: maintenance_reminder_toggle
                         text: 'Turn reminders off'
                         on_press: root.toggle_reminders()
@@ -369,7 +369,7 @@ Builder.load_string(
                         valign: "middle"
 
                     ToggleButton:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: show_spindle_overload_toggle
                         text: 'Show spindle overload'
                         on_press: root.toggle_spindle_mode()
@@ -378,7 +378,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Diagnostics'
                         on_press: root.diagnostics()
                         text_size: self.size
@@ -386,7 +386,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Current'
                         on_press: root.enter_current_adjustment()
                         text_size: self.size
@@ -394,7 +394,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'FT B1'
                         background_normal: ''
                         background_color: [0.75,0.34,0.51,1]
@@ -404,7 +404,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'FT B2'
                         background_normal: ''
                         background_color: [0.28,0.44,0.97,1]
@@ -414,7 +414,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'FT B3'
                         background_normal: ''
                         background_color: [0.2,0.8,0.2,1]
@@ -424,7 +424,7 @@ Builder.load_string(
                         valign: "middle"
 
                     ToggleButton:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: sc2_compatability_toggle
                         text: 'Enable SC2 compatability'
                         on_press: root.show_sc2_decision_popup()
@@ -433,7 +433,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Retrieve LB cal data'
                         on_press: root.enter_serial_number_screen()
                         text_size: self.size
@@ -441,7 +441,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'SG & Load test'
                         on_press: root.enter_calibration_test()
                         text_size: self.size
@@ -449,7 +449,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Overnight test'
                         on_press: root.enter_overnight_test()
                         text_size: self.size
@@ -457,7 +457,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Stall Jig'
                         on_press: root.enter_stall_jig()
                         text_size: self.size
@@ -465,7 +465,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'SG thresh'
                         on_press: root.enter_set_thresholds()
                         text_size: self.size
@@ -473,7 +473,7 @@ Builder.load_string(
                         valign: "middle"
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Measure'
                         on_press: root.enter_general_measurement()
                         text_size: self.size
@@ -481,7 +481,7 @@ Builder.load_string(
                         valign: "middle"
                         
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'SC2 spindle test'
                         on_press: root.digital_spindle_test_pressed()
                         text_size: self.size
@@ -491,29 +491,29 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([10.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.108333333333*app.height)
-                            width: dp(0.075*app.width)
+                            height: app.get_scaled_height(52.0)
+                            width: app.get_scaled_width(60.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -531,34 +531,34 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.775*app.width)
-                    height: dp(0.166666666667*app.height)
-                    padding:[dp(0.2)*app.width, 0]
+                    width: app.get_scaled_width(620.0)
+                    height: app.get_scaled_height(80.0)
+                    padding: app.get_scaled_tuple([160.0, 0.0])
                     spacing: 0
                     orientation: 'vertical'
                     BoxLayout:
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: 'FACTORY RESET'
                             on_press: root.factory_reset()
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.02375)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([19.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.06375*app.width)
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(51.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_final_test.py
@@ -58,12 +58,12 @@ Builder.load_string(
                 size_hint_x: 0.165
 
                 Button: 
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Home'
                     on_press: root.home()
 
                 Button: 
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: 'Y-Home, X-mid'
                     on_press: root.y_home_x_mid()
 
@@ -75,31 +75,31 @@ Builder.load_string(
                         hint_text: "Y"
                         valign: 'middle'
                         halign: 'center'
-                        font_size: str(0.03*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('24.0sp')
                         text_size: self.size
                         markup: True
                         multiline: False
                         input_filter: 'int'
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: "Set"
                         on_press: root.set_y_steps()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: y_pos_label
                     text: "G91 G0 Y1636.6"
                     on_press: root.Y_plus()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: y_neg_label
                     text: "G91 G0 Y-1636.6"
                     on_press: root.Y_minus()
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     text: "Factory Settings"
                     on_press: root.go_back()
 
@@ -120,19 +120,19 @@ Builder.load_string(
 
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: x_pos_label
                         text: "G91 G0 X1150.3"
                         on_press: root.X_plus()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: x_neg_label
                         text: "G91 G0 X-1150.3"
                         on_press: root.X_minus()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: "G91 G0 X575.0"
                         on_press: root.X_575()
 
@@ -144,14 +144,14 @@ Builder.load_string(
                             hint_text: "X"
                             valign: 'middle'
                             halign: 'center'
-                            font_size: str(0.03*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('24.0sp')
                             text_size: self.size
                             markup: True
                             multiline: False
                             input_filter: 'int'
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             text: "Set"
                             on_press: root.set_x_steps()
 

--- a/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_grbl_settings.py
@@ -14,8 +14,8 @@ Builder.load_string(
 
 <GRBLSettingsScreen>
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#f9f9f9ff')
@@ -25,7 +25,7 @@ Builder.load_string(
 
         BoxLayout:
             padding: 0
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -38,20 +38,20 @@ Builder.load_string(
                         size: self.size
                 Label:
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "GRBL settings"
                     color: hex('#f9f9f9ff')
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
                    
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.666666666667*app.height)
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(320.0)
+                padding: app.get_scaled_tuple([20.0, 20.0])
                 spacing: 0
                 orientation: 'vertical'
 
@@ -63,74 +63,74 @@ Builder.load_string(
                     size_hint_y: 0.67
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Download to USB'
                         on_press: root.download_grbl_settings()
                                 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Save to file'
                         on_press: root.save_grbl_settings()
                                    
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: ''
                         
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Restore from USB'
                         on_press: root.restore_grbl_settings_from_usb()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Restore from file'
                         on_press: root.restore_grbl_settings_from_file()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: 'Bake defaults'
                         on_press: root.bake_default_settings()
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: '$RST=$'
                         on_press: root.send_rst_dollar()
                                    
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: '$RST=*'
                         on_press: root.send_rst_star()
                         
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         text: '$RST=#'
                         on_press: root.send_rst_hash()
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
                 padding: 0
-                spacing:0.0125*app.width
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([10.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.108333333333*app.height)
-                            width: dp(0.075*app.width)
+                            height: app.get_scaled_height(52.0)
+                            width: app.get_scaled_width(60.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -148,29 +148,29 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.775*app.width)
-                    height: dp(0.166666666667*app.height)
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    width: app.get_scaled_width(620.0)
+                    height: app.get_scaled_height(80.0)
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     spacing: 0
                     orientation: 'vertical'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(0.1*app.width)
-                    height: dp(0.166666666667*app.height)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(0.166666666667*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.02375)*app.width, dp(0.0208333333333)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([19.0, 10.0, 10.0, 10.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.125*app.height)
-                            width: dp(0.06375*app.width)
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(51.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/screen_support_menu.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_support_menu.py
@@ -37,8 +37,8 @@ Builder.load_string(
     GridLayout:
         size: self.parent.size
         pos: self.parent.pos
-        padding:[dp(0.0104125)*app.width, dp(0.125)*app.height]
-        spacing:[dp(0.0104125)*app.width, dp(0.125)*app.height]
+        padding: app.get_scaled_tuple([8.33, 60.0])
+        spacing: app.get_scaled_tuple([8.33, 60.0])
         cols: 5
         rows: 2
 
@@ -58,7 +58,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/download_logs.png"
             background_down: "./asmcnc/apps/systemTools_app/img/download_logs.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_reinstall_pika
@@ -72,7 +72,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/pika_reinstall.png"
             background_down: "./asmcnc/apps/systemTools_app/img/pika_reinstall.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_git_fsck
@@ -86,7 +86,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/git_fsck_button.png"
             background_down: "./asmcnc/apps/systemTools_app/img/git_fsck_button.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         BoxLayout:
             padding: 0
@@ -107,7 +107,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/download_to_usb.png"
             background_down: "./asmcnc/apps/systemTools_app/img/download_to_usb.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_upload_settings_from_usb
@@ -121,7 +121,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/upload_from_usb.png"
             background_down: "./asmcnc/apps/systemTools_app/img/upload_from_usb.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         BoxLayout:
             padding: 0
@@ -138,7 +138,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/exit_system_tools.png"
             background_down: "./asmcnc/apps/systemTools_app/img/exit_system_tools.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/apps/systemTools_app/screens/screen_system_menu.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_system_menu.py
@@ -43,8 +43,8 @@ Builder.load_string(
     GridLayout:
         size: self.parent.size
         pos: self.parent.pos
-        padding:[dp(0.0104125)*app.width, dp(0.125)*app.height]
-        spacing:[dp(0.0104125)*app.width, dp(0.125)*app.height]
+        padding: app.get_scaled_tuple([8.33, 60.0])
+        spacing: app.get_scaled_tuple([8.33, 60.0])
         cols: 5
         rows: 2
 
@@ -60,7 +60,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/system_info.png"
             background_down: "./asmcnc/apps/systemTools_app/img/system_info.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_reboot
@@ -74,7 +74,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/reboot_console.png"
             background_down: "./asmcnc/apps/systemTools_app/img/reboot_console.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_support_menu
@@ -88,7 +88,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/support.png"
             background_down: "./asmcnc/apps/systemTools_app/img/support.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_exit_software
@@ -102,7 +102,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/quit_to_console.png"
             background_down: "./asmcnc/apps/systemTools_app/img/quit_to_console.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_usb_first_aid
@@ -116,7 +116,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/usb_first_aid.png"
             background_down: "./asmcnc/apps/systemTools_app/img/usb_first_aid.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_beta_testing
@@ -130,7 +130,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/beta_testing.png"
             background_down: "./asmcnc/apps/systemTools_app/img/beta_testing.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_grbl_settings
@@ -144,7 +144,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/grbl_settings.png"
             background_down: "./asmcnc/apps/systemTools_app/img/grbl_settings.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_factory
@@ -158,7 +158,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/factory.png"
             background_down: "./asmcnc/apps/systemTools_app/img/factory.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         # Button:
         #     id: button_update_testing
@@ -172,7 +172,7 @@ Builder.load_string(
         #     background_normal: "./asmcnc/apps/systemTools_app/img/update_developer.png"
         #     background_down: "./asmcnc/apps/systemTools_app/img/update_developer.png"
         #     padding_y: 5.0/800.0*app.width
-        #     border: (0,0,0,0)
+        #     border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
 
         Button:
@@ -188,7 +188,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/developer.png"
             background_down: "./asmcnc/apps/systemTools_app/img/developer.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
         Button:
             id: button_go_back
@@ -202,7 +202,7 @@ Builder.load_string(
             background_normal: "./asmcnc/apps/systemTools_app/img/exit_system_tools.png"
             background_down: "./asmcnc/apps/systemTools_app/img/exit_system_tools.png"
             padding_y: 5.0/800.0*app.width
-            border: (0,0,0,0)
+            border: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
 
 """
 )

--- a/src/asmcnc/apps/systemTools_app/screens/screen_update_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_update_testing.py
@@ -32,7 +32,7 @@ Builder.load_string("""
         size_hint_y: None
         height: self.texture_size[1]
         text_size: self.width, None
-        font_size: '12sp'
+        font_size: app.get_scaled_sp('12sp')
         text: root.text
         max_lines: 3
 
@@ -42,8 +42,8 @@ Builder.load_string("""
     output_view: output_view
 
     BoxLayout:
-        height: dp(800)
-        width: dp(480)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#f9f9f9ff')
@@ -53,7 +53,7 @@ Builder.load_string("""
 
         BoxLayout:
             padding: 0
-            spacing: 10
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             BoxLayout:
                 padding: 0
@@ -66,20 +66,20 @@ Builder.load_string("""
                         size: self.size
                 Label:
                     size_hint: (None,None)
-                    height: dp(60)
-                    width: dp(800)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Update Testing"
                     color: hex('#f9f9f9ff')
-                    font_size: 30
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
                    
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(800)
-                height: dp(320)
-                padding: 20
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(320.0)
+                padding: app.get_scaled_width(20.0)
                 spacing: 0
                 orientation: 'vertical'
 
@@ -147,28 +147,28 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(800)
-                height: dp(80)
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
                 padding: 0
-                spacing: 10
+                spacing: app.get_scaled_width(10.0)
                 orientation: 'horizontal'
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(80)
-                    height: dp(80)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(80)
-                        width: dp(80)
-                        padding: [10, 10, 10, 10]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([10.0, 10.0, 10.0, 10.0])
                         Button:
                             size_hint: (None,None)
-                            height: dp(52)
-                            width: dp(60)
+                            height: app.get_scaled_height(52.0)
+                            width: app.get_scaled_width(60.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos
@@ -186,9 +186,9 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(620)
-                    height: dp(80)
-                    padding: 10
+                    width: app.get_scaled_width(620.0)
+                    height: app.get_scaled_height(80.0)
+                    padding: app.get_scaled_width(10.0)
                     spacing: 0
                     orientation: 'vertical'
                     ScrollableLabelOSOutput:
@@ -196,20 +196,20 @@ Builder.load_string("""
 
                 BoxLayout:
                     size_hint: (None,None)
-                    width: dp(80)
-                    height: dp(80)
+                    width: app.get_scaled_width(80.0)
+                    height: app.get_scaled_height(80.0)
                     padding: 0
                     spacing: 0
 
                     BoxLayout: 
                         size_hint: (None, None)
-                        height: dp(80)
-                        width: dp(80)
-                        padding: [19, 10, 10, 10]
+                        height: app.get_scaled_height(80.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([19.0, 10.0, 10.0, 10.0])
                         Button:
                             size_hint: (None,None)
-                            height: dp(60)
-                            width: dp(51)
+                            height: app.get_scaled_height(60.0)
+                            width: app.get_scaled_width(51.0)
                             background_color: hex('#F4433600')
                             center: self.parent.center
                             pos: self.parent.pos

--- a/src/asmcnc/apps/systemTools_app/screens/widget_final_test_xy_move.py
+++ b/src/asmcnc/apps/systemTools_app/screens/widget_final_test_xy_move.py
@@ -26,8 +26,8 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        spacing: 10
-        padding: [0, 0, 0, 0]
+        spacing: app.get_scaled_width(10.0)
+        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
         
         BoxLayout:
             orientation: 'horizontal'
@@ -56,12 +56,12 @@ Builder.load_string("""
                         allow_stretch: True
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos 
             
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
                 
@@ -75,7 +75,7 @@ Builder.load_string("""
             padding: 0
     
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos           
             
@@ -160,7 +160,7 @@ Builder.load_string("""
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 
@@ -186,7 +186,7 @@ Builder.load_string("""
                         allow_stretch: True                     
             # speed toggle
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 
@@ -217,7 +217,7 @@ Builder.load_string("""
                         allow_stretch: True
             
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 

--- a/src/asmcnc/apps/upgrade_app/screen_already_upgraded.py
+++ b/src/asmcnc/apps/upgrade_app/screen_already_upgraded.py
@@ -28,7 +28,7 @@ Builder.load_string("""
                 text: 'Upgrade SB V1.3 to PrecisionPro +'
                 halign: 'center'
                 valign: 'middle'
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
                 text_size: self.size
 
         BoxLayout:
@@ -44,7 +44,7 @@ Builder.load_string("""
 
             LabelBase:
                 id: already_upgraded_label
-                font_size: dp(0.04*app.width)
+                font_size: app.get_scaled_width(32.0)
                 color: 0,0,0,1
                 halign: 'center'
                 valign: 'middle'
@@ -52,18 +52,18 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint_y: 0.25
-                padding:[dp(0.21875)*app.width, 0, dp(0.21875)*app.width, dp(0.229166666667)*app.height]
+                padding: app.get_scaled_tuple([175.0, 0.0, 175.0, 110.0])
 
                 Button:
                     id: continue_button
                     on_press: root.next_screen()
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     background_normal: "./asmcnc/skavaUI/img/next.png"
                     background_down: "./asmcnc/skavaUI/img/next.png"
-                    border: [dp(14.5)]*4
+                    border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                     size_hint: (None,None)
-                    width: dp(0.5625*app.width)
-                    height: dp(0.125*app.height)
+                    width: app.get_scaled_width(450.0)
+                    height: app.get_scaled_height(60.0)
                     color: hex('#f9f9f9ff')
                     center: self.parent.center
                     pos: self.parent.pos

--- a/src/asmcnc/apps/upgrade_app/screen_upgrade.py
+++ b/src/asmcnc/apps/upgrade_app/screen_upgrade.py
@@ -40,26 +40,26 @@ Builder.load_string("""
                     pos: self.pos
 
             BoxLayout:
-                padding:[dp(0.075)*app.width, 0, 0, 0]
+                padding: app.get_scaled_tuple([60.0, 0.0, 0.0, 0.0])
 
                 LabelBase:
                     id: title_label
                     text: 'Upgrade SB V1.3 to PrecisionPro +'
                     halign: 'center'
                     valign: 'middle'
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     text_size: self.size
 
             BoxLayout:
                 size_hint_x: 0.08
-                padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                padding: app.get_scaled_tuple([5.0, 5.0])
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: exit_button
                     size_hint: (None,None)
-                    height: dp(0.104166666667*app.height)
-                    width: dp(0.0625*app.width)
+                    height: app.get_scaled_height(50.0)
+                    width: app.get_scaled_width(50.0)
                     background_color: [0,0,0,0]
                     opacity: 1
                     on_press: root.quit_to_lobby()
@@ -77,7 +77,7 @@ Builder.load_string("""
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: 7
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             canvas: 
                 Color:
@@ -92,18 +92,18 @@ Builder.load_string("""
                 LabelBase:
                     id: instruction_label
                     size_hint_y: 2
-                    font_size: dp(0.03*app.width)
+                    font_size: app.get_scaled_width(24.0)
                     color: 0,0,0,1
                     halign: 'center'
                     valign: 'middle'
                     text_size: self.size
 
                 BoxLayout:
-                    padding:[dp(0.25)*app.width, 0, dp(0.25)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([200.0, 0.0, 200.0, 20.0])
 
                     TextInput:
                         id: upgrade_code_input
-                        font_size: dp(0.0375*app.width)
+                        font_size: app.get_scaled_width(30.0)
                         multiline: False
                         valign: 'middle'
                         halign: 'center'
@@ -120,7 +120,7 @@ Builder.load_string("""
                         id: error_label
                         size_hint_y: 0
                         height: 0
-                        font_size: dp(0.02875*app.width)
+                        font_size: app.get_scaled_width(23.0)
                         color: 1,0,0,1
                         halign: 'center'
                         valign: 'middle'
@@ -132,7 +132,7 @@ Builder.load_string("""
                         LabelBase:
                             id: support_label
                             size_hint_y: 1.5
-                            font_size: dp(0.03*app.width)
+                            font_size: app.get_scaled_width(24.0)
                             color: 0,0,0,1
                             halign: 'center'
                             valign: 'middle'
@@ -145,7 +145,7 @@ Builder.load_string("""
 
                         LabelBase:
                             id: spindle_label
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             color: 0,0,0,1
                             halign: 'center'
                             valign: 'middle'

--- a/src/asmcnc/apps/upgrade_app/screen_upgrade_successful.py
+++ b/src/asmcnc/apps/upgrade_app/screen_upgrade_successful.py
@@ -28,7 +28,7 @@ Builder.load_string("""
                 text: 'Upgrade SB V1.3 to PrecisionPro +'
                 halign: 'center'
                 valign: 'middle'
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
                 text_size: self.size
 
         BoxLayout:
@@ -44,7 +44,7 @@ Builder.load_string("""
 
             LabelBase:
                 id: success_label
-                font_size: dp(0.04*app.width)
+                font_size: app.get_scaled_width(32.0)
                 color: 0,0,0,1
                 halign: 'center'
                 valign: 'middle'
@@ -52,18 +52,18 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint_y: 0.25
-                padding:[dp(0.21875)*app.width, 0, dp(0.21875)*app.width, dp(0.229166666667)*app.height]
+                padding: app.get_scaled_tuple([175.0, 0.0, 175.0, 110.0])
 
                 Button:
                     id: continue_button
                     on_press: root.next_screen()
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     background_normal: "./asmcnc/skavaUI/img/next.png"
                     background_down: "./asmcnc/skavaUI/img/next.png"
-                    border: [dp(14.5)]*4
+                    border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                     size_hint: (None,None)
-                    width: dp(0.5625*app.width)
-                    height: dp(0.125*app.height)
+                    width: app.get_scaled_width(450.0)
+                    height: app.get_scaled_height(60.0)
                     color: hex('#f9f9f9ff')
                     center: self.parent.center
                     pos: self.parent.pos

--- a/src/asmcnc/apps/wifi_app/screen_wifi.py
+++ b/src/asmcnc/apps/wifi_app/screen_wifi.py
@@ -27,7 +27,7 @@ Builder.load_string(
 
     background_normal: ''
     background_color: [1,1,1,1]
-    height: dp(0.0833333333333*app.height)
+    height: app.get_scaled_height(40.0)
     color: 0,0,0,1
     halign: 'left'
     markup: 'True'
@@ -58,8 +58,8 @@ Builder.load_string(
     
     BoxLayout:
         size_hint: (None, None)
-        height: dp(1.0*app.height)
-        width: dp(1.0*app.width)
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
         orientation: 'vertical'
         canvas:
             Color:
@@ -70,20 +70,20 @@ Builder.load_string(
         
         BoxLayout:
             size_hint: (None, None)
-            height: dp(0.395833333333*app.height)
-            width: dp(1.0*app.width)
-            padding:[dp(0.0375)*app.width, dp(0.0625)*app.height, dp(0.0375)*app.width, dp(0.0416666666667)*app.height]
-            spacing:0.0375*app.width
+            height: app.get_scaled_height(190.0)
+            width: app.get_scaled_width(800.0)
+            padding: app.get_scaled_tuple([30.0, 30.0, 30.0, 20.0])
+            spacing: app.get_scaled_width(30.0)
             orientation: 'horizontal'
             
             # Status indicator            
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.291666666667*app.height)
-                width: dp(0.1875*app.width)
+                height: app.get_scaled_height(140.0)
+                width: app.get_scaled_width(150.0)
                 orientation: 'vertical'
-                padding:[0, dp(0.0729166666667)*app.height, 0, dp(0.0208333333333)*app.height]
-                spacing:0.0208333333333*app.height
+                padding: app.get_scaled_tuple([0.0, 35.0, 0.0, 10.0])
+                spacing: app.get_scaled_width(10.0)
                 canvas:
                     Color:
                         rgba: root.status_color
@@ -92,8 +92,8 @@ Builder.load_string(
                         size: self.size
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.0520833333333*app.height)
-                    width: dp(0.1875*app.width)
+                    height: app.get_scaled_height(25.0)
+                    width: app.get_scaled_width(150.0)
                     Image:
                         id: wifi_image
                         source: "./asmcnc/skavaUI/img/wifi_on.png"
@@ -104,13 +104,13 @@ Builder.load_string(
 
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.125*app.height)
-                    width: dp(0.1875*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(150.0)
                     orientation: 'vertical'
                     LabelBase:
                         id: ip_address_label
                         color: 1,1,1,1
-                        font_size: 0.0225*app.width
+                        font_size: app.get_scaled_width(18.0)
                         markup: True
                         halign: "center"
                         valign: "middle"
@@ -121,7 +121,7 @@ Builder.load_string(
                     LabelBase:
                         id: ip_status_label
                         color: 1,1,1,1
-                        font_size: 0.0225*app.width
+                        font_size: app.get_scaled_width(18.0)
                         markup: True
                         halign: "center"
                         valign: "middle"
@@ -132,10 +132,10 @@ Builder.load_string(
             # Text Entry Area
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.291666666667*app.height)
-                width: dp(0.7*app.width)
-                padding:[dp(0.0125)*app.width, dp(0.0416666666667)*app.height, dp(0.0125)*app.width, dp(0.0625)*app.height]
-                spacing:0.0125*app.width
+                height: app.get_scaled_height(140.0)
+                width: app.get_scaled_width(560.0)
+                padding: app.get_scaled_tuple([10.0, 20.0, 10.0, 30.0])
+                spacing: app.get_scaled_width(10.0)
                 canvas:
                     Color:
                         rgba: [1,1,1,1]
@@ -145,27 +145,27 @@ Builder.load_string(
                 # SSID
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.275*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(220.0)
                     pos_hint: {'top': 0.66}
                     orientation: "vertical"
-                    padding:[dp(0.0125)*app.width, 0, dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 0.0, 20.0, 20.0])
                     
                     BoxLayout: 
                         size_hint: (None, None) 
                         orientation: "horizontal"
-                        width: dp(0.2625*app.width)
-                        height: dp(0.0833333333333*app.height)
+                        width: app.get_scaled_width(210.0)
+                        height: app.get_scaled_height(40.0)
                         BoxLayout: 
                             size_hint: (None, None) 
                             orientation: "vertical"
-                            width: dp(0.18875*app.width)
-                            height: dp(0.0833333333333*app.height)
+                            width: app.get_scaled_width(151.0)
+                            height: app.get_scaled_height(40.0)
                             LabelBase:
                                 id: network_name_label
-                                width: dp(0.18875*app.width)
+                                width: app.get_scaled_width(151.0)
                                 color: 0,0,0,1
-                                font_size: 0.025*app.width
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "middle"
@@ -176,14 +176,14 @@ Builder.load_string(
                         BoxLayout: 
                             size_hint: (None, None) 
                             orientation: "vertical"
-                            width: dp(0.04875*app.width)
-                            height: dp(0.0833333333333*app.height)
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height, dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            width: app.get_scaled_width(39.0)
+                            height: app.get_scaled_height(40.0)
+                            padding: app.get_scaled_tuple([5.0, 5.0, 5.0, 5.0])
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 size_hint: (None,None)
-                                height: dp(0.0625*app.height)
-                                width: dp(0.03625*app.width)
+                                height: app.get_scaled_height(30.0)
+                                width: app.get_scaled_width(29.0)
                                 background_color: hex('#F4433600')
                                 center: self.parent.center
                                 pos: self.parent.pos
@@ -201,18 +201,18 @@ Builder.load_string(
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.2625*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(210.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                         orientation: 'horizontal'
                         id: network_name_input
                         
                         # The Spinner with the background image, grouped together in this BoxLayout
                         BoxLayout:
                             size_hint: (None,None)
-                            height: dp(0.0833333333333*app.height)
-                            width: dp(0.2625*app.width)
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height, dp(0.00625)*app.width, dp(0.0166666666667)*app.height]
+                            height: app.get_scaled_height(40.0)
+                            width: app.get_scaled_width(210.0)
+                            padding: app.get_scaled_tuple([5.0, 5.0, 5.0, 8.0])
                             id: network_name_box
                             
                             canvas:
@@ -228,9 +228,9 @@ Builder.load_string(
                                 pos_hint: {'top': 0.8}
                                 markup: True
                                 size_hint: (None, None)
-                                size: 200.0/800*app.width, 24.0/480*app.height
+                                size: app.get_scaled_tuple([200.0, 24.0])
                                 text: ''
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text_size: self.size
                                 multiline: False
                                 color: 0,0,0,1
@@ -242,9 +242,9 @@ Builder.load_string(
                         # The TextInput for the custom network name, very similar to the Password BoxLayout
                         BoxLayout:
                             size_hint: (None,None)
-                            height: dp(0.0833333333333*app.height)
-                            width: dp(0.2625*app.width)
-                            padding:[0, 0, 0, 0]
+                            height: app.get_scaled_height(40.0)
+                            width: app.get_scaled_width(210.0)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                             id: custom_network_name_box
                             
                             TextInput: 
@@ -253,7 +253,7 @@ Builder.load_string(
                                 padding_y: [self.height / 2.0 - (self.line_height / 2.0) * len(self._lines), 0]
                                 halign: 'center'
                                 text_size: self.size
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 markup: True
                                 multiline: False
                                 text: ''
@@ -263,13 +263,13 @@ Builder.load_string(
                     BoxLayout: 
                         size_hint: (None, None) 
                         orientation: "horizontal"
-                        width: dp(0.2625*app.width)
-                        height: dp(0.0833333333333*app.height)
-                        padding:[0, dp(0.0104166666667)*app.height, 0, dp(0.0104166666667)*app.height]
+                        width: app.get_scaled_width(210.0)
+                        height: app.get_scaled_height(40.0)
+                        padding: app.get_scaled_tuple([0.0, 5.0, 0.0, 5.0])
                         ToggleButton:
                             id: custom_ssid_button
                             on_release: root.custom_ssid_input()
-                            font_size: 0.025*app.width
+                            font_size: app.get_scaled_width(20.0)
                             color: hex('#f9f9f9ff')
                             markup: True
                             background_normal: "./asmcnc/apps/wifi_app/img/CustomSSID_blank.png"
@@ -278,15 +278,15 @@ Builder.load_string(
                 #Password
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.2625*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(210.0)
                     orientation: "vertical"
-                    padding:[0, 0, 0, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 20.0])
                               
                     LabelBase:
                         id: password_label
                         color: 0,0,0,1
-                        font_size: 0.025*app.width
+                        font_size: app.get_scaled_width(20.0)
                         markup: True
                         halign: "left"
                         valign: "middle"
@@ -296,16 +296,16 @@ Builder.load_string(
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.2625*app.width)
-                        padding:[0, 0, 0, 0]
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(210.0)
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                                     
                         TextInput: 
                             id: _password
                             valign: 'middle'
                             halign: 'center'
                             text_size: self.size
-                            font_size: str(0.025*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('20.0sp')
                             markup: True
                             multiline: False
                             text: ''
@@ -314,15 +314,15 @@ Builder.load_string(
                 #Country Code
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.208333333333*app.height)
-                    width: dp(0.1125*app.width)
+                    height: app.get_scaled_height(100.0)
+                    width: app.get_scaled_width(90.0)
                     orientation: 'vertical'
-                    padding:[0, 0, dp(0.0125)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([0.0, 0.0, 10.0, 20.0])
                               
                     LabelBase:
                         id: country_label
                         color: 0,0,0,1
-                        font_size: 0.025*app.width
+                        font_size: app.get_scaled_width(20.0)
                         markup: True
                         halign: "left"
                         valign: "middle"
@@ -332,9 +332,9 @@ Builder.load_string(
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.0833333333333*app.height)
-                        width: dp(0.1*app.width)
-                        padding:[dp(0.025)*app.width, 0, dp(0.00625)*app.width, 0]
+                        height: app.get_scaled_height(40.0)
+                        width: app.get_scaled_width(80.0)
+                        padding: app.get_scaled_tuple([20.0, 0.0, 5.0, 0.0])
                         orientation: 'horizontal'
                         canvas:
                             Rectangle:
@@ -347,9 +347,9 @@ Builder.load_string(
                             halign: 'left'
                             valign: 'middle'
                             markup: True
-                            size: 55.0/800*app.width, 40.0/480*app.height
+                            size: app.get_scaled_tuple([55.0, 40.0])
                             text: 'GB'
-                            font_size: str(0.025*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('20.0sp')
                             text_size: self.size
                             color: 0,0,0,1
                             values: root.values
@@ -358,17 +358,17 @@ Builder.load_string(
 
         BoxLayout:
             size_hint: (None, None)
-            height: dp(0.604166666667*app.height)
-            width: dp(1.0*app.width)
-            padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, dp(0.0625)*app.height]
-            spacing:0.0125*app.width
+            height: app.get_scaled_height(290.0)
+            width: app.get_scaled_width(800.0)
+            padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 30.0])
+            spacing: app.get_scaled_width(10.0)
             
             # Doc viewer
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.541666666667*app.height)
-                width: dp(0.7125*app.width)
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                height: app.get_scaled_height(260.0)
+                width: app.get_scaled_width(570.0)
+                padding: app.get_scaled_tuple([20.0, 20.0])
                 canvas:
                     Color:
                         rgba: [1,1,1,1]
@@ -385,15 +385,15 @@ Builder.load_string(
                     RstDocument:
                         id: connection_instructions_rst
                         background_color: hex('#FFFFFF')
-                        base_font_size: 26.0 / 800 * app.width
+                        base_font_size: app.get_scaled_width(26.0)
                         underline_color: '000000'
                                                                                    
             BoxLayout: 
                 size_hint: (None, None)
-                height: dp(0.541666666667*app.height)
-                width: dp(0.2*app.width)
+                height: app.get_scaled_height(260.0)
+                width: app.get_scaled_width(160.0)
                 orientation: 'vertical'
-                spacing:0.0625*app.height
+                spacing: app.get_scaled_width(30.0)
                 canvas:
                     Color:
                         rgba: [226 / 255., 226 / 255., 226 / 255., 1.]
@@ -402,9 +402,9 @@ Builder.load_string(
                         size: self.size
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.239583333333*app.height)
-                    width: dp(0.2*app.width)
-                    padding:[dp(0.0025)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(115.0)
+                    width: app.get_scaled_width(160.0)
+                    padding: app.get_scaled_tuple([2.0, 0.0, 0.0, 0.0])
                     canvas:
                         Color:
                             rgba: [226 / 255., 226 / 255., 226 / 255., 1.]
@@ -416,13 +416,13 @@ Builder.load_string(
                         id: connect_button
                         background_normal: "./asmcnc/apps/wifi_app/img/connect_blank.png"
                         background_down: "./asmcnc/apps/wifi_app/img/connect_blank.png"
-                        border: [dp(14.5)]*4
+                        border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                         size_hint: (None,None)
-                        height: dp(0.239583333333*app.height)
-                        width: dp(0.1975*app.width)
+                        height: app.get_scaled_height(115.0)
+                        width: app.get_scaled_width(158.0)
                         on_press: root.check_credentials()
                         # text: 'Connect'
-                        font_size: str(0.035*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('28.0sp')
                         color: hex('#f9f9f9ff')
                         markup: True
                         center: self.parent.center
@@ -431,14 +431,14 @@ Builder.load_string(
 
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.233333333333*app.height)
-                    width: dp(0.2*app.width)
-                    padding:[dp(0.035)*app.width, 0, dp(0.025)*app.width, 0]
+                    height: app.get_scaled_height(112.0)
+                    width: app.get_scaled_width(160.0)
+                    padding: app.get_scaled_tuple([28.0, 0.0, 20.0, 0.0])
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.233333333333*app.height)
-                        width: dp(0.14*app.width)
+                        height: app.get_scaled_height(112.0)
+                        width: app.get_scaled_width(112.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos

--- a/src/asmcnc/calibration_app/screen_backlash.py
+++ b/src/asmcnc/calibration_app/screen_backlash.py
@@ -41,17 +41,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -64,18 +64,18 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -88,17 +88,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -111,20 +111,20 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -134,7 +134,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.2
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -150,15 +150,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge01_button
                         size: self.texture_size
@@ -171,17 +171,17 @@ Builder.load_string(
                             root.nudge_01()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.1 mm[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge002_button
                         size: self.texture_size
@@ -194,13 +194,13 @@ Builder.load_string(
                             root.nudge_002()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.02 mm[/color]'
                                 markup: True
 
@@ -212,18 +212,18 @@ Builder.load_string(
                 Label:
                     id: test_instructions_label
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([20.0, 20.0])
                     size_hint_y: 0.6
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: action_button
                         size: self.texture_size
                         valign: 'top'
@@ -235,13 +235,13 @@ Builder.load_string(
                             root.next_instruction()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: test_ok_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text:'[color=455A64]Test[/color]'
                                 markup: True         
 """

--- a/src/asmcnc/calibration_app/screen_distance_1_x.py
+++ b/src/asmcnc/calibration_app/screen_distance_1_x.py
@@ -45,17 +45,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -68,18 +68,18 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -92,17 +92,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -115,19 +115,19 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -137,7 +137,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -153,15 +153,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge01_button
                         size: self.texture_size
@@ -174,17 +174,17 @@ Builder.load_string(
                             root.nudge_01()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.1 mm[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge002_button
                         size: self.texture_size
@@ -197,12 +197,12 @@ Builder.load_string(
                             root.nudge_002()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.02 mm[/color]'
                                 markup: True
 
@@ -217,7 +217,7 @@ Builder.load_string(
                     size_hint_x: 1
                     size: self.texture_size
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
@@ -233,7 +233,7 @@ Builder.load_string(
                         valign: 'middle'
                         halign: 'center'
                         text_size: self.size
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         markup: True
                         input_filter: 'float'
                         multiline: False
@@ -243,7 +243,7 @@ Builder.load_string(
                     Label: 
                         text_size: self.size
                         text: '[color=000000]  mm[/color]'
-                        font_size: str(0.0225*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('18.0sp')
                         halign: 'left'
                         valign: 'bottom'
                         markup: True
@@ -251,18 +251,18 @@ Builder.load_string(
                 Label:
                     id: test_instructions_label
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size_hint_y: 0.7
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: set_move_button
                         size: self.texture_size
                         valign: 'top'
@@ -274,13 +274,13 @@ Builder.load_string(
                             root.next_instruction()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: set_move_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Set and move[/color]'
                                 markup: True
                         

--- a/src/asmcnc/calibration_app/screen_distance_1_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_1_y.py
@@ -38,17 +38,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -61,17 +61,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -84,17 +84,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -107,20 +107,20 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -130,7 +130,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -146,15 +146,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge01_button
                         size: self.texture_size
@@ -167,17 +167,17 @@ Builder.load_string(
                             root.nudge_01()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.1 mm[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge002_button
                         size: self.texture_size
@@ -190,12 +190,12 @@ Builder.load_string(
                             root.nudge_002()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.02 mm[/color]'
                                 markup: True
 
@@ -210,7 +210,7 @@ Builder.load_string(
                     size_hint_x: 1
                     size: self.texture_size
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
@@ -226,7 +226,7 @@ Builder.load_string(
                         valign: 'middle'
                         halign: 'center'
                         text_size: self.size
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         markup: True
                         input_filter: 'float'
                         multiline: False
@@ -236,7 +236,7 @@ Builder.load_string(
                     Label: 
                         text_size: self.size
                         text: '[color=000000]  mm[/color]'
-                        font_size: str(0.0225*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('18.0sp')
                         halign: 'left'
                         valign: 'bottom'
                         markup: True
@@ -245,18 +245,18 @@ Builder.load_string(
                     id: test_instructions_label
 #                    size_hint_y: 0.5
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size_hint_y: 0.7
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: set_move_button
                         size: self.texture_size
                         valign: 'top'
@@ -268,13 +268,13 @@ Builder.load_string(
                             root.next_instruction()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: set_move_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Set and move[/color]'
                                 markup: True
                         

--- a/src/asmcnc/calibration_app/screen_distance_2_x.py
+++ b/src/asmcnc/calibration_app/screen_distance_2_x.py
@@ -34,17 +34,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -57,17 +57,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -80,17 +80,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -103,19 +103,19 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -125,7 +125,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -141,15 +141,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         size: self.texture_size
                         valign: 'top'
@@ -161,19 +161,19 @@ Builder.load_string(
                             root.left_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: improve_button_label
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]I want to try to improve the result[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
 
                         valign: 'top'
@@ -185,14 +185,14 @@ Builder.load_string(
                             root.right_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: continue_button_label
                                 text_size: self.size
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 valign: 'middle'
                                 halign: 'center'
                                 markup: True

--- a/src/asmcnc/calibration_app/screen_distance_2_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_2_y.py
@@ -32,17 +32,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -55,17 +55,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -78,17 +78,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -101,19 +101,19 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -123,7 +123,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -139,15 +139,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         size: self.texture_size
                         valign: 'top'
@@ -159,19 +159,19 @@ Builder.load_string(
                             root.left_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: improve_button_label
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]I want to try to improve the result[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
 
                         valign: 'top'
@@ -183,7 +183,7 @@ Builder.load_string(
                             root.right_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
@@ -191,7 +191,7 @@ Builder.load_string(
                                 id: continue_button_label
                                 text_size: self.size
                                 text: '[color=455A64]Ok, it measures as expected. Move to the next section.[/color]'
-                                font_size: str(0.0225*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('18.0sp')
                                 valign: 'middle'
                                 halign: 'center'
                                 markup: True   

--- a/src/asmcnc/calibration_app/screen_distance_3_x.py
+++ b/src/asmcnc/calibration_app/screen_distance_3_x.py
@@ -36,17 +36,17 @@ Builder.load_string(
 
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
         
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -59,17 +59,17 @@ Builder.load_string(
                     root.repeat_section()
 
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
 
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -82,18 +82,18 @@ Builder.load_string(
                     root.skip_section()
 
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
 
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -106,19 +106,19 @@ Builder.load_string(
                     root.quit_calibration()
 
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
 
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -128,7 +128,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -144,15 +144,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge01_button
                         size: self.texture_size
@@ -165,17 +165,17 @@ Builder.load_string(
                             root.nudge_01()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.1 mm[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge002_button
                         size: self.texture_size
@@ -188,12 +188,12 @@ Builder.load_string(
                             root.nudge_002()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.02 mm[/color]'
                                 markup: True
 
@@ -207,7 +207,7 @@ Builder.load_string(
                     size_hint_x: 1
                     size: self.texture_size
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
@@ -222,7 +222,7 @@ Builder.load_string(
                         valign: 'middle'
                         halign: 'center'
                         text_size: self.size
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         markup: True
                         input_filter: 'float'
                         multiline: False
@@ -232,7 +232,7 @@ Builder.load_string(
                     Label: 
                         text_size: self.size
                         text: '[color=000000]  mm[/color]'
-                        font_size: str(0.0225*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('18.0sp')
                         halign: 'left'
                         valign: 'bottom'
                         markup: True
@@ -240,18 +240,18 @@ Builder.load_string(
                 Label:
                     id: test_instructions_label
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size_hint_y: 0.7
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size: self.texture_size
                         valign: 'top'
                         halign: 'center'
@@ -262,13 +262,13 @@ Builder.load_string(
                             root.next_instruction()
 
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
 
                             Label:
                                 id: set_move_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Set and check[/color]'
                                 markup: True
 """

--- a/src/asmcnc/calibration_app/screen_distance_3_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_3_y.py
@@ -38,17 +38,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -61,17 +61,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -84,17 +84,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -107,19 +107,19 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -129,7 +129,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -145,15 +145,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge01_button
                         size: self.texture_size
@@ -166,18 +166,18 @@ Builder.load_string(
                             root.nudge_01()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.1 mm[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: nudge002_button
                         size: self.texture_size
@@ -190,13 +190,13 @@ Builder.load_string(
                             root.nudge_002()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Nudge 0.02 mm[/color]'
                                 markup: True
 
@@ -210,7 +210,7 @@ Builder.load_string(
                     size_hint_x: 1
                     size: self.texture_size
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
@@ -226,7 +226,7 @@ Builder.load_string(
                         valign: 'middle'
                         halign: 'center'
                         text_size: self.size
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         markup: True
                         input_filter: 'float'
                         multiline: False
@@ -236,7 +236,7 @@ Builder.load_string(
                     Label: 
                         text_size: self.size
                         text: '[color=000000]  mm[/color]'
-                        font_size: str(0.0225*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('18.0sp')
                         halign: 'left'
                         valign: 'bottom'
                         markup: True
@@ -245,18 +245,18 @@ Builder.load_string(
                     id: test_instructions_label
 #                    size_hint_y: 0.5
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size_hint_y: 0.7
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size: self.texture_size
                         valign: 'top'
                         halign: 'center'
@@ -267,13 +267,13 @@ Builder.load_string(
                             root.next_instruction()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: set_move_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Set and check[/color]'
                                 markup: True
                         

--- a/src/asmcnc/calibration_app/screen_distance_4_x.py
+++ b/src/asmcnc/calibration_app/screen_distance_4_x.py
@@ -36,17 +36,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -59,17 +59,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -82,17 +82,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -105,19 +105,19 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -127,7 +127,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -143,15 +143,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         size: self.texture_size
                         valign: 'top'
@@ -163,18 +163,18 @@ Builder.load_string(
                             root.left_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: improve_button_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]NO - RESTART THIS SECTION[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: right_button_id
                         size_hint_y:0.9
                         valign: 'top'
@@ -186,7 +186,7 @@ Builder.load_string(
                             root.right_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
@@ -194,7 +194,7 @@ Builder.load_string(
                                 id: continue_button_label
                                 text_size: self.size
                                 text: '[color=455A64]YES - SET, HOME, AND VERIFY[/color]'
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 valign: 'middle'
                                 halign: 'center'
                                 markup: True

--- a/src/asmcnc/calibration_app/screen_distance_4_y.py
+++ b/src/asmcnc/calibration_app/screen_distance_4_y.py
@@ -30,16 +30,16 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -52,16 +52,16 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -74,17 +74,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -97,18 +97,18 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
             BoxLayout:
                 orientation: 'vertical'
                 spacing: 0
@@ -117,7 +117,7 @@ Builder.load_string(
                 Label:
                     id: title_label
                     size_hint_y: 0.3
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -132,15 +132,15 @@ Builder.load_string(
                     RstDocument:
                         id: user_instructions_text
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
                         
                 BoxLayout: 
                     orientation: 'horizontal' 
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
-                    spacing:0.0125*app.width
+                    padding: app.get_scaled_tuple([30.0, 30.0])
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         size: self.texture_size
                         valign: 'top'
@@ -152,17 +152,17 @@ Builder.load_string(
                             root.left_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 id: improve_button_label
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]NO - RESTART THIS SECTION[/color]'
                                 markup: True
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: right_button_id
                         size_hint_y: 0.9
                         valign: 'top'
@@ -174,7 +174,7 @@ Builder.load_string(
                             root.right_button()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
@@ -182,7 +182,7 @@ Builder.load_string(
                                 id: continue_button_label
                                 text_size: self.size
                                 text: '[color=455A64]YES - SET, HOME, AND VERIFY[/color]'
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 valign: 'middle'
                                 halign: 'center'
                                 markup: True          

--- a/src/asmcnc/calibration_app/screen_finished.py
+++ b/src/asmcnc/calibration_app/screen_finished.py
@@ -27,7 +27,7 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.1125)*app.width, dp(0.104166666667)*app.height]
+        padding: app.get_scaled_tuple([90.0, 50.0])
         spacing: 0
         size_hint_x: 1
 
@@ -38,7 +38,7 @@ Builder.load_string(
             Label:
                 id: screen_text
                 text_size: self.size
-                font_size: str(0.035*app.width) + 'sp'
+                font_size: app.get_scaled_sp('28.0sp')
                 halign: 'center'
                 valign: 'middle'
                 text: '[color=455A64]Calibration Complete![/color]'

--- a/src/asmcnc/calibration_app/screen_landing.py
+++ b/src/asmcnc/calibration_app/screen_landing.py
@@ -37,18 +37,18 @@ Builder.load_string(
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[dp(0.1125)*app.width, dp(0.104166666667)*app.height, dp(0.0375)*app.width, dp(0.104166666667)*app.height]
+            padding: app.get_scaled_tuple([90.0, 50.0, 30.0, 50.0])
             spacing: 0
             size_hint_x: 1
 
             BoxLayout:
                 orientation: 'vertical'
                 size_hint_x: 0.8
-                # spacing: 10
+                # spacing: app.get_scaled_width(10.0)
                 
                 Label:
                     size_hint_y: 1
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text: '[color=263238]Do you want to calibrate SmartBench?[/color]'
                     markup: True
 
@@ -56,14 +56,14 @@ Builder.load_string(
                     id: user_instruction
                     size_hint_y: 2
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     markup: True
 
                 Label:
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'center'
                     valign: 'middle'
                     text: '[color=546E7A]Calibration can take 10 minutes. You will need an accurate tape measure.[/color]'
@@ -71,11 +71,11 @@ Builder.load_string(
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[0, 0]
-                    spacing:0.025*app.width
+                    padding: app.get_scaled_tuple([0.0, 0.0])
+                    spacing: app.get_scaled_width(20.0)
                 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: getout_button
                         size: self.texture_size
@@ -88,18 +88,18 @@ Builder.load_string(
                             root.skip_to_lobby()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]No, skip[/color]'
                                 markup: True
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y:0.9
                         id: getout_button
                         size: self.texture_size
@@ -112,26 +112,26 @@ Builder.load_string(
                             root.next_screen()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
                                 #size_hint_y: 1
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Yes, calibrate[/color]'
                                 markup: True
 
         BoxLayout:
             size_hint_x: 0.1
-            padding:[0, 0, 0, dp(0.833333333333)*app.height]
+            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 400.0])
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: exit_button
                 size_hint: (None,None)
-                height: dp(0.0833333333333*app.height)
-                width: dp(0.05*app.width)
+                height: app.get_scaled_height(40.0)
+                width: app.get_scaled_width(40.0)
                 background_color: hex('#F4433600')
                 opacity: 1
                 on_press: root.skip_to_lobby()

--- a/src/asmcnc/calibration_app/screen_measurement.py
+++ b/src/asmcnc/calibration_app/screen_measurement.py
@@ -35,17 +35,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -58,17 +58,17 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Go Back[/color]'
                         markup: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -81,17 +81,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Skip section[/color]'
                         markup: True
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 id: getout_button
                 size: self.texture_size
@@ -104,21 +104,21 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.025*app.width
+            spacing: app.get_scaled_width(20.0)
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: instruction_left
                 size_hint_x: 0.4
                 size: self.texture_size
@@ -132,7 +132,7 @@ Builder.load_string(
                 size_hint_x: 1.3
                  
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: instruction_top
                     size_hint_y: 0.3
                     size: self.texture_size
@@ -149,11 +149,11 @@ Builder.load_string(
 
             BoxLayout:
                 orientation: 'vertical'
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size_hint_x: 0.3
                   
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: action_button
                     size_hint_y: 0.9
                     size: self.texture_size
@@ -166,12 +166,12 @@ Builder.load_string(
                         root.next_instruction()
                         
                     BoxLayout:
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         size: self.parent.size
                         pos: self.parent.pos
                         
                         Label:
-                            font_size: str(0.025*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('20.0sp')
                             text: '[color=455A64]Next[/color]'
                             markup: True
                         

--- a/src/asmcnc/calibration_app/screen_prep_calibration.py
+++ b/src/asmcnc/calibration_app/screen_prep_calibration.py
@@ -24,17 +24,17 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         spacing: 0
 
         BoxLayout:
             orientation: 'horizontal'
-            padding:[0, 0]
-            spacing:0.025*app.width
+            padding: app.get_scaled_tuple([0.0, 0.0])
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 0.2
         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 size: self.texture_size
                 valign: 'top'
@@ -44,16 +44,16 @@ Builder.load_string(
                     root.repeat_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: 'Go Back'
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 size: self.texture_size
                 valign: 'top'
@@ -63,17 +63,17 @@ Builder.load_string(
                     root.skip_section()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: 'Skip section'
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y:0.9
                 size: self.texture_size
                 valign: 'top'
@@ -85,20 +85,20 @@ Builder.load_string(
                     root.quit_calibration()
                     
                 BoxLayout:
-                    padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                    padding: app.get_scaled_tuple([5.0, 5.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     
                     Label:
                         #size_hint_y: 1
-                        font_size: str(0.025*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('20.0sp')
                         text: '[color=455A64]Quit calibration[/color]'
                         markup: True
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0416666666667*app.height
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+            spacing: app.get_scaled_width(20.0)
+            padding: app.get_scaled_tuple([10.0, 10.0])
 
             BoxLayout:
                 orientation: 'vertical'
@@ -107,7 +107,7 @@ Builder.load_string(
                  
                 Label:
                     size_hint_y: 0.2
-                    font_size: str(0.04375*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('35.0sp')
                     text_size: self.size
                     halign: 'left'
                     valign: 'middle'
@@ -124,28 +124,28 @@ Builder.load_string(
                     RstDocument:
                         text: root.preparation_list
                         background_color: hex('#FFFFFF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
 
             BoxLayout:
                 orientation: 'vertical'
-                # spacing: 10
-                # padding: 10
+                # spacing: app.get_scaled_width(10.0)
+                # padding: app.get_scaled_width(10.0)
                 size_hint_x: 0.6
 
                 Label:
                     text_size: self.size
-                    font_size: str(0.0225*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('18.0sp')
                     halign: 'left'
                     valign: 'middle'
                     markup: True
                     
                 BoxLayout:
                     orientation: 'horizontal'
-                    padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([20.0, 20.0])
                     size_hint_y: 0.6
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size: self.texture_size
                         valign: 'top'
                         halign: 'center'
@@ -156,12 +156,12 @@ Builder.load_string(
                             root.next_screen()
                             
                         BoxLayout:
-                            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                            padding: app.get_scaled_tuple([5.0, 5.0])
                             size: self.parent.size
                             pos: self.parent.pos
                             
                             Label:
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 text: '[color=455A64]Home[/color]'
                                 markup: True
                         

--- a/src/asmcnc/calibration_app/screen_tape_measure.py
+++ b/src/asmcnc/calibration_app/screen_tape_measure.py
@@ -23,7 +23,7 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.1)*app.width, dp(0.0625)*app.height]
+        padding: app.get_scaled_tuple([80.0, 30.0])
         spacing: 0
         size_hint_x: 1
         BoxLayout:
@@ -32,7 +32,7 @@ Builder.load_string(
             
 #             Label:
 #                 text_size: self.size
-#                 font_size: '40sp'
+#                 font_size: app.get_scaled_sp('40sp')
 #                 halign: 'center'
 #                 valign: 'middle'
 #                 text: '[color=455A64]TAPE MEASURE ALERT![/color]'
@@ -50,7 +50,7 @@ Builder.load_string(
             Label:
                 id: alert_label
                 text_size: self.size
-                font_size: str(0.03*app.width) + 'sp'
+                font_size: app.get_scaled_sp('24.0sp')
                 halign: 'center'
                 valign: 'middle'
                 text: '[color=455A64]PLEASE REMOVE YOUR TAPE MEASURE FROM THE MACHINE NOW.[/color]'
@@ -59,7 +59,7 @@ Builder.load_string(
         
             AnchorLayout:
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     #size: self.texture_size
                     size_hint_y: 0.8
                     size_hint_x: 0.35
@@ -72,12 +72,12 @@ Builder.load_string(
                         root.next_screen()
     
                     BoxLayout:
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         size: self.parent.size
                         pos: self.parent.pos
                         
                         Label:
-                            font_size: str(0.0325*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('26.0sp')
                             text: '[color=FFFFFF]Ok, continue...[/color]'
                             markup: 'True'
                 

--- a/src/asmcnc/calibration_app/screen_wait.py
+++ b/src/asmcnc/calibration_app/screen_wait.py
@@ -24,7 +24,7 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.1125)*app.width, dp(0.104166666667)*app.height]
+        padding: app.get_scaled_tuple([90.0, 50.0])
         spacing: 0
         size_hint_x: 1
 
@@ -34,7 +34,7 @@ Builder.load_string(
 
             Label:
                 text_size: self.size
-                font_size: str(0.025*app.width) + 'sp'
+                font_size: app.get_scaled_sp('20.0sp')
                 halign: 'center'
                 valign: 'middle'
                 text: '[color=455A64]Moving to the next measurement point...[/color]'

--- a/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
+++ b/src/asmcnc/core_UI/job_go/popups/popup_yetipilot_settings.py
@@ -37,7 +37,7 @@ Builder.load_string(
     color: hex('#333333ff')
     halign: 'center'
     markup: 'True'
-    font_size: 0.0175*app.width
+    font_size: app.get_scaled_width(14.0)
     background_color: 0,0,0,0
     text_size : self.width, None
     canvas.before:
@@ -54,7 +54,7 @@ Builder.load_string(
     size: self.size
     color: hex('#333333ff')
     background_color: 0,0,0,0
-    font_size: 0.0175*app.width
+    font_size: app.get_scaled_width(14.0)
     text_size : self.width, None
     halign: 'center'
     canvas.before:
@@ -78,7 +78,7 @@ Builder.load_string(
 
 <BigSpindleHealthCheckButton@Button>:
     size_hint: (None, None)
-    size: [150.0/800*app.width,150.0/480*app.height]
+    size: app.get_scaled_tuple([150.0, 150.0])
     background_color: 0,0,0,0
     background_normal: ''
     BoxLayout:

--- a/src/asmcnc/core_UI/job_go/screens/screen_spindle_health_check.py
+++ b/src/asmcnc/core_UI/job_go/screens/screen_spindle_health_check.py
@@ -23,11 +23,11 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         orientation: 'vertical'
         size_hint: (None, None)
-        height: 1.0*app.height
-        width: 1.0*app.width
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
         canvas:
             Color: 
                 rgba: hex('#E5E5E5FF')
@@ -59,21 +59,21 @@ Builder.load_string(
 
             BoxLayout: 
                 spacing: 0
-                padding:[dp(0.125)*app.width, 0, dp(0.125)*app.width, dp(0.270833333333)*app.height]
+                padding: app.get_scaled_tuple([100.0, 0.0, 100.0, 130.0])
                 orientation: 'horizontal'          
                 size_hint: (None, None)
-                height: dp(251.0/480.0)*app.height
-                width: 1.0*app.width
+                height: app.get_scaled_height(251.0)
+                width: app.get_scaled_width(800.0)
                 pos: self.parent.pos
 
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[dp(0.01)*app.width, 0, dp(0.07125)*app.width, 0]
+                    padding: app.get_scaled_tuple([8.0, 0.0, 57.0, 0.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.225*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(180.0)
                     Image:
                         id: spindle_icon
                         source: "./asmcnc/core_UI/job_go/img/spindle_check.png"
@@ -82,16 +82,16 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
                         size_hint: (None, None)
-                        height: dp(0.252083333333*app.height)
-                        width: dp(0.14375*app.width) 
+                        height: app.get_scaled_height(121.0)
+                        width: app.get_scaled_width(115.0)
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[0, 0, 0, 0]
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.25*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(200.0)
                     Label:
                         id: countdown
                         markup: True
@@ -105,11 +105,11 @@ Builder.load_string(
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[dp(0.0875)*app.width, 0, dp(0.0125)*app.width, dp(0.00625)*app.height]
+                    padding: app.get_scaled_tuple([70.0, 0.0, 10.0, 3.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.225*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(180.0)
                     Image:
                         id: countdown_icon
                         source: "./asmcnc/skavaUI/img/countdown_big.png"
@@ -118,8 +118,8 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
                         size_hint: (None, None)
-                        height: dp(0.245833333333*app.height)
-                        width: dp(0.125*app.width) 
+                        height: app.get_scaled_height(118.0)
+                        width: app.get_scaled_width(100.0)
 
 
 """

--- a/src/asmcnc/core_UI/job_go/widgets/widget_disabled_yeti_pilot.py
+++ b/src/asmcnc/core_UI/job_go/widgets/widget_disabled_yeti_pilot.py
@@ -24,20 +24,20 @@ Builder.load_string(
         orientation: 'horizontal'
         size: self.parent.size
         pos: self.parent.pos
-        padding:[dp(0.0125)*app.width, dp(0.0166666666667)*app.height, dp(0.0125)*app.width, dp(0.0166666666667)*app.height]
+        padding: app.get_scaled_tuple([10.0, 8.0, 10.0, 8.0])
 
         BoxLayout:
             id: text_container
             size_hint_x: 0.85
             orientation: 'vertical'
-            padding:[dp(0.0025)*app.width, 0, dp(0.00625)*app.width, 0]
+            padding: app.get_scaled_tuple([2.0, 0.0, 5.0, 0.0])
             spacing: 0
 
             ScrollView:
                 do_scroll_x: False
                 do_scroll_y: True
                 scroll_y: 1
-                bar_width: 0.005*app.width
+                bar_width: app.get_scaled_width(4.0)
                 bar_inactive_color: [.7, .7, .7, .7]
 
                 Label:
@@ -48,7 +48,7 @@ Builder.load_string(
                     halign: 'left'
                     height: self.texture_size[1]
                     text_size: self.width - dp(3.0/800.0)*app.width, None
-                    font_size: str(0.01875*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     valign: "middle"
                     max_lines: 60
 
@@ -57,7 +57,7 @@ Builder.load_string(
             size_hint_x: 0.15
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: health_check_button
                 size_hint_x: 1
                 disabled: False

--- a/src/asmcnc/core_UI/job_go/widgets/widget_load_slider.py
+++ b/src/asmcnc/core_UI/job_go/widgets/widget_load_slider.py
@@ -36,13 +36,13 @@ Builder.load_string(
             halign: "center" 
             valign: "middle"
             color: 0, 0, 0, 1
-            font_size: str(0.0275*app.width) + 'sp'
+            font_size: app.get_scaled_sp('22.0sp')
             size_hint_y: 0.3
 
         BoxLayout:
             orientation: 'horizontal'
             size_hint_y: 0.2
-            padding:[dp(0.01875)*app.width, 0]
+            padding: app.get_scaled_tuple([15.0, 0.0])
 
             Label: 
                 id: min_label
@@ -51,7 +51,7 @@ Builder.load_string(
                 halign: "center" 
                 valign: "middle"
                 size_hint_x: 0.1
-                font_size: str(0.0175*app.width) + 'sp'
+                font_size: app.get_scaled_sp('14.0sp')
 
             Slider:
                 id: power_slider
@@ -67,14 +67,14 @@ Builder.load_string(
                 halign: "center" 
                 valign: "middle"
                 size_hint_x: 0.1
-                font_size: str(0.0175*app.width) + 'sp'
+                font_size: app.get_scaled_sp('14.0sp')
 
         BoxLayout:
             id: button_container
             size_hint_y: 0.5
             orientation: 'horizontal'
-            spacing:0.00625*app.width
-            padding:[dp(0.00625)*app.width, dp(0.03125)*app.height, dp(0.00625)*app.width, dp(0.0416666666667)*app.height]
+            spacing: app.get_scaled_width(5.0)
+            padding: app.get_scaled_tuple([5.0, 15.0, 5.0, 20.0])
             # buttons made in init
 
                 

--- a/src/asmcnc/core_UI/job_go/widgets/widget_yeti_pilot.py
+++ b/src/asmcnc/core_UI/job_go/widgets/widget_yeti_pilot.py
@@ -21,13 +21,13 @@ Builder.load_string(
         orientation: 'horizontal'
         size: self.parent.size
         pos: self.parent.pos
-        padding:[dp(0.0125)*app.width, dp(0.0166666666667)*app.height, dp(0.0125)*app.width, dp(0.0166666666667)*app.height]
+        padding: app.get_scaled_tuple([10.0, 8.0, 10.0, 8.0])
 
         
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 0.25
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
 
             Label:
                 id: yetipilot_two_tone
@@ -35,19 +35,19 @@ Builder.load_string(
                 markup: True
                 halign: 'center'
                 text_size: self.size
-                font_size: str(0.025*app.width) + 'sp'
+                font_size: app.get_scaled_sp('20.0sp')
                 valign: "bottom"
 
             BoxLayout: 
                 id: bl
                 size_hint_y: 0.5
-                padding:[dp(0.017620614025)*app.width, 0]
+                padding: app.get_scaled_tuple([14.1, 0.0])
 
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: switch
                     size_hint: (None, None)
-                    size: (dp(64.0/800)*app.width, dp(29.0/480)*app.height)
+                    size: app.get_scaled_tuple([64.0, 29.0])
                     background_normal: ''
                     background_down: ''
                     on_press: root.toggle_yeti_pilot(self)
@@ -63,12 +63,12 @@ Builder.load_string(
                             allow_stretch: False
 
         BoxLayout:
-            padding:[0, 0]
+            padding: app.get_scaled_tuple([0.0, 0.0])
             size_hint_x: 0.025
             
             BoxLayout:
                 size_hint_x: None
-                width: 0.0025*app.width
+                width: app.get_scaled_width(2.0)
                 canvas:
                     Color:
                         rgba: hex('#ccccccff')
@@ -79,7 +79,7 @@ Builder.load_string(
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 0.6
-            padding:[dp(0.0025)*app.width, 0, dp(0.00625)*app.width, 0]
+            padding: app.get_scaled_tuple([2.0, 0.0, 5.0, 0.0])
             spacing: 0
             Label: 
                 id: profile_label
@@ -89,7 +89,7 @@ Builder.load_string(
                 halign: 'left'
                 text_size: self.size
                 bold: True
-                font_size: str(0.0225*app.width) + 'sp'
+                font_size: app.get_scaled_sp('18.0sp')
                 valign: "bottom"
 
             Label:
@@ -99,14 +99,14 @@ Builder.load_string(
                 markup: True
                 halign: 'left'
                 text_size: self.size
-                font_size: str(0.0175*app.width) + 'sp'
+                font_size: app.get_scaled_sp('14.0sp')
                 valign: "middle"
 
         BoxLayout: 
             size_hint_x: 0.1
-            padding:[0, 0, dp(0.0125)*app.width, 0]
+            padding: app.get_scaled_tuple([0.0, 0.0, 10.0, 0.0])
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: yp_cog_button
                 background_normal: ''
                 on_press: root.open_yp_settings()

--- a/src/asmcnc/core_UI/new_popups/popup_bases.py
+++ b/src/asmcnc/core_UI/new_popups/popup_bases.py
@@ -87,7 +87,7 @@ class PopupWarningTitle(PopupTitle):
 
 scroll_view_kv = """
 <ScrollView>:
-    bar_width: dp(6)
+    bar_width: app.get_scaled_width(6.0)
     _handle_y_pos: (self.right - self.bar_width - self.bar_margin) if self.bar_pos_y == 'right' else (self.x + self.bar_margin), self.y + self.height * self.vbar[0]
     _handle_y_size: min(self.bar_width, self.width), self.height * self.vbar[1]
     _handle_x_pos: self.x + self.width * self.hbar[0], (self.y + self.bar_margin) if self.bar_pos_x == 'bottom' else (self.top - self.bar_margin - self.bar_width)

--- a/src/asmcnc/core_UI/scaling_utils.py
+++ b/src/asmcnc/core_UI/scaling_utils.py
@@ -24,11 +24,11 @@ def get_scaled_width(width):
         return None
     if width is 0:
         return 0
-    return float(width) / 800.0 * Width
+    return dp(float(width) / 800.0 * Width)
 
 
 def get_scaled_dp_width(width):
-    return dp(get_scaled_width(width))
+    return get_scaled_width(width)
 
 
 def get_scaled_height(height):
@@ -41,11 +41,11 @@ def get_scaled_height(height):
         return None
     if height is 0:
         return 0
-    return float(height) / 480.0 * Height
+    return dp(float(height) / 480.0 * Height)
 
 
 def get_scaled_dp_height(height):
-    return dp(get_scaled_height(height))
+    return get_scaled_height(height)
 
 
 def get_scaled_tuple(tup, orientation="horizontal"):

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_1.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_1.py
@@ -28,33 +28,33 @@ Builder.load_string(
 		padding: 0
 		spacing: 0
 		size_hint: (None, None)
-		height: dp(1.0*app.height)
-		width: dp(1.0*app.width)
+		height: app.get_scaled_height(480.0)
+		width: app.get_scaled_width(800.0)
 		# Alarm header
 		BoxLayout: 
-			padding:[dp(0.01875)*app.width, 0, dp(0.01875)*app.width, 0]
+			padding: app.get_scaled_tuple([15.0, 0.0, 15.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(50.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			Label:
 				id: alarm_title
 				size_hint: (None, None)
-				font_size: str(0.0375*app.width) + 'sp'
+				font_size: app.get_scaled_sp('30.0sp')
 				color: [0,0,0,1]
 				markup: True
 				halign: 'left'
-				height: dp(0.104166666667*app.height)
-				width: dp(0.9625*app.width)
+				height: app.get_scaled_height(50.0)
+				width: app.get_scaled_width(770.0)
 				text_size: self.size
 		# Red underline
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.0104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(5.0)
+			width: app.get_scaled_width(800.0)
 			Image:
 				id: red_underline
 				source: "./asmcnc/skavaUI/img/red_underline.png"
@@ -64,18 +64,18 @@ Builder.load_string(
 				allow_stretch: True
 		# Image and text
 		BoxLayout: 
-			padding:[0, dp(0.0729166666667)*app.height, 0, 0]
+			padding: app.get_scaled_tuple([0.0, 35.0, 0.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.589583333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(283.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'vertical'
 			BoxLayout: 
 				id: icon_container
-				padding:[dp(0.41875)*app.width, 0, 0, 0]
+				padding: app.get_scaled_tuple([335.0, 0.0, 0.0, 0.0])
 				size_hint: (None, None)
-				height: dp(0.270833333333*app.height)
-				width: dp(1.0*app.width)       
+				height: app.get_scaled_height(130.0)
+				width: app.get_scaled_width(800.0)
 				Image:
 					id: icon
 					center_x: self.parent.center_x
@@ -83,18 +83,18 @@ Builder.load_string(
 					size: self.parent.width, self.parent.height
 					allow_stretch: True
 					size_hint: (None, None)
-					height: dp(0.270833333333*app.height)
-					width: dp(0.1625*app.width)
+					height: app.get_scaled_height(130.0)
+					width: app.get_scaled_width(130.0)
 			BoxLayout:
 				id: description container
-				padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, 0]
+				padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 0.0])
 				spacing: 0
 				size_hint: (None, None)
-				height: dp(0.245833333333*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(118.0)
+				width: app.get_scaled_width(800.0)
 				Label:
 					id: description_label
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					color: [0,0,0,1]
 					markup: True
 					halign: 'center'
@@ -103,42 +103,42 @@ Builder.load_string(
 					size: self.parent.size
 		# Buttons
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 			size_hint: (None, None)
-			height: dp(0.295833333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(142.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[0, 0, dp(0.230625)*app.width, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.36375*app.width)
-				padding:[0, 0, 0, dp(0.108333333333)*app.height]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(291.0)
+				padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
 				Button:
 					id: next_button
 					background_normal: "./asmcnc/skavaUI/img/next.png"
 					background_down: "./asmcnc/skavaUI/img/next.png"
-					border: [dp(14.5)]*4
+					border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 					size_hint: (None,None)
-					width: dp(0.36375*app.width)
-					height: dp(0.164583333333*app.height)
+					width: app.get_scaled_width(291.0)
+					height: app.get_scaled_height(79.0)
 					on_press: root.next_screen()
 					text: 'Next...'
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					color: hex('#f9f9f9ff')
 					markup: True
 					center: self.parent.center
 					pos: self.parent.pos
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[dp(0.241875)*app.width, 0, 0, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_2.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_2.py
@@ -27,33 +27,33 @@ Builder.load_string(
 		padding: 0
 		spacing: 0
 		size_hint: (None, None)
-		height: dp(1.0*app.height)
-		width: dp(1.0*app.width)
+		height: app.get_scaled_height(480.0)
+		width: app.get_scaled_width(800.0)
 		# Alarm header
 		BoxLayout: 
-			padding:[dp(0.01875)*app.width, 0, dp(0.01875)*app.width, 0]
+			padding: app.get_scaled_tuple([15.0, 0.0, 15.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(50.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			Label:
 				id: alarm_title
 				size_hint: (None, None)
-				font_size: str(0.0375*app.width) + 'sp'
+				font_size: app.get_scaled_sp('30.0sp')
 				color: [0,0,0,1]
 				markup: True
 				halign: 'left'
-				height: dp(0.104166666667*app.height)
-				width: dp(0.9625*app.width)
+				height: app.get_scaled_height(50.0)
+				width: app.get_scaled_width(770.0)
 				text_size: self.size
 		# Red underline
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.0104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(5.0)
+			width: app.get_scaled_width(800.0)
 			Image:
 				id: red_underline
 				source: "./asmcnc/skavaUI/img/red_underline.png"
@@ -63,42 +63,42 @@ Builder.load_string(
 				allow_stretch: True
 		# Image and text
 		BoxLayout: 
-			padding:[0, dp(0.0729166666667)*app.height, 0, 0]
+			padding: app.get_scaled_tuple([0.0, 35.0, 0.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.589583333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(283.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'vertical'
 			BoxLayout: 
 				id: icon_container
-				padding:[dp(0.2375)*app.width, dp(0.0625)*app.height, dp(0.273125)*app.width, 0]
-				spacing:0.260625*app.width
+				padding: app.get_scaled_tuple([190.0, 30.0, 218.5, 0.0])
+				spacing: app.get_scaled_width(208.5)
 				size_hint: (None, None)
-				height: dp(0.270833333333*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(130.0)
+				width: app.get_scaled_width(800.0)
 				orientation: 'horizontal'    
 				Image:
 					id: icon_left
 					allow_stretch: False
 					size_hint: (None, None)
-					height: dp(0.208333333333*app.height)
-					width: dp(0.15*app.width)
+					height: app.get_scaled_height(100.0)
+					width: app.get_scaled_width(120.0)
 				Image:
 					id: icon_right
 					allow_stretch: False
 					size_hint: (None, None)
-					height: dp(0.208333333333*app.height)
-					width: dp(0.07875*app.width)
+					height: app.get_scaled_height(100.0)
+					width: app.get_scaled_width(63.0)
 			BoxLayout:
 				id: description container
-				padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, 0]
+				padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 0.0])
 				spacing: 0
 				size_hint: (None, None)
-				height: dp(0.245833333333*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(118.0)
+				width: app.get_scaled_width(800.0)
 				Label:
 					id: description_label
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					color: [0,0,0,1]
 					markup: True
 					halign: 'center'
@@ -107,21 +107,21 @@ Builder.load_string(
 					size: self.parent.size
 		# Buttons
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 			size_hint: (None, None)
-			height: dp(0.295833333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(142.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[0, 0, dp(0.230625)*app.width, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 				Button:
-				    font_size: str(0.01875 * app.width) + 'sp'
+				    font_size: app.get_scaled_sp('15.0sp')
 					size_hint: (None,None)
-					height: dp(0.108333333333*app.height)
-					width: dp(0.075*app.width)
+					height: app.get_scaled_height(52.0)
+					width: app.get_scaled_width(60.0)
 					background_color: hex('#F4433600')
 					center: self.parent.center
 					pos: self.parent.pos
@@ -138,29 +138,29 @@ Builder.load_string(
 							allow_stretch: True
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.36375*app.width)
-				padding:[0, 0, 0, dp(0.108333333333)*app.height]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(291.0)
+				padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
 				Button:
 					id: next_button
 					background_normal: "./asmcnc/skavaUI/img/next.png"
 					background_down: "./asmcnc/skavaUI/img/next.png"
-					border: [dp(14.5)]*4
+					border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 					size_hint: (None,None)
-					width: dp(0.36375*app.width)
-					height: dp(0.164583333333*app.height)
+					width: app.get_scaled_width(291.0)
+					height: app.get_scaled_height(79.0)
 					on_press: root.next_screen()
 					text: 'Next...'
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					color: hex('#f9f9f9ff')
 					markup: True
 					center: self.parent.center
 					pos: self.parent.pos
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[dp(0.241875)*app.width, 0, 0, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_3.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_3.py
@@ -21,8 +21,8 @@ Builder.load_string(
 
     BoxLayout: 
         size_hint: (None,None)
-        width: dp(1.0*app.width)
-        height: dp(1.0*app.height)
+        width: app.get_scaled_width(800.0)
+        height: app.get_scaled_height(480.0)
         orientation: 'vertical'
         canvas:
             Color:
@@ -38,10 +38,10 @@ Builder.load_string(
             orientation: 'vertical'
             BoxLayout: 
                 orientation: 'vertical'
-                padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([20.0, 10.0])
                 Label:
                     id: description_label
-                    font_size: str(0.02*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('16.0sp')
                     color: [0,0,0,1]
                     markup: True
                     halign: 'left'
@@ -50,21 +50,21 @@ Builder.load_string(
                     size: self.size
             # Buttons
             BoxLayout: 
-                padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
                 size_hint: (None, None)
-                height: dp(0.275*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(132.0)
+                width: app.get_scaled_width(800.0)
                 orientation: 'horizontal'
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.275*app.height)
-                    width: dp(0.305625*app.width)
-                    padding:[0, 0, dp(0.230625)*app.width, 0]
+                    height: app.get_scaled_height(132.0)
+                    width: app.get_scaled_width(244.5)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint: (None,None)
-                        height: dp(0.108333333333*app.height)
-                        width: dp(0.075*app.width)
+                        height: app.get_scaled_height(52.0)
+                        width: app.get_scaled_width(60.0)
                         background_color: hex('#F4433600')
                         center: self.parent.center
                         pos: self.parent.pos
@@ -81,17 +81,17 @@ Builder.load_string(
                                 allow_stretch: True
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.275*app.height)
-                    width: dp(0.36375*app.width)
-                    padding:[0, 0, 0, dp(0.108333333333)*app.height]
+                    height: app.get_scaled_height(132.0)
+                    width: app.get_scaled_width(291.0)
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
                     Button:
                         id: next_button
                         background_normal: "./asmcnc/skavaUI/img/next.png"
                         background_down: "./asmcnc/skavaUI/img/next.png"
-                        border: [dp(14.5)]*4
+                        border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                         size_hint: (None,None)
-                        width: dp(0.36375*app.width)
-                        height: dp(0.164583333333*app.height)
+                        width: app.get_scaled_width(291.0)
+                        height: app.get_scaled_height(79.0)
                         on_press: root.next_screen()
                         text: 'Next...'
                         font_size: root.default_font_size
@@ -101,17 +101,17 @@ Builder.load_string(
                         pos: self.parent.pos
                 BoxLayout: 
                     size_hint: (None, None)
-                    height: dp(0.275*app.height)
-                    width: dp(0.305625*app.width)
-                    padding:[dp(0.241875)*app.width, 0, 0, 0]
+                    height: app.get_scaled_height(132.0)
+                    width: app.get_scaled_width(244.5)
+                    padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
     FloatLayout:
         Image:
             id: camera_img
             x: 660.0 / 800 * app.width 
             y: 321.60 / 480 * app.height
             size_hint: None, None
-            height: dp(100.0/480.0)*app.height
-            width: 0.15*app.width
+            height: app.get_scaled_height(100.0)
+            width: app.get_scaled_width(120.0)
             allow_stretch: True
             opacity: 1
     # FloatLayout:
@@ -120,8 +120,8 @@ Builder.load_string(
  #            x: 680
  #            y: 238.6
  #            size_hint: None, None
- #            height: 63
- #            width: 100
+ #            height: app.get_scaled_height(63.0)
+ #            width: app.get_scaled_width(100.0)
  #            allow_stretch: True
 """
 )

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_4.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_4.py
@@ -26,33 +26,33 @@ Builder.load_string(
 		padding: 0
 		spacing: 0
 		size_hint: (None, None)
-		height: dp(1.0*app.height)
-		width: dp(1.0*app.width)
+		height: app.get_scaled_height(480.0)
+		width: app.get_scaled_width(800.0)
 		# Alarm header
 		BoxLayout: 
-			padding:[dp(0.01875)*app.width, 0, dp(0.01875)*app.width, 0]
+			padding: app.get_scaled_tuple([15.0, 0.0, 15.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(50.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			Label:
 				id: alarm_title
 				size_hint: (None, None)
-				font_size: str(0.0375*app.width) + 'sp'
+				font_size: app.get_scaled_sp('30.0sp')
 				color: [0,0,0,1]
 				markup: True
 				halign: 'left'
-				height: dp(0.104166666667*app.height)
-				width: dp(0.9625*app.width)
+				height: app.get_scaled_height(50.0)
+				width: app.get_scaled_width(770.0)
 				text_size: self.size
 		# Red underline
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.0104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(5.0)
+			width: app.get_scaled_width(800.0)
 			Image:
 				id: red_underline
 				source: "./asmcnc/skavaUI/img/red_underline.png"
@@ -62,18 +62,18 @@ Builder.load_string(
 				allow_stretch: True
 		# Image and text
 		BoxLayout: 
-			padding:[0, dp(0.0729166666667)*app.height, 0, 0]
+			padding: app.get_scaled_tuple([0.0, 35.0, 0.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.589583333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(283.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'vertical'
 			BoxLayout: 
 				id: icon_container
-				padding:[dp(0.41875)*app.width, 0, 0, 0]
+				padding: app.get_scaled_tuple([335.0, 0.0, 0.0, 0.0])
 				size_hint: (None, None)
-				height: dp(0.270833333333*app.height)
-				width: dp(1.0*app.width)       
+				height: app.get_scaled_height(130.0)
+				width: app.get_scaled_width(800.0)
 				Image:
 					id: icon
 					center_x: self.parent.center_x
@@ -81,18 +81,18 @@ Builder.load_string(
 					size: self.parent.width, self.parent.height
 					allow_stretch: True
 					size_hint: (None, None)
-					height: dp(0.270833333333*app.height)
-					width: dp(0.1625*app.width)
+					height: app.get_scaled_height(130.0)
+					width: app.get_scaled_width(130.0)
 			BoxLayout:
 				id: description container
-				padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, 0]
+				padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 0.0])
 				spacing: 0
 				size_hint: (None, None)
-				height: dp(0.245833333333*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(118.0)
+				width: app.get_scaled_width(800.0)
 				Label:
 					id: description_label
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					color: [0,0,0,1]
 					markup: True
 					halign: 'center'
@@ -101,21 +101,21 @@ Builder.load_string(
 					size: self.parent.size
 		# Buttons
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 			size_hint: (None, None)
-			height: dp(0.295833333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(142.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[0, 0, dp(0.230625)*app.width, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 				Button:
-				    font_size: str(0.01875 * app.width) + 'sp'
+				    font_size: app.get_scaled_sp('15.0sp')
 					size_hint: (None,None)
-					height: dp(0.108333333333*app.height)
-					width: dp(0.075*app.width)
+					height: app.get_scaled_height(52.0)
+					width: app.get_scaled_width(60.0)
 					background_color: hex('#F4433600')
 					center: self.parent.center
 					pos: self.parent.pos
@@ -132,29 +132,29 @@ Builder.load_string(
 							allow_stretch: True
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.36375*app.width)
-				padding:[0, 0, 0, dp(0.108333333333)*app.height]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(291.0)
+				padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
 				Button:
 					id: next_button
 					background_normal: "./asmcnc/skavaUI/img/next.png"
 					background_down: "./asmcnc/skavaUI/img/next.png"
-					border: [dp(14.5)]*4
+					border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 					size_hint: (None,None)
-					width: dp(0.36375*app.width)
-					height: dp(0.164583333333*app.height)
+					width: app.get_scaled_width(291.0)
+					height: app.get_scaled_height(79.0)
 					on_press: root.next_screen()
 					text: 'Next...'
-					font_size: str(0.0375*app.width) + 'sp'
+					font_size: app.get_scaled_sp('30.0sp')
 					color: hex('#f9f9f9ff')
 					markup: True
 					center: self.parent.center
 					pos: self.parent.pos
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[dp(0.241875)*app.width, 0, 0, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 """
 )
 

--- a/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_5.py
+++ b/src/asmcnc/core_UI/sequence_alarm/screens/screen_alarm_5.py
@@ -28,33 +28,33 @@ Builder.load_string(
 		padding: 0
 		spacing: 0
 		size_hint: (None, None)
-		height: dp(1.0*app.height)
-		width: dp(1.0*app.width)
+		height: app.get_scaled_height(480.0)
+		width: app.get_scaled_width(800.0)
 		# Alarm header
 		BoxLayout: 
-			padding:[dp(0.01875)*app.width, 0, dp(0.01875)*app.width, 0]
+			padding: app.get_scaled_tuple([15.0, 0.0, 15.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(50.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			Label:
 				id: alarm_title
 				size_hint: (None, None)
-				font_size: str(0.0375*app.width) + 'sp'
+				font_size: app.get_scaled_sp('30.0sp')
 				color: [0,0,0,1]
 				markup: True
 				halign: 'left'
-				height: dp(0.104166666667*app.height)
-				width: dp(0.9625*app.width)
+				height: app.get_scaled_height(50.0)
+				width: app.get_scaled_width(770.0)
 				text_size: self.size
 		# Red underline
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.0104166666667*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(5.0)
+			width: app.get_scaled_width(800.0)
 			Image:
 				id: red_underline
 				source: "./asmcnc/skavaUI/img/red_underline.png"
@@ -64,18 +64,18 @@ Builder.load_string(
 				allow_stretch: True
 		# Image and text
 		BoxLayout: 
-			padding:[0, dp(0.0729166666667)*app.height, 0, 0]
+			padding: app.get_scaled_tuple([0.0, 35.0, 0.0, 0.0])
 			spacing: 0
 			size_hint: (None, None)
-			height: dp(0.589583333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(283.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'vertical'
 			BoxLayout: 
 				id: icon_container
-				padding:[dp(0.41875)*app.width, 0, 0, 0]
+				padding: app.get_scaled_tuple([335.0, 0.0, 0.0, 0.0])
 				size_hint: (None, None)
-				height: dp(0.270833333333*app.height)
-				width: dp(1.0*app.width)       
+				height: app.get_scaled_height(130.0)
+				width: app.get_scaled_width(800.0)
 				Image:
 					id: icon
 					source: "./asmcnc/core_UI/sequence_alarm/img/alarm_icon.png"
@@ -84,18 +84,18 @@ Builder.load_string(
 					size: self.parent.width, self.parent.height
 					allow_stretch: True
 					size_hint: (None, None)
-					height: dp(0.270833333333*app.height)
-					width: dp(0.1625*app.width)
+					height: app.get_scaled_height(130.0)
+					width: app.get_scaled_width(130.0)
 			BoxLayout:
 				id: description container
-				padding:[dp(0.0375)*app.width, 0, dp(0.0375)*app.width, 0]
+				padding: app.get_scaled_tuple([30.0, 0.0, 30.0, 0.0])
 				spacing: 0
 				size_hint: (None, None)
-				height: dp(0.245833333333*app.height)
-				width: dp(1.0*app.width)
+				height: app.get_scaled_height(118.0)
+				width: app.get_scaled_width(800.0)
 				Label:
 					id: description_label
-					font_size: str(0.025*app.width) + 'sp'
+					font_size: app.get_scaled_sp('20.0sp')
 					color: [0,0,0,1]
 					markup: True
 					halign: 'center'
@@ -104,21 +104,21 @@ Builder.load_string(
 					size: self.parent.size
 		# Buttons
 		BoxLayout: 
-			padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+			padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
 			size_hint: (None, None)
-			height: dp(0.295833333333*app.height)
-			width: dp(1.0*app.width)
+			height: app.get_scaled_height(142.0)
+			width: app.get_scaled_width(800.0)
 			orientation: 'horizontal'
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[0, 0, dp(0.230625)*app.width, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 				Button:
-				    font_size: str(0.01875 * app.width) + 'sp'
+				    font_size: app.get_scaled_sp('15.0sp')
 					size_hint: (None,None)
-					height: dp(0.108333333333*app.height)
-					width: dp(0.075*app.width)
+					height: app.get_scaled_height(52.0)
+					width: app.get_scaled_width(60.0)
 					background_color: hex('#F4433600')
 					center: self.parent.center
 					pos: self.parent.pos
@@ -135,17 +135,17 @@ Builder.load_string(
 							allow_stretch: True
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.36375*app.width)
-				padding:[0, 0, 0, dp(0.108333333333)*app.height]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(291.0)
+				padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
 				Button:
 					id: next_button
 					background_normal: "./asmcnc/skavaUI/img/next.png"
 					background_down: "./asmcnc/skavaUI/img/next.png"
-					border: [dp(14.5)]*4
+					border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
 					size_hint: (None,None)
-					width: dp(0.36375*app.width)
-					height: dp(0.164583333333*app.height)
+					width: app.get_scaled_width(291.0)
+					height: app.get_scaled_height(79.0)
 					on_press: root.more_info()
 					font_size: root.default_font_size
 					color: hex('#f9f9f9ff')
@@ -156,14 +156,14 @@ Builder.load_string(
 
 			BoxLayout: 
 				size_hint: (None, None)
-				height: dp(0.275*app.height)
-				width: dp(0.305625*app.width)
-				padding:[dp(0.241875)*app.width, 0, 0, 0]
+				height: app.get_scaled_height(132.0)
+				width: app.get_scaled_width(244.5)
+				padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
 				Button:
-				    font_size: str(0.01875 * app.width) + 'sp'
+				    font_size: app.get_scaled_sp('15.0sp')
 					size_hint: (None,None)
-					height: dp(0.125*app.height)
-					width: dp(0.06375*app.width)
+					height: app.get_scaled_height(60.0)
+					width: app.get_scaled_width(51.0)
 					background_color: hex('#F4433600')
 					center: self.parent.center
 					pos: self.parent.pos

--- a/src/asmcnc/production/lower_beam_qc_jig/lower_beam_qc.py
+++ b/src/asmcnc/production/lower_beam_qc_jig/lower_beam_qc.py
@@ -48,7 +48,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 							on_press: root.new_test_motor_chips()
 						Image:
 							id: motor_chips_check
@@ -63,7 +63,7 @@ Builder.load_string("""
 						text_size: self.size
 						halign: 'left'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						on_press: root.disable_alarms()
 
 					GridLayout:
@@ -73,7 +73,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 						Image:
 							id: y_home_check
 							source: "./asmcnc/skavaUI/img/checkbox_inactive.png"
@@ -87,7 +87,7 @@ Builder.load_string("""
 						text_size: self.size
 						halign: 'left'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						on_press: root.enable_alarms()
 
 					ToggleButton:
@@ -96,7 +96,7 @@ Builder.load_string("""
 						text_size: self.size
 						halign: 'left'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						on_press: root.set_vac()
 
 				# COLUMN 2
@@ -118,20 +118,20 @@ Builder.load_string("""
 								id: xy_move_container
 								size_hint: (None,None)
 								pos_hint: {'center_x': .5, 'center_y': .5}
-								height: dp(270)
-								width: dp(270)
+								height: app.get_scaled_height(270.0)
+								width: app.get_scaled_width(270.0)
 
 						BoxLayout:
 							orientation: 'vertical'
 							size_hint_x: 0.25
-							padding: [0,0,0,dp(150)]
+							padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 150.0])
 
 							Button:
 								text: 'OFF'
 								text_size: self.size
 								halign: 'left'
 								valign: 'middle'
-								padding: [dp(10),0]
+								padding: app.get_scaled_tuple([10.0, 0.0])
 								on_press: console_utils.shutdown()
 
 							ToggleButton:
@@ -140,7 +140,7 @@ Builder.load_string("""
 								text_size: self.size
 								halign: 'left'
 								valign: 'middle'
-								padding: [dp(10),0]
+								padding: app.get_scaled_tuple([10.0, 0.0])
 								on_press: root.switch_screen()
 
 					Button:
@@ -148,7 +148,7 @@ Builder.load_string("""
 						markup: 'True'
 						halign: 'center'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						text: 'STOP'
 						background_color: [1,0,0,1]
 						background_normal: ''

--- a/src/asmcnc/production/lower_beam_qc_jig/lower_beam_qc_warranty.py
+++ b/src/asmcnc/production/lower_beam_qc_jig/lower_beam_qc_warranty.py
@@ -46,7 +46,7 @@ Builder.load_string("""
 						text_size: self.size
 						halign: 'left'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						on_press: root.disable_alarms()
 
 					GridLayout:
@@ -56,7 +56,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 						Image:
 							id: y_max_check
 							source: "./asmcnc/skavaUI/img/checkbox_inactive.png"
@@ -72,7 +72,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 						Image:
 							id: y_home_check
 							source: "./asmcnc/skavaUI/img/checkbox_inactive.png"
@@ -86,7 +86,7 @@ Builder.load_string("""
 						text_size: self.size
 						halign: 'left'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						on_press: root.enable_alarms()
 
 					GridLayout:
@@ -97,7 +97,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 							on_press: root.set_vac()
 
 						ToggleButton:
@@ -106,7 +106,7 @@ Builder.load_string("""
 							text_size: self.size
 							halign: 'left'
 							valign: 'middle'
-							padding: [dp(10),0]
+							padding: app.get_scaled_tuple([10.0, 0.0])
 							on_press: root.set_spindle()
 
 				# COLUMN 2
@@ -128,20 +128,20 @@ Builder.load_string("""
 								id: xy_move_container
 								size_hint: (None,None)
 								pos_hint: {'center_x': .5, 'center_y': .5}
-								height: dp(270)
-								width: dp(270)
+								height: app.get_scaled_height(270.0)
+								width: app.get_scaled_width(270.0)
 
 						BoxLayout:
 							orientation: 'vertical'
 							size_hint_x: 0.25
-							padding: [0,0,0,dp(150)]
+							padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 150.0])
 
 							Button:
 								text: 'OFF'
 								text_size: self.size
 								halign: 'left'
 								valign: 'middle'
-								padding: [dp(10),0]
+								padding: app.get_scaled_tuple([10.0, 0.0])
 								on_press: console_utils.shutdown()
 
 							ToggleButton:
@@ -150,7 +150,7 @@ Builder.load_string("""
 								text_size: self.size
 								halign: 'left'
 								valign: 'middle'
-								padding: [dp(10),0]
+								padding: app.get_scaled_tuple([10.0, 0.0])
 								on_press: root.switch_screen()
 
 					Button:
@@ -158,7 +158,7 @@ Builder.load_string("""
 						markup: 'True'
 						halign: 'center'
 						valign: 'middle'
-						padding: [dp(10),0]
+						padding: app.get_scaled_tuple([10.0, 0.0])
 						text: 'STOP'
 						background_color: [1,0,0,1]
 						background_normal: ''

--- a/src/asmcnc/production/lower_beam_qc_jig/widget_lower_beam_qc_xy_move.py
+++ b/src/asmcnc/production/lower_beam_qc_jig/widget_lower_beam_qc_xy_move.py
@@ -19,8 +19,8 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        padding: 10
-        spacing: 10
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
 
         GridLayout:
             cols: 3
@@ -31,7 +31,7 @@ Builder.load_string("""
     
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos                               
 
@@ -56,7 +56,7 @@ Builder.load_string("""
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos                 
                             
@@ -118,7 +118,7 @@ Builder.load_string("""
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos  
 
@@ -143,7 +143,7 @@ Builder.load_string("""
                         allow_stretch: True                                    
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos 
 """)

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_1.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_1.py
@@ -21,12 +21,12 @@ Builder.load_string("""
             Label:
                 id: user_text
                 text: "Getting ready..."
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Label:
                 id: calibrate_time
                 text: root.formatted_max
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
 """)
 

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_2.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_2.py
@@ -23,7 +23,7 @@ Builder.load_string("""
         Label:
             id: calibration_label
             text: 'Calibrating...'
-            font_size: dp(50)
+            font_size: app.get_scaled_width(50.0)
             text_size: root.width, None
             size: self.texture_size
             halign: 'center'

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_3.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_3.py
@@ -21,10 +21,10 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         GridLayout:
             cols: 1
@@ -32,12 +32,12 @@ Builder.load_string("""
 
             Label:
                 text: 'Calibration complete!'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Button:
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_4.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_4.py
@@ -24,42 +24,42 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         GridLayout:
             cols: 1
             rows: 4
 
-            spacing: 50
+            spacing: app.get_scaled_width(50.0)
 
             GridLayout:
                 cols: 1
                 rows: 1
 
-                padding: [200, 0]
+                padding: app.get_scaled_tuple([200.0, 0.0])
 
                 TextInput:
                     id: serial_no_input
-                    font_size: dp(50)
+                    font_size: app.get_scaled_width(50.0)
                     multiline: False
 
 
             Label:
                 text: '^ Enter LB serial number: ^'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
             Label:
                 id: error_label
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
 
             Button:
                 id: ok_button
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.6
                 disabled: False
 

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_fail.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_fail.py
@@ -24,10 +24,10 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         GridLayout:
             cols: 1
@@ -36,12 +36,12 @@ Builder.load_string("""
             Label:
                 id: success_label
                 text: 'Database update failed'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Button:
                 on_press: root.retry_send()
                 text: 'RETRY DATA SEND'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_success.py
+++ b/src/asmcnc/production/lowerbeam_calibration_jig/lowerbeam_calibration_success.py
@@ -28,10 +28,10 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         GridLayout:
             cols: 1
@@ -40,12 +40,12 @@ Builder.load_string("""
             Label:
                 id: success_label
                 text: 'Database updated for '
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Button:
                 on_press: console_utils.shutdown()
                 text: 'OK, SHUT DOWN'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/z_head_mechanics_jig/widget_z_move_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/widget_z_move_mechanics.py
@@ -14,12 +14,12 @@ Builder.load_string("""
 
         size: self.parent.size
         pos: self.parent.pos
-        padding: 10
-        spacing: 10
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
         orientation: 'horizontal'
 
         BoxLayout:
-            spacing: 10
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
 
             ToggleButton:
@@ -56,7 +56,7 @@ Builder.load_string("""
                         allow_stretch: True
 
         BoxLayout:
-            spacing: 10
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
 
             Button:
@@ -106,13 +106,13 @@ Builder.load_string("""
             x: up_button.pos[0] + up_button.size[0] * 0.75
             y: up_button.pos[1] + up_button.size[1] * 0.75
             size_hint: None, None
-            height: dp(30)
-            width: dp(30)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             text: 'Z'
             markup: True
             bold: True
             color: hex('#333333ff')
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
 """)
     

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics.py
@@ -34,18 +34,18 @@ Builder.load_string("""
 
         BoxLayout:
             orientation: 'horizontal'
-            padding: dp(5)
-            spacing: dp(5)
+            padding: app.get_scaled_width(5.0)
+            spacing: app.get_scaled_width(5.0)
 
             BoxLayout:
                 orientation: 'vertical'
-                spacing: dp(5)
+                spacing: app.get_scaled_width(5.0)
 
                 Button:
                     id: calibrate_button
                     text: 'Calibrate Motor'
                     bold: True
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     background_color: hex('#FF9900FF')
                     background_normal: ''
                     on_press: root.show_calibration_popup()
@@ -54,7 +54,7 @@ Builder.load_string("""
                     id: begin_test_button
                     text: 'Begin Test'
                     bold: True
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     background_color: hex('#00C300FF')
                     background_normal: ''
                     on_press: root.prepare_for_test()
@@ -123,7 +123,7 @@ Builder.load_string("""
                         id: load_realtime
                         size_hint_y: 2
                         text: '-'
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
 
                 BoxLayout:
                     orientation: 'vertical'
@@ -139,17 +139,17 @@ Builder.load_string("""
                         id: current_realtime
                         size_hint_y: 2
                         text: '-'
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
 
             BoxLayout:
                 size_hint_x: 0.7
                 orientation: 'vertical'
-                spacing: dp(5)
+                spacing: app.get_scaled_width(5.0)
 
                 Button:
                     text: 'Serial Monitor'
                     bold: True
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     text_size: self.size
                     valign: 'middle'
                     halign: 'center'
@@ -160,7 +160,7 @@ Builder.load_string("""
                 Button:
                     text: 'Manual Move'
                     bold: True
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     text_size: self.size
                     valign: 'middle'
                     halign: 'center'
@@ -172,7 +172,7 @@ Builder.load_string("""
                 id: stop_button
                 text: 'STOP'
                 bold: True
-                font_size: dp(20)
+                font_size: app.get_scaled_width(20.0)
                 background_color: [1,0,0,1]
                 background_normal: ''
                 on_press: root.stop()
@@ -181,7 +181,7 @@ Builder.load_string("""
             id: test_progress_label
             size_hint_y: 3
             text: 'Waiting...'
-            font_size: dp(30)
+            font_size: app.get_scaled_width(30.0)
             markup: True
             bold: True
             text_size: self.size
@@ -192,8 +192,8 @@ Builder.load_string("""
         Image:
             id: load_graph
             size_hint: None, None
-            height: dp(355)
-            width: dp(790)
+            height: app.get_scaled_height(355.0)
+            width: app.get_scaled_width(790.0)
             x: dp(5)
             y: dp(5)
             allow_stretch: True

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_booting.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_booting.py
@@ -13,7 +13,7 @@ Builder.load_string("""
 
     Label:
         text: 'Booting...'
-        font_size: dp(40)
+        font_size: app.get_scaled_width(40.0)
 
 """)
 

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_manual_move.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_manual_move.py
@@ -18,31 +18,31 @@ Builder.load_string("""
 
     BoxLayout:
         orientation: 'vertical'
-        padding: dp(10)
-        spacing: dp(10)
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
 
         Button:
             text: 'Back'
             bold: True
-            font_size: dp(25)
+            font_size: app.get_scaled_width(25.0)
             on_press: root.back()
 
         BoxLayout:
             size_hint_y: 8
             orientation: 'horizontal'
-            spacing: dp(30)
+            spacing: app.get_scaled_width(30.0)
 
             BoxLayout:
                 orientation: 'vertical'
-                spacing: dp(10)
+                spacing: app.get_scaled_width(10.0)
 
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing: dp(10)
+                    spacing: app.get_scaled_width(10.0)
 
                     TextInput:
                         id: phase_one_input
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
                         input_filter: 'int'
                         multiline: False
 
@@ -57,11 +57,11 @@ Builder.load_string("""
 
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing: dp(10)
+                    spacing: app.get_scaled_width(10.0)
 
                     TextInput:
                         id: phase_two_input
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
                         input_filter: 'int'
                         multiline: False
 
@@ -76,7 +76,7 @@ Builder.load_string("""
 
                 Button:
                     text: 'Set power high'
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     bold: True
                     background_color: [0,0,1,1]
                     background_normal: ''
@@ -84,7 +84,7 @@ Builder.load_string("""
 
                 Button:
                     text: 'Set power low'
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     bold: True
                     background_color: hex('#EAEA00FF')
                     background_normal: ''
@@ -92,7 +92,7 @@ Builder.load_string("""
 
                 Button:
                     text: 'Energise motor'
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     bold: True
                     background_color: [0,1,0,1]
                     background_normal: ''
@@ -100,7 +100,7 @@ Builder.load_string("""
 
                 Button:
                     text: 'De-energise motor'
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     bold: True
                     background_color: [1,0,0,1]
                     background_normal: ''
@@ -115,36 +115,36 @@ Builder.load_string("""
 
                     Label:
                         text: 'Real time load:'
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
 
                     Label:
                         id: load_label
                         size_hint_y: 2
                         text: '-'
-                        font_size: dp(50)
+                        font_size: app.get_scaled_width(50.0)
                         bold: True
 
                     Label:
                         text: 'Z axis position:'
-                        font_size: dp(25)
+                        font_size: app.get_scaled_width(25.0)
 
                     Label:
                         id: pos_label
                         size_hint_y: 2
                         text: '-'
-                        font_size: dp(50)
+                        font_size: app.get_scaled_width(50.0)
                         bold: True
 
                 Button:
                     text: 'Home'
-                    font_size: dp(25)
+                    font_size: app.get_scaled_width(25.0)
                     bold: True
                     background_color: hex('#9900FFFF')
                     background_normal: ''
                     on_press: root.home()
 
             BoxLayout:
-                padding: [dp(0), dp(50)]
+                padding: app.get_scaled_tuple([0.0, 50.0])
 
                 BoxLayout:
                     id: z_move_container

--- a/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_monitor.py
+++ b/src/asmcnc/production/z_head_mechanics_jig/z_head_mechanics_monitor.py
@@ -10,13 +10,13 @@ Builder.load_string("""
 
     BoxLayout:
         orientation: 'vertical'
-        padding: dp(10)
-        spacing: dp(10)
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
 
         Button:
             text: 'Back'
             bold: True
-            font_size: dp(25)
+            font_size: app.get_scaled_width(25.0)
             on_press: root.back()
 
         BoxLayout:

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_1.py
@@ -52,7 +52,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 GridLayout:
                     cols: 2
@@ -63,7 +63,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.test_motor_chips()
 
                     Image:
@@ -79,7 +79,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'center'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     text: 'STOP'
                     background_color: [1,0,0,1]
                     background_normal: ''
@@ -94,7 +94,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 GridLayout:
                     cols: 2
@@ -105,7 +105,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     GridLayout:
                         cols: 2
@@ -116,7 +116,7 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'center'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
                             on_press: root.x_motor_down()
                             on_release: root.quit_jog()
 
@@ -126,7 +126,7 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'center'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
                             on_press: root.x_motor_up()
                             on_release: root.quit_jog()
 
@@ -136,7 +136,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.disable_alarms()
 
                 # ROW 3
@@ -150,7 +150,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     Image:
                         id: temp_voltage_power_check
@@ -169,7 +169,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         size_hint_x: 1.6
 
                     Button: 
@@ -178,7 +178,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'center'
                         valign: 'middle'
-                        padding: [dp(5),0]
+                        padding: app.get_scaled_tuple([5.0, 0.0])
                         on_press: root.z_motor_down()
                         on_release: root.quit_jog()
                         size_hint_x: 1
@@ -189,7 +189,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'center'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.z_motor_up()
                         on_release: root.quit_jog()
                         size_hint_x: 1
@@ -200,7 +200,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'center'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.mini_cycle()
                         size_hint_x: 1
 
@@ -213,7 +213,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     Image:
                         id: x_home_check
@@ -233,7 +233,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         text: '2. Bake GRBL Settings'
                         on_press: root.bake_grbl_settings()
 
@@ -255,7 +255,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.set_spindle()
 
                     ToggleButton:
@@ -264,7 +264,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         text: '9. Laser'
                         on_press: root.set_laser()
 
@@ -274,7 +274,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         text: '10. Vac'
                         on_press: root.set_vac()
 
@@ -287,7 +287,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     Image:
                         id: x_max_check
@@ -309,7 +309,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.home()
 
                     Button: 
@@ -319,7 +319,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.resume_from_alarm()
 
                 GridLayout:
@@ -331,7 +331,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     GridLayout:
                         cols: 3
@@ -341,7 +341,7 @@ Builder.load_string("""
                             text_size: self.size
                             markup: 'True'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
                             on_press: root.dust_shoe_red()
 
                         Button:
@@ -349,7 +349,7 @@ Builder.load_string("""
                             text_size: self.size
                             markup: 'True'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
                             on_press: root.dust_shoe_green()
 
                         Button:
@@ -363,7 +363,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
             # RECIEVED STATUS MONITOR
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_2.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_2.py
@@ -37,7 +37,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 GridLayout:
                     cols: 2
@@ -48,7 +48,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.run_digital_spindle_test()
 
                     Image:
@@ -64,7 +64,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'center'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     text: 'STOP'
                     background_color: [1,0,0,1]
                     background_normal: ''
@@ -79,7 +79,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
 
                     Image:
                         id: probe_check
@@ -95,7 +95,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 Label:
                     text: '25. Remove USB "spindle"'
@@ -103,7 +103,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 Button:
                     text: '17. Enable alarms'
@@ -111,7 +111,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.enable_alarms()
 
                 Label: 
@@ -120,7 +120,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 Button:
                     text: '26. CONFIRM COVER ON: START AUTO-CALIBRATE'
@@ -128,7 +128,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.enter_next_screen()
 
                 Button:
@@ -137,7 +137,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.set_spindle_digital()
 
                 Button:
@@ -146,7 +146,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.set_spindle_analogue()
 
                 Label
@@ -157,7 +157,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
                 GridLayout:
                     cols: 2
@@ -168,7 +168,7 @@ Builder.load_string("""
                         markup: 'True'
                         halign: 'left'
                         valign: 'middle'
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                         on_press: root.run_analogue_spindle_check()
 
                     Image:

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_3.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_3.py
@@ -20,28 +20,28 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         BoxLayout: 
             orientation: "vertical"
-            spacing: dp(10)
+            spacing: app.get_scaled_width(10.0)
 
             Label:
                 text: 'ENSURE COVER ON'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
             Label:
                 id: user_text
                 text: "Getting ready..."
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Label:
                 id: calibrate_time
                 text: root.formatted_max
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
 """)
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_4.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_4.py
@@ -22,7 +22,7 @@ Builder.load_string("""
         Label:
             id: calibration_label
             text: 'Calibrating...'
-            font_size: dp(50)
+            font_size: app.get_scaled_width(50.0)
             text_size: root.width, None
             size: self.texture_size
             halign: 'center'

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_5.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_5.py
@@ -23,12 +23,12 @@ Builder.load_string("""
 
             Label:
                 text: 'Calibration complete!'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Button:
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_6.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_6.py
@@ -18,18 +18,18 @@ Builder.load_string("""
 
             Label:
                 text: '28. Set wheels and leadscrew(s)'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
             Label:
                 text: '29. Install top plate'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
             
             Button:
                 id: ok_button
                 disabled: 'True'
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.4
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_7.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_7.py
@@ -19,7 +19,7 @@ Builder.load_string("""
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: 0.92
-            spacing: dp(15)
+            spacing: app.get_scaled_width(15.0)
 
             GridLayout:
                 cols: 2
@@ -34,22 +34,22 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
-                    font_size: dp(20)
+                    padding: app.get_scaled_tuple([10.0, 0.0])
+                    font_size: app.get_scaled_width(20.0)
 
                 Label:
                     text: ''
 
             GridLayout:
                 cols: 3
-                spacing: dp(5)
+                spacing: app.get_scaled_width(5.0)
 
                 Button:
                     text: 'Home'
                     background_color: [1,1,0,1]
                     background_normal: ''
                     color: [0,0,0,1]
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
                     on_press: root.home()
 
                 Button:
@@ -57,7 +57,7 @@ Builder.load_string("""
                     background_color: [1,1,0,1]
                     background_normal: ''
                     color: [0,0,0,1]
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
                     on_press: root.resume_from_alarm()
 
                 Button:
@@ -66,13 +66,13 @@ Builder.load_string("""
                     background_color: [0,1,0,1]
                     background_normal: ''
                     color: [0,0,0,1]
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
                     on_press: root.do_cycle()
 
             Button:
                 id: disconnect_button
                 text: 'Cycle finished - go to next screen'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.55
                 disabled: True
                 on_press: root.enter_next_screen()

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_8.py
@@ -25,25 +25,25 @@ Builder.load_string("""
                 markup: 'True'
                 halign: 'left'
                 valign: 'middle'
-                padding: [dp(10),0]
+                padding: app.get_scaled_tuple([10.0, 0.0])
                 size_hint_y: 0.2
                 size_hint_x: 0.5
-                font_size: dp(20)
+                font_size: app.get_scaled_width(20.0)
 
             GridLayout:
                 rows: 2
-                padding: [dp(0), dp(10)]
-                spacing: dp(10)
+                padding: app.get_scaled_tuple([0.0, 10.0])
+                spacing: app.get_scaled_width(10.0)
 
                 Button:
                     text: 'Disconnect'
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
                     on_press: root.disconnect()
 
                 Button:
                     id: connect_button
                     text: 'Connect and Restart'
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
                     on_press: root.connect_and_restart()
                     disabled: True
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_aftr_apr_21.py
@@ -102,7 +102,7 @@ Builder.load_string("""
                         halign: 'left'
                         valign: 'middle'
                         on_press: root.enable_alarms()
-                        padding: [dp(10),0]
+                        padding: app.get_scaled_tuple([10.0, 0.0])
                     Button:
                         text: '  STOP'
                         text_size: self.size

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_b4_apr_21.py
@@ -130,7 +130,7 @@ Builder.load_string("""
                     halign: 'left'
                     valign: 'middle'
                     on_press: root.enable_alarms()
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
 
         # Row 3

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_connecting.py
@@ -22,8 +22,8 @@ Builder.load_string("""
              
     BoxLayout:
         orientation: 'horizontal'
-        padding: 70
-        spacing: 70
+        padding: app.get_scaled_width(70.0)
+        spacing: app.get_scaled_width(70.0)
         size_hint_x: 1
 
         BoxLayout:
@@ -35,7 +35,7 @@ Builder.load_string("""
                 text_size: self.size
                 size_hint_y: 0.5
                 markup: True
-                font_size: '40sp'   
+                font_size: app.get_scaled_sp('40sp')
                 valign: 'middle'
                 halign: 'center'    
     

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_db1.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_db1.py
@@ -18,31 +18,31 @@ Builder.load_string("""
             cols: 1
             rows: 4
 
-            spacing: 50
+            spacing: app.get_scaled_width(50.0)
 
             GridLayout:
                 cols: 1
                 rows: 1
 
-                padding: [200, 0]
+                padding: app.get_scaled_tuple([200.0, 0.0])
 
                 TextInput:
                     id: serial_no_input
-                    font_size: dp(50)
+                    font_size: app.get_scaled_width(50.0)
                     multiline: False
 
             Label:
                 text: '^ Enter ZH Serial number: ^'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
 
             Label:
                 id: error_label
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
 
             Button:
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.6
 
 """)

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_db2.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_db2.py
@@ -10,7 +10,7 @@ Builder.load_string("""
 
     Label:
         text: 'Updating database...'
-        font_size: dp(50)
+        font_size: app.get_scaled_width(50.0)
 
 """)
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_db_fail.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_db_fail.py
@@ -25,10 +25,10 @@ Builder.load_string("""
             markup: 'True'
             halign: 'left'
             valign: 'middle'
-            padding: [dp(10),0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
             size_hint_y: 0.2
             size_hint_x: 0.5
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
         GridLayout:
             cols: 1
@@ -37,7 +37,7 @@ Builder.load_string("""
             Label:
                 id: success_label
                 text: 'Database update failed!!'
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
                 text_size: self.size
                 halign: 'center'
                 valign: 'center'
@@ -45,7 +45,7 @@ Builder.load_string("""
             Button:
                 on_press: root.retry_send()
                 text: 'RETRY DATA SEND'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_db_success.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_db_success.py
@@ -24,7 +24,7 @@ Builder.load_string("""
             Label:
                 id: success_label
                 text: 'Database updated for '
-                font_size: dp(50)
+                font_size: app.get_scaled_width(50.0)
                 text_size: self.size
                 halign: 'center'
                 valign: 'center'
@@ -32,7 +32,7 @@ Builder.load_string("""
             Button:
                 on_press: root.enter_next_screen()
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 size_hint_x: 0.3
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_home.py
@@ -39,7 +39,7 @@ Builder.load_string("""
                 markup: 'True'
                 halign: 'center'
                 valign: 'middle'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
 
             GridLayout: 
                 cols: 2
@@ -47,14 +47,14 @@ Builder.load_string("""
                 Button:
                     id: test_fw_update_button 
                     text: 'NO - Set up PCB & Flash FW'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.go_back_to_pcb_setup()
                     markup: True
                     halign: "center"
 
                 Button:
                     text: 'YES - Take me to QC! (For v1.3)'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.enter_qc()
 
             GridLayout:
@@ -62,12 +62,12 @@ Builder.load_string("""
 
                 Button: 
                     text: 'Take me to WARRANTY QC! (For v1.2)'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.secret_option_c()
 
                 Button:
                     text: 'Shut down'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     background_color: [1,0,0,1]
                     background_normal: ''
                     on_press: console_utils.shutdown()

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up.py
@@ -62,7 +62,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.go_to_qc_home()
 
                 Label: 
@@ -71,7 +71,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
 
 
                 ToggleButton: 
@@ -81,8 +81,8 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'center'
                     valign: 'middle'
-                    padding: [dp(10),0]
-                    font_size: dp(20)
+                    padding: app.get_scaled_tuple([10.0, 0.0])
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.toggle_connection_to_z_head()
 
             BoxLayout: 
@@ -91,7 +91,7 @@ Builder.load_string("""
 
                 BoxLayout: 
                     orientation: 'vertical'
-                    padding: [dp(5),dp(10)]
+                    padding: app.get_scaled_tuple([5.0, 10.0])
 
                     BoxLayout: 
                         size_hint_y: 0.2
@@ -108,12 +108,12 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'left'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
 
                     BoxLayout: 
                         orientation: 'vertical'
                         size_hint_y: 0.8
-                        padding: [dp(5),0]
+                        padding: app.get_scaled_tuple([5.0, 0.0])
 
                         Label: 
                             size_hint_y: 0.2
@@ -182,7 +182,7 @@ Builder.load_string("""
 
                 BoxLayout: 
                     orientation: 'vertical'
-                    padding: [dp(5),dp(10)]
+                    padding: app.get_scaled_tuple([5.0, 10.0])
 
                     BoxLayout: 
                         size_hint_y: 0.2
@@ -199,12 +199,12 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'left'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
 
                     BoxLayout: 
                         orientation: 'vertical'
                         size_hint_y: 0.8
-                        padding: [dp(5),0]
+                        padding: app.get_scaled_tuple([5.0, 0.0])
 
                         BoxLayout: 
                             orientation: 'horizontal'
@@ -260,8 +260,8 @@ Builder.load_string("""
                                 size_hint_x: 0.4
                                 input_filter: "int"
                                 multiline: False
-                                font_size: "22sp"
-                                padding: [dp(5), dp(5)]
+                                font_size: app.get_scaled_sp('22sp')
+                                padding: app.get_scaled_tuple([5.0, 5.0])
                                 on_text_validate: root.x_current = root.set_value_to_update_to(other_x_current_textinput, self)
 
                         BoxLayout: 
@@ -270,7 +270,7 @@ Builder.load_string("""
 
                 BoxLayout: 
                     orientation: 'vertical'
-                    padding: [dp(5),dp(10)]
+                    padding: app.get_scaled_tuple([5.0, 10.0])
 
                     BoxLayout: 
                         size_hint_y: 0.2
@@ -287,12 +287,12 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'left'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
 
                     BoxLayout: 
                         orientation: 'vertical'
                         size_hint_y: 0.8
-                        padding: [dp(5),0]
+                        padding: app.get_scaled_tuple([5.0, 0.0])
 
                         BoxLayout: 
                             orientation: 'horizontal'
@@ -332,8 +332,8 @@ Builder.load_string("""
                                 size_hint_x: 0.4
                                 input_filter: "int"
                                 multiline: False
-                                font_size: "22sp"
-                                padding: [dp(5), dp(5)]
+                                font_size: app.get_scaled_sp('22sp')
+                                padding: app.get_scaled_tuple([5.0, 5.0])
                                 on_text_validate: root.z_current = root.set_value_to_update_to(other_z_current_textinput, self)
                         
                         BoxLayout: 
@@ -341,7 +341,7 @@ Builder.load_string("""
 
                 BoxLayout: 
                     orientation: 'vertical'
-                    padding: [dp(5),dp(10)]
+                    padding: app.get_scaled_tuple([5.0, 10.0])
 
                     BoxLayout: 
                         size_hint_y: 0.2
@@ -358,12 +358,12 @@ Builder.load_string("""
                             markup: 'True'
                             halign: 'left'
                             valign: 'middle'
-                            padding: [dp(10),0]
+                            padding: app.get_scaled_tuple([10.0, 0.0])
 
                     BoxLayout: 
                         orientation: 'vertical'
                         size_hint_y: 0.8
-                        padding: [dp(5),0]
+                        padding: app.get_scaled_tuple([5.0, 0.0])
 
                         GridLayout: 
                             size_hint_y: 0.6
@@ -377,8 +377,8 @@ Builder.load_string("""
                                 text: "5000"
                                 input_filter: "int"
                                 multiline: False
-                                font_size: "22sp"
-                                padding: [dp(5), dp(5)]
+                                font_size: app.get_scaled_sp('22sp')
+                                padding: app.get_scaled_tuple([5.0, 5.0])
                                 on_text_validate: root.x_thermal_coefficient = root.set_value_to_update_to(self)
                             Label:
                                 id: thermal_coeff_y_label
@@ -388,8 +388,8 @@ Builder.load_string("""
                                 text: "5000"
                                 input_filter: "int"
                                 multiline: False
-                                font_size: "22sp"
-                                padding: [dp(5), dp(5)]
+                                font_size: app.get_scaled_sp('22sp')
+                                padding: app.get_scaled_tuple([5.0, 5.0])
                                 on_text_validate: root.y_thermal_coefficient = root.set_value_to_update_to(self)
                             Label:
                                 id: thermal_coeff_z_label
@@ -399,8 +399,8 @@ Builder.load_string("""
                                 text: "10000"
                                 input_filter: "int"
                                 multiline: False
-                                font_size: "22sp"
-                                padding: [dp(5), dp(5)]
+                                font_size: app.get_scaled_sp('22sp')
+                                padding: app.get_scaled_tuple([5.0, 5.0])
                                 on_text_validate: root.z_thermal_coefficient = root.set_value_to_update_to(self)
 
                         BoxLayout: 
@@ -409,7 +409,7 @@ Builder.load_string("""
             Button:
                 id: ok_button
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 on_press: root.do_pcb_update_and_set_settings()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_pcb_set_up_outcome.py
@@ -39,7 +39,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'left'
                     valign: 'middle'
-                    padding: [dp(10),0]
+                    padding: app.get_scaled_tuple([10.0, 0.0])
                     on_press: root.go_back_to_pcb_setup()
 
 
@@ -130,7 +130,7 @@ Builder.load_string("""
             Button:
                 on_press: 
                 text: 'OK'
-                font_size: dp(30)
+                font_size: app.get_scaled_width(30.0)
                 size_hint_y: 0.2
                 on_press: root.go_to_qc_home()
 

--- a/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
+++ b/src/asmcnc/production/z_head_qc_jig/z_head_qc_warranty_choice.py
@@ -35,7 +35,7 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'center'
                     valign: 'bottom'
-                    font_size: dp(30)
+                    font_size: app.get_scaled_width(30.0)
 
                 Label: 
                     id: fw_version_label
@@ -45,14 +45,14 @@ Builder.load_string("""
                     markup: 'True'
                     halign: 'center'
                     valign: 'middle'
-                    font_size: dp(24)
+                    font_size: app.get_scaled_width(24.0)
 
             GridLayout: 
                 cols: 2
 
                 Button:
                     text: root.after_label
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     color: 1,1,1,1
                     text_size: self.size
                     markup: 'True'
@@ -62,7 +62,7 @@ Builder.load_string("""
 
                 Button:
                     text: root.before_label
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     color: 1,1,1,1
                     text_size: self.size
                     markup: 'True'
@@ -75,20 +75,20 @@ Builder.load_string("""
 
                 Button: 
                     text: '<<< Back'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.back_to_home()
 
                 ToggleButton: 
                     id: connection_button
                     text: "Disconnect Z Head"
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.toggle_connection_to_z_head()
 
 
                 ToggleButton:
                     id: usb_change_button
                     text: 'FW on USB: vx.x.x'
-                    font_size: dp(20)
+                    font_size: app.get_scaled_width(20.0)
                     on_press: root.toggle_usb_mounted()
                     markup: True
                     halign: "center"

--- a/src/asmcnc/skavaUI/screen_boundary_warning.py
+++ b/src/asmcnc/skavaUI/screen_boundary_warning.py
@@ -44,26 +44,26 @@ Builder.load_string(
             size: self.texture_size
             text_size: self.size
             color: hex('#333333ff')
-            font_size: str(0.045*app.width) + 'sp'
+            font_size: app.get_scaled_sp('36.0sp')
 
         BoxLayout:
             orientation: 'horizontal'
             padding: 0
-            spacing:0.0833333333333*app.height
+            spacing: app.get_scaled_width(40.0)
             size_hint_y: 6.77
 
             BoxLayout:
                 orientation: 'vertical'
                 size_hint_x: 1
                 spacing: 0
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                padding: app.get_scaled_tuple([20.0, 20.0])
 
                 Label:
                     size_hint_y: 3
                     size: self.texture_size
                     text_size: self.size
                     color: hex('#333333ff')
-                    font_size: str(0.025*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('20.0sp')
                     halign: 'center'
                     valign: 'middle'
                     text: root.check_outcome
@@ -72,7 +72,7 @@ Builder.load_string(
                 BoxLayout:
                     orientation: 'horizontal'
                     size_hint_y: 1
-                    padding:[dp(0.030625)*app.width, 0]
+                    padding: app.get_scaled_tuple([24.5, 0.0])
 
                     Button:
                         id: quit_button
@@ -80,11 +80,11 @@ Builder.load_string(
                         text: root.exit_label
                         background_normal: "./asmcnc/skavaUI/img/next.png"
                         background_down: "./asmcnc/skavaUI/img/next.png"
-                        border: [dp(14.5)]*4
+                        border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                         size_hint: (None,None)
-                        width: dp(0.36375*app.width)
-                        height: dp(0.164583333333*app.height)
-                        font_size: str(0.035*app.width) + 'sp'
+                        width: app.get_scaled_width(291.0)
+                        height: app.get_scaled_height(79.0)
+                        font_size: app.get_scaled_sp('28.0sp')
                         color: hex('#f9f9f9ff')
                         markup: True
                         center: self.parent.center
@@ -93,8 +93,8 @@ Builder.load_string(
             BoxLayout:
                 size_hint_x: 1
                 orientation: 'vertical'
-                spacing:0.0104166666667*app.height
-                padding:[0, 0, dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                spacing: app.get_scaled_width(5.0)
+                padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 20.0])
                                 
                 ScrollView:
                     size_hint: 1, 1
@@ -106,7 +106,7 @@ Builder.load_string(
                     RstDocument:
                         text: root.display_output
                         background_color: hex('#E5E5E5FF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
 
                 BoxLayout:
                     orientation: 'horizontal'

--- a/src/asmcnc/skavaUI/screen_check_job.py
+++ b/src/asmcnc/skavaUI/screen_check_job.py
@@ -93,7 +93,7 @@ Builder.load_string(
             size: self.texture_size
             text_size: self.size
             color: hex('#333333ff')
-            font_size: str(0.05*app.width) + 'sp'
+            font_size: app.get_scaled_sp('40.0sp')
             text: root.job_checking_checked
 
         Label:
@@ -102,28 +102,28 @@ Builder.load_string(
             size: self.texture_size
             text_size: self.size
             color: hex('#333333ff')
-            font_size: str(0.025*app.width) + 'sp'
+            font_size: app.get_scaled_sp('20.0sp')
             halign: 'center'
             valign: 'top'
 
         BoxLayout:
             orientation: 'horizontal'
             padding: 0
-            spacing:0.0833333333333*app.height
+            spacing: app.get_scaled_width(40.0)
             size_hint_y: 6.12
 
             BoxLayout:
                 orientation: 'vertical'
                 size_hint_x: 1
                 spacing: 0
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                padding: app.get_scaled_tuple([20.0, 20.0])
                     
                 Label:
                     size_hint_y: 3
                     size: self.texture_size
                     text_size: self.size
                     color: hex('#333333ff')
-                    font_size: str(0.025*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('20.0sp')
                     halign: 'center'
                     valign: 'middle'
                     text: root.check_outcome
@@ -132,7 +132,7 @@ Builder.load_string(
                 BoxLayout:
                     orientation: 'horizontal'
                     size_hint_y: 1
-                    padding:[dp(0.030625)*app.width, 0]
+                    padding: app.get_scaled_tuple([24.5, 0.0])
 
                     Button:
                         id: quit_button
@@ -140,11 +140,11 @@ Builder.load_string(
                         text: root.exit_label
                         background_normal: "./asmcnc/skavaUI/img/next.png"
                         background_down: "./asmcnc/skavaUI/img/next.png"
-                        border: [dp(14.5)]*4
+                        border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                         size_hint: (None,None)
-                        width: dp(0.36375*app.width)
-                        height: dp(0.164583333333*app.height)
-                        font_size: str(0.035*app.width) + 'sp'
+                        width: app.get_scaled_width(291.0)
+                        height: app.get_scaled_height(79.0)
+                        font_size: app.get_scaled_sp('28.0sp')
                         color: hex('#f9f9f9ff')
                         markup: True
                         center: self.parent.center
@@ -153,8 +153,8 @@ Builder.load_string(
             BoxLayout:
                 size_hint_x: 1
                 orientation: 'vertical'
-                spacing:0.0104166666667*app.height
-                padding:[0, 0, dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                spacing: app.get_scaled_width(5.0)
+                padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 20.0])
                                 
                 ScrollView:
                     size_hint: 1, 1
@@ -166,15 +166,15 @@ Builder.load_string(
                     RstDocument:
                         text: root.display_output
                         background_color: hex('#E5E5E5FF')
-                        base_font_size: str(31.0/800.0*app.width) + 'sp'
+                        base_font_size: app.get_scaled_sp('31.0sp')
 
                 BoxLayout:
                     orientation: 'horizontal'
                     size_hint_y: 0.15
-                    spacing:0.0125*app.width
+                    spacing: app.get_scaled_width(10.0)
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: load_file_now_button
                         color: hex('#f9f9f9ff')
                         markup: True
@@ -184,10 +184,10 @@ Builder.load_string(
                         on_press: root.load_file_now()
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: "./asmcnc/apps/systemTools_app/img/word_button.png"
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                         
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: check_gcode_button
                         color: hex('#f9f9f9ff')
                         markup: True
@@ -197,7 +197,7 @@ Builder.load_string(
                         on_press: root.check_gcode()
                         background_normal: "./asmcnc/apps/systemTools_app/img/word_button.png"
                         background_down: "./asmcnc/apps/systemTools_app/img/word_button.png"
-                        border: [dp(7.5)]*4
+                        border: app.get_scaled_tuple([7.5, 7.5, 7.5, 7.5])
                              
 """
 )

--- a/src/asmcnc/skavaUI/screen_diagnostics.py
+++ b/src/asmcnc/skavaUI/screen_diagnostics.py
@@ -39,32 +39,32 @@ Builder.load_string(
             orientation: "horizontal"
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'LED ring:'
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'Red'
                 on_press: root.led('RED')
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'Green'
                 on_press: root.led('GREEN')
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'Blue'
                 on_press: root.led('BLUE')
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'OFF'
                 on_press: root.led('off')
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: probe_label
                 text: 'Probe'
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: dust_shoe_cover_label
                 text: 'Dust cover'
                 
@@ -74,22 +74,22 @@ Builder.load_string(
             orientation: "horizontal"
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'X axis:'
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '-'
                 on_press: root.move('x-')
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '+'
                 on_press: root.move('x+')
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: limit_x_label
                 text: 'X Min'
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: limit_X_label
                 text: 'X Max'
 
@@ -99,22 +99,22 @@ Builder.load_string(
             orientation: "horizontal"
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'Y axis:'
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '-'
                 on_press: root.move('y-')
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '+'
                 on_press: root.move('y+')
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: limit_y_label
                 text: 'Y Min'
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: limit_Y_label
                 text: 'Y Max'
 
@@ -124,26 +124,26 @@ Builder.load_string(
             orientation: "horizontal"
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: 'Z axis:'
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '-'
                 on_press: root.move('z-')
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: '+'
                 on_press: root.move('z+')
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: limit_z_label
                 text: 'Z Min'
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: ''
 
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             text: 'Return to factory settings'
             on_press: root.return_to_home()
             

--- a/src/asmcnc/skavaUI/screen_door.py
+++ b/src/asmcnc/skavaUI/screen_door.py
@@ -37,8 +37,8 @@ Builder.load_string(
 
     FloatLayout:
         size_hint: (None, None)
-        height: dp(0.73125*app.height)
-        width: dp(0.62*app.width)
+        height: app.get_scaled_height(351.0)
+        width: app.get_scaled_width(496.0)
         pos: (dp(148.0/800.0)*app.width, dp(80.0/480.0)*app.height)
         Image:
             id: x_beam
@@ -49,8 +49,8 @@ Builder.load_string(
 
     FloatLayout:
         size_hint: (None, None)
-        height: dp(0.114583333333*app.height)
-        width: dp(0.06875*app.width)
+        height: app.get_scaled_height(55.0)
+        width: app.get_scaled_width(55.0)
         pos: (dp(270.0/800.0)*app.width, dp(240.0/480.0)*app.height)
         Image:
             id: stop_img
@@ -65,35 +65,35 @@ Builder.load_string(
         padding: 0
         spacing: 0
         size_hint: (None, None)
-        height: dp(1.0*app.height)
-        width: dp(1.0*app.width)
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
 
         # Door label
         BoxLayout: 
-            padding:[dp(0.01875)*app.width, 0, 0, 0]
+            padding: app.get_scaled_tuple([15.0, 0.0, 0.0, 0.0])
             spacing: 0
             size_hint: (None, None)
-            height: dp(0.104166666667*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(50.0)
+            width: app.get_scaled_width(800.0)
             Label:
                 id: header_label
                 size_hint: (None, None)
-                font_size: str(0.0375*app.width) + 'sp'
+                font_size: app.get_scaled_sp('30.0sp')
                 color: [0,0,0,1]
                 markup: True
                 halign: 'left'
-                height: dp(0.104166666667*app.height)
-                width: dp(0.9875*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(790.0)
                 text_size: self.size
                 size: self.parent.size
                 pos: self.parent.pos
 
         BoxLayout: 
-            padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, 0]
+            padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 0.0])
             spacing: 0
             size_hint: (None, None)
-            height: dp(0.0104166666667*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(5.0)
+            width: app.get_scaled_width(800.0)
             Image:
                 id: red_underline
                 source: "./asmcnc/skavaUI/img/red_underline.png"
@@ -107,24 +107,24 @@ Builder.load_string(
             padding: 0
             spacing: 0
             size_hint: (None, None)
-            height: dp(0.614583333333*app.height)
-            width: dp(1.0*app.width)
+            height: app.get_scaled_height(295.0)
+            width: app.get_scaled_width(800.0)
             orientation: 'vertical'
 
             BoxLayout: 
                 padding: 0
                 spacing: 0
                 size_hint: (None, None)
-                height: dp(0.510416666667*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(245.0)
+                width: app.get_scaled_width(800.0)
                 orientation: 'vertical'
 
             FloatLayout: 
                 padding: 0
                 spacing: 0
                 size_hint: (None, None)
-                height: dp(0.104166666667*app.height)
-                width: dp(1.0*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(800.0)
                 orientation: 'vertical'
                 pos: (dp(0),dp(130.0/480.0)*app.height)
 
@@ -138,13 +138,13 @@ Builder.load_string(
                 Label:
                     id: spindle_raise_label
                     size_hint: (None, None)
-                    font_size: str(0.03*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('24.0sp')
                     color: [0,0,0,1]
                     markup: True
                     halign: 'center'
                     valign: 'middle'
-                    height: dp(0.104166666667*app.height)
-                    width: dp(0.9*app.width)
+                    height: app.get_scaled_height(50.0)
+                    width: app.get_scaled_width(720.0)
                     text_size: self.size
                     size: self.parent.size
                     x: self.parent.x + 80.0/800*app.width
@@ -165,13 +165,13 @@ Builder.load_string(
             orientation: 'horizontal'
             spacing: 0
             size_hint: (None, None)
-            height: dp(0.270833333333*app.height)
-            width: dp(1.0*app.width)
-            padding:[0, 0, 0, dp(0.0208333333333)*app.height]
+            height: app.get_scaled_height(130.0)
+            width: app.get_scaled_width(800.0)
+            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 10.0])
    
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: cancel_button
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -185,7 +185,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: resume_button
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')

--- a/src/asmcnc/skavaUI/screen_error.py
+++ b/src/asmcnc/skavaUI/screen_error.py
@@ -83,20 +83,20 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
-        spacing:0.0625*app.height
+        padding: app.get_scaled_tuple([40.0, 40.0])
+        spacing: app.get_scaled_width(30.0)
         size_hint_x: 1
 
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 1
-            spacing:0.0416666666667*app.height
+            spacing: app.get_scaled_width(20.0)
              
             Label:
                 id: error_header
                 size_hint_y: 0.6
                 text_size: self.size
-                font_size: str(0.03*app.width) + 'sp'
+                font_size: app.get_scaled_sp('24.0sp')
                 markup: True
                 halign: 'left'
                 vallign: 'top'
@@ -104,7 +104,7 @@ Builder.load_string(
             Label:
                 size_hint_y: 1.2
                 text_size: self.size
-                font_size: str(0.0275*app.width) + 'sp'
+                font_size: app.get_scaled_sp('22.0sp')
                 halign: 'left'
                 valign: 'middle'
                 text: root.error_description 
@@ -112,18 +112,18 @@ Builder.load_string(
             Label:
                 id: user_instruction
                 size_hint_y: 0.6
-                font_size: str(0.0275*app.width) + 'sp'
+                font_size: app.get_scaled_sp('22.0sp')
                 text_size: self.size
                 halign: 'left'
                 valign: 'middle'
                 
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.1625)*app.width, 0]
+                padding: app.get_scaled_tuple([130.0, 0.0])
                 size_hint_y: 0.8
             
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y:0.9
                     id: getout_button
                     size: self.texture_size
@@ -135,13 +135,13 @@ Builder.load_string(
                         root.button_press()
                         
                     BoxLayout:
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         size: self.parent.size
                         pos: self.parent.pos
                         
                         Label:
                             id: return_label
-                            font_size: str(0.025*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('20.0sp')
                             text: 'Return'
                         
   

--- a/src/asmcnc/skavaUI/screen_file_loading.py
+++ b/src/asmcnc/skavaUI/screen_file_loading.py
@@ -54,7 +54,7 @@ Builder.load_string(
         size_hint_x: 1
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             id: usb_status_label
             canvas.before:
                 Color:
@@ -64,15 +64,15 @@ Builder.load_string(
                     pos: self.pos
             size_hint_y: 0.7
             markup: True
-            font_size: str(0.0225*app.width) + 'sp'   
+            font_size: app.get_scaled_sp('18.0sp')
             valign: 'middle'
             halign: 'left'
             text_size: self.size
-            padding:[dp(0.0125)*app.width, 0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
 
         BoxLayout: 
             spacing: 0
-            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 20.0])
             orientation: 'vertical'
             size_hint_y: 7.81
              
@@ -85,12 +85,12 @@ Builder.load_string(
                 size: self.texture_size
                 text_size: self.size
                 color: hex('#333333ff')
-                font_size: str(0.05*app.width) + 'sp'
+                font_size: app.get_scaled_sp('40.0sp')
                 text: root.progress_value          
 
             Label:
                 id: filename_label
-                font_size: str(0.025*app.width) + 'sp'
+                font_size: app.get_scaled_sp('20.0sp')
                 size_hint_y: 0.5
                 markup: True
                 valign: 'top'
@@ -102,7 +102,7 @@ Builder.load_string(
                 
             Label:
                 id: warning_body_label
-                font_size: str(0.0275*app.width) + 'sp'
+                font_size: app.get_scaled_sp('22.0sp')
                 halign: 'center'
                 valign: 'center'
                 size_hint_y: 1.7
@@ -113,8 +113,8 @@ Builder.load_string(
 
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height, dp(0.025)*app.width, dp(0.0208333333333)*app.height]
-                spacing:0.075*app.width
+                padding: app.get_scaled_tuple([20.0, 10.0, 20.0, 10.0])
+                spacing: app.get_scaled_width(60.0)
                 size_hint_y: 3
 
                 Button:
@@ -128,8 +128,8 @@ Builder.load_string(
                     background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                     background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                     background_disabled_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                    border: [dp(30)]*4
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
+                    border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                    padding: app.get_scaled_tuple([30.0, 30.0])
                     on_press: root.quit_to_home()
 
                 Button:
@@ -144,8 +144,8 @@ Builder.load_string(
                     background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                     background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                     background_disabled_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                    border: [dp(30)]*4
-                    padding:[dp(0.0375)*app.width, dp(0.0625)*app.height]
+                    border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                    padding: app.get_scaled_tuple([30.0, 30.0])
 """
 )
 job_cache_dir = "./jobCache/"

--- a/src/asmcnc/skavaUI/screen_go.py
+++ b/src/asmcnc/skavaUI/screen_go.py
@@ -73,13 +73,13 @@ Builder.load_string(
         BoxLayout:
             size_hint_y: 0.92
             padding: 0
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
             orientation: "horizontal"
 
             BoxLayout:
                 size_hint_x: 0.9
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                spacing:0.025*app.width
+                padding: app.get_scaled_tuple([20.0, 20.0])
+                spacing: app.get_scaled_width(20.0)
                 orientation: "horizontal"
 
                 canvas:
@@ -92,11 +92,11 @@ Builder.load_string(
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 0.8
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
 
                     BoxLayout:
                         size_hint_y: 0.3
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                        padding: app.get_scaled_tuple([20.0, 20.0])
                         canvas:
                             Color:
                                 rgba: hex('#FFFFFFFF')
@@ -106,9 +106,9 @@ Builder.load_string(
                         BoxLayout:
                             orientation: 'horizontal'
                             padding: 0
-                            spacing:0.0125*app.width
+                            spacing: app.get_scaled_width(10.0)
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: btn_back
                                 size_hint_x: 1
                                 background_color: hex('#F4433600')
@@ -129,7 +129,7 @@ Builder.load_string(
                             Label:
                                 size_hint_x: 5
                                 text_size: self.size
-                                font_size: str(0.025*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('20.0sp')
                                 markup: True
                                 halign: 'center'
                                 valign: 'middle'
@@ -137,7 +137,7 @@ Builder.load_string(
                                 color: hex('#333333ff')
                                 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 id: stop_start
                                 size_hint_x: 1
                                 disabled: False
@@ -162,13 +162,13 @@ Builder.load_string(
                         id: override_and_progress_container
                         orientation: 'horizontal'
                         size_hint_y: 0.7
-                        padding:[dp(0.0)*app.width, dp(0.0)*app.height]
-                        spacing:0.0416666666667*app.height
+                        padding: app.get_scaled_tuple([0.0, 0.0])
+                        spacing: app.get_scaled_width(20.0)
 
                         BoxLayout:
                             orientation: 'vertical'
-                            padding:[0, 0, 0, dp(0.0104166666667)*app.height]
-                            spacing:0.0208333333333*app.height
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 5.0])
+                            spacing: app.get_scaled_width(10.0)
                             size_hint_x: 0.2
                             canvas:
                                 Color:
@@ -180,8 +180,8 @@ Builder.load_string(
                             BoxLayout:
                                 size_hint_y: 1.8
                                 orientation: 'vertical'
-                                padding:[dp(0.0)*app.width, dp(0.0)*app.height]
-                                spacing:0.0*app.height
+                                padding: app.get_scaled_tuple([0.0, 0.0])
+                                spacing: 0
                                 canvas:
                                     Color:
                                         rgba: hex('#FFFFFFFF')
@@ -213,8 +213,8 @@ Builder.load_string(
                         BoxLayout:
                             id: speed_override_container
                             orientation: 'vertical'
-                            padding:[0, 0, 0, dp(0.0104166666667)*app.height]
-                            spacing:0.0208333333333*app.height
+                            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 5.0])
+                            spacing: app.get_scaled_width(10.0)
                             size_hint_x: 0.2
                             canvas:
                                 Color:
@@ -226,8 +226,8 @@ Builder.load_string(
                             BoxLayout:
                                 size_hint_y: 1.8
                                 orientation: 'vertical'
-                                padding:[dp(0.0)*app.width, dp(0.0)*app.height]
-                                spacing:0.0*app.height
+                                padding: app.get_scaled_tuple([0.0, 0.0])
+                                spacing: 0
                                 canvas:
                                     Color:
                                         rgba: hex('#FFFFFFFF')
@@ -258,7 +258,7 @@ Builder.load_string(
                         BoxLayout:
                             size_hint_x: 0.8
                             orientation: 'vertical'
-                            spacing:0.0208333333333*app.height
+                            spacing: app.get_scaled_width(10.0)
                             
                             BoxLayout:
                                 id: yetipilot_container
@@ -276,8 +276,8 @@ Builder.load_string(
                                 id: job_progress_container
                                 size_hint_y: 2.5
                                 orientation: 'vertical'
-                                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                                spacing:0.0*app.height
+                                padding: app.get_scaled_tuple([20.0, 20.0])
+                                spacing: 0
 
                                 canvas:
                                     Color:
@@ -333,8 +333,8 @@ Builder.load_string(
                     id: spindle_widgets
                     orientation: 'vertical'
                     size_hint_x: 0.15
-                    padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                    spacing:0.0416666666667*app.height
+                    padding: app.get_scaled_tuple([20.0, 20.0])
+                    spacing: app.get_scaled_width(20.0)
 
                     canvas:
                         Color:
@@ -352,8 +352,8 @@ Builder.load_string(
                         id: spindle_overload_container
                         orientation: 'vertical'
                         size_hint_y: 0.25
-                        padding:[0, 0, 0, dp(-0.0208333333333)*app.height]
-                        spacing:0.0208333333333*app.height
+                        padding: app.get_scaled_tuple([0.0, 0.0, 0.0, -10.0])
+                        spacing: app.get_scaled_width(10.0)
  
                         Label:
                             id: spindle_overload_label

--- a/src/asmcnc/skavaUI/screen_help.py
+++ b/src/asmcnc/skavaUI/screen_help.py
@@ -48,7 +48,7 @@ Builder.load_string("""
                     root.quit_to_home()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding: 15
+                    padding: app.get_scaled_width(15.0)
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -61,7 +61,7 @@ Builder.load_string("""
 
         BoxLayout:
             size_hint_x: 8
-            padding: 10
+            padding: app.get_scaled_width(10.0)
             VideoPlayer:
                 id: video_player
 #                 state: "stop"

--- a/src/asmcnc/skavaUI/screen_home.py
+++ b/src/asmcnc/skavaUI/screen_home.py
@@ -64,13 +64,13 @@ Builder.load_string(
 
     BoxLayout:
         padding: 0
-        spacing:0.0208333333333*app.height
+        spacing: app.get_scaled_width(10.0)
         orientation: "vertical"
 
         BoxLayout:
             size_hint_y: 0.9
             padding: 0
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
             orientation: "horizontal"
 
             BoxLayout:
@@ -82,16 +82,16 @@ Builder.load_string(
                     pos_hint: {'center_x': .5, 'center_y': .5}
                     do_default_tab: False
                     tab_pos: 'left_top'
-                    tab_height: 0.1875*app.height
-                    tab_width: 0.1125*app.width
+                    tab_height: app.get_scaled_height(90.0)
+                    tab_width: app.get_scaled_width(90.0)
 
                     TabbedPanelItem:
                         background_normal: 'asmcnc/skavaUI/img/tab_set_normal.png'
                         background_down: 'asmcnc/skavaUI/img/tab_set_up.png'
                         on_press: root.m.laser_off()
                         BoxLayout:
-                            padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                            spacing:0.025*app.width
+                            padding: app.get_scaled_tuple([20.0, 20.0])
+                            spacing: app.get_scaled_width(20.0)
                             canvas:
                                 Color:
                                     rgba: hex('#E5E5E5FF')
@@ -110,8 +110,8 @@ Builder.load_string(
                         on_press: root.m.laser_on()
                         BoxLayout:
                             orientation: 'horizontal'
-                            padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                            spacing:0.025*app.width
+                            padding: app.get_scaled_tuple([20.0, 20.0])
+                            spacing: app.get_scaled_width(20.0)
                             canvas:
                                 Color:
                                     rgba: hex('#E5E5E5FF')
@@ -151,8 +151,8 @@ Builder.load_string(
                         on_press: root.m.laser_on()
                         BoxLayout:
                             orientation: 'vertical'
-                            padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                            spacing:0.0416666666667*app.height
+                            padding: app.get_scaled_tuple([20.0, 20.0])
+                            spacing: app.get_scaled_width(20.0)
                             canvas:
                                 Color:
                                     rgba: hex('#E5E5E5FF')
@@ -162,7 +162,7 @@ Builder.load_string(
 
                             BoxLayout:
                                 size_hint_y: 5
-                                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                                padding: app.get_scaled_tuple([10.0, 10.0])
                                 canvas:
                                     Color:
                                         rgba: 1,1,1,1
@@ -183,8 +183,8 @@ Builder.load_string(
                         id: home_tab
                         BoxLayout:
                             orientation: 'vertical'
-                            padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-                            spacing:0.0416666666667*app.height
+                            padding: app.get_scaled_tuple([20.0, 20.0])
+                            spacing: app.get_scaled_width(20.0)
                             id: job_container
                             canvas:
                                 Color:
@@ -195,8 +195,8 @@ Builder.load_string(
 
                             BoxLayout:
                                 size_hint_y: 1
-                                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-                                spacing:0.0125*app.width
+                                padding: app.get_scaled_tuple([10.0, 10.0])
+                                spacing: app.get_scaled_width(10.0)
                                 orientation: 'horizontal'
                                 canvas:
                                     Color:
@@ -206,7 +206,7 @@ Builder.load_string(
                                         pos: self.pos
 
                                 Button:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     size_hint_x: 1
                                     background_color: hex('#F4433600')
                                     on_press:
@@ -223,7 +223,7 @@ Builder.load_string(
                                             allow_stretch: True
 
                                 Button:
-                                    font_size: str(0.01875 * app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('15.0sp')
                                     id: job_recovery_button
                                     size_hint_x: 1
                                     background_color: hex('#F4433600')
@@ -245,7 +245,7 @@ Builder.load_string(
                                     id: file_data_label
                                     size_hint_x: 4
                                     text_size: self.size
-                                    font_size: str(0.025*app.width) + 'sp'
+                                    font_size: app.get_scaled_sp('20.0sp')
                                     markup: True
                                     text: '[color=333333]Load a file...[/color]'
                                     halign: 'center'
@@ -253,7 +253,7 @@ Builder.load_string(
 
                             BoxLayout:
                                 size_hint_y: 3
-                                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                                padding: app.get_scaled_tuple([20.0, 20.0])
                                 orientation: 'horizontal'
                                 canvas:
                                     Color:

--- a/src/asmcnc/skavaUI/screen_homing_active.py
+++ b/src/asmcnc/skavaUI/screen_homing_active.py
@@ -30,20 +30,20 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([40.0, 40.0])
         orientation: 'vertical'
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.025*app.width
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 1.5
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.windows_cheat_to_procede()
@@ -67,7 +67,7 @@ Builder.load_string(
                 color: hex('#333333ff')
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.stop_button_press()
@@ -80,7 +80,7 @@ Builder.load_string(
                         allow_stretch: True 
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1                
 
 """

--- a/src/asmcnc/skavaUI/screen_homing_decision.py
+++ b/src/asmcnc/skavaUI/screen_homing_decision.py
@@ -30,27 +30,27 @@ Builder.load_string(
 
     BoxLayout:
         spacing: 0
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([40.0, 40.0])
         orientation: 'vertical'
 
         # Cancel button
         BoxLayout:
             size_hint: (None,None)
-            height: dp(0.0416666666667*app.height)
-            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
-            spacing:0.85*app.width
+            height: app.get_scaled_height(20.0)
+            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
+            spacing: app.get_scaled_width(680.0)
             orientation: 'horizontal'
             pos: self.parent.pos
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: ""
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.104166666667*app.height)
-                width: dp(0.0625*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(50.0)
                 background_color: hex('#FFFFFF00')
                 opacity: 1
                 on_press: root.cancel()
@@ -66,13 +66,13 @@ Builder.load_string(
                         allow_stretch: True
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 0.1
 
         BoxLayout:
             orientation: 'vertical'
-            spacing:0.0208333333333*app.height
-            padding:[0, dp(0.0416666666667)*app.height, 0, dp(0.0416666666667)*app.height]
+            spacing: app.get_scaled_width(10.0)
+            padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 20.0])
             size_hint_y: 3
 
 
@@ -100,7 +100,7 @@ Builder.load_string(
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0375*app.width
+            spacing: app.get_scaled_width(30.0)
             size_hint_y: 3
 
             Button:
@@ -114,11 +114,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 0.3
                 background_color: hex('#FFFFFF00')
                 on_press: root.popup_help()
@@ -141,11 +141,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: .5
 
 """

--- a/src/asmcnc/skavaUI/screen_homing_prepare.py
+++ b/src/asmcnc/skavaUI/screen_homing_prepare.py
@@ -31,27 +31,27 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([20.0, 40.0])
         orientation: 'vertical'
 
         # Cancel button
         BoxLayout:
             size_hint: (None,None)
-            height: dp(0.0416666666667*app.height)
-            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
-            spacing:0.85*app.width
+            height: app.get_scaled_height(20.0)
+            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
+            spacing: app.get_scaled_width(680.0)
             orientation: 'horizontal'
             pos: self.parent.pos
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: ""
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.104166666667*app.height)
-                width: dp(0.0625*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(50.0)
                 background_color: hex('#FFFFFF00')
                 opacity: 1
                 on_press: root.cancel()
@@ -92,7 +92,7 @@ Builder.load_string(
         #     size_hint_y: 0.1                
 
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 4.9
             background_color: hex('#FFFFFF00')
             on_press: root.begin_homing()
@@ -105,7 +105,7 @@ Builder.load_string(
                     allow_stretch: True 
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1                
 
 """

--- a/src/asmcnc/skavaUI/screen_job_feedback.py
+++ b/src/asmcnc/skavaUI/screen_job_feedback.py
@@ -29,8 +29,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#e5e5e5ff')
@@ -55,11 +55,11 @@ Builder.load_string(
                 Label:
                     id: job_completed_label
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Job completed!"
                     color: hex('#f9f9f9ff')
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "middle"
                     markup: True
@@ -67,18 +67,18 @@ Builder.load_string(
             # BODY
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.875*app.height)
-                padding:[0, dp(0.0208333333333)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(420.0)
+                padding: app.get_scaled_tuple([0.0, 10.0])
                 spacing: 0
                 orientation: 'vertical'
                 
                 # METADATA AND PRODUCTION NOTES
                 BoxLayout:
                     size_hint_y: None
-                    height: dp(0.270833333333*app.height)
+                    height: app.get_scaled_height(130.0)
                     orientation: 'horizontal'
-                    padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 10.0])
                     
                     BoxLayout:
                         orientation: 'vertical'
@@ -86,9 +86,9 @@ Builder.load_string(
                         Label: 
                             id: metadata_label
                             size_hint_y: None
-                            height: dp(0.1875*app.height)
+                            height: app.get_scaled_height(90.0)
                             color: hex('#333333ff') #grey
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             text_size: self.size
                             halign: "left"
@@ -97,13 +97,13 @@ Builder.load_string(
                         BoxLayout:
                             id: parts_completed_container
                             size_hint_y: None
-                            height: dp(0.0625*app.height)
+                            height: app.get_scaled_height(30.0)
                             orientation: 'horizontal'
 
                             Label: 
                                 id: parts_completed_label
                                 color: hex('#333333ff') #grey
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -117,15 +117,15 @@ Builder.load_string(
                         BoxLayout: 
                             id: batch_number_container
                             size_hint_y: None
-                            height: dp(0.0854166666667*app.height)
+                            height: app.get_scaled_height(41.0)
                             orientation: 'horizontal'
-                            padding:[0, dp(0.0229166666667)*app.height, 0, 0]
+                            padding: app.get_scaled_tuple([0.0, 11.0, 0.0, 0.0])
 
                             Label:
                                 id: batch_number_label
                                 size_hint_x: 0.45
                                 color: hex('#333333ff') #grey
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 halign: "left"
                                 valign: "bottom"
                                 markup: True
@@ -136,16 +136,16 @@ Builder.load_string(
                                 size_hint_x: 0.55
                                 TextInput:
                                     id: batch_number_input
-                                    padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                                    padding: app.get_scaled_tuple([4.0, 2.0])
                                     color: hex('#333333ff')
                                     # foreground_color: hex('#333333ff')
                                     text_size: self.size
                                     size_hint_x: 1
-                                    width: dp(0.125*app.width)
+                                    width: app.get_scaled_width(100.0)
                                     halign: "left"
                                     valign: "bottom"
                                     markup: True
-                                    font_size: dp(0.025*app.width)
+                                    font_size: app.get_scaled_width(20.0)
                                     multiline: False
                                     background_color: hex('#e5e5e5ff')
 
@@ -154,7 +154,7 @@ Builder.load_string(
                             id: post_production_notes_label
                             text: "Production notes"
                             color: hex('#333333ff') #grey
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             halign: "left"
                             valign: "top"
                             markup: True
@@ -163,8 +163,8 @@ Builder.load_string(
                         TextInput:
                             id: post_production_notes
                             size_hint_y: None
-                            height: dp(0.116666666667*app.height)
-                            padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                            height: app.get_scaled_height(56.0)
+                            padding: app.get_scaled_tuple([4.0, 2.0])
                             text: ""
                             color: hex('#333333ff')
                             # foreground_color: hex('#333333ff')
@@ -172,7 +172,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "top"
                             markup: True
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             multiline: True
                             background_color: hex('#e5e5e5ff')
 
@@ -180,12 +180,12 @@ Builder.load_string(
                 Label:
                     id: success_question
                     size_hint: (None,None)
-                    height: dp(0.0625*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(30.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Did this complete successfully?"
                     # color: hex('#f9f9f9ff')
                     color: hex('#333333ff') #grey
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
@@ -193,25 +193,25 @@ Builder.load_string(
                 # Feedback buttons
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.5*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(240.0)
+                    width: app.get_scaled_width(800.0)
                     orientation: 'vertical'
-                    padding:[0, dp(0.0416666666667)*app.height, 0, 0]
+                    padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 0.0])
 
                     BoxLayout:
                         size_hint: (None,None)
-                        height: dp(0.416666666667*app.height)
-                        width: dp(1.0*app.width)
+                        height: app.get_scaled_height(200.0)
+                        width: app.get_scaled_width(800.0)
                         orientation: 'horizontal'
-                        spacing:dp(0.12)*app.width
-                        padding:[dp(0.1875)*app.width, 0]
+                        spacing: app.get_scaled_width(96.0)
+                        padding: app.get_scaled_tuple([150.0, 0.0])
 
                         # Thumbs down button
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.416666666667*app.height)
-                            width: dp(0.2525*app.width)
+                            height: app.get_scaled_height(200.0)
+                            width: app.get_scaled_width(202.0)
                             background_color: hex('#e5e5e5ff')
                             background_normal: ""
                             on_press: root.confirm_job_unsuccessful()
@@ -226,10 +226,10 @@ Builder.load_string(
                                     allow_stretch: True
                         # Thumbs up button
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             size_hint: (None,None)
-                            height: dp(0.416666666667*app.height)
-                            width: dp(0.2525*app.width)
+                            height: app.get_scaled_height(200.0)
+                            width: app.get_scaled_width(202.0)
                             background_color: hex('#e5e5e5ff')
                             background_normal: ""
                             on_press: root.confirm_job_successful()
@@ -250,7 +250,7 @@ Builder.load_string(
                         halign: 'center'
                         vallign: 'middle'
                         color: hex('#333333ff')
-                        font_size: dp(0.0225*app.width)
+                        font_size: app.get_scaled_width(18.0)
 
 """
 )

--- a/src/asmcnc/skavaUI/screen_job_incomplete.py
+++ b/src/asmcnc/skavaUI/screen_job_incomplete.py
@@ -34,8 +34,8 @@ Builder.load_string(
     on_touch_down: root.on_touch()
 
     BoxLayout:
-        height: dp(1.66666666667*app.height)
-        width: dp(0.6*app.width)
+        height: app.get_scaled_height(800.0)
+        width: app.get_scaled_width(480.0)
         canvas.before:
             Color: 
                 rgba: hex('#e5e5e5ff')
@@ -60,10 +60,10 @@ Builder.load_string(
                 Label:
                     id: job_incomplete_label
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     color: hex('#f9f9f9ff')
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "middle"
                     markup: True
@@ -71,18 +71,18 @@ Builder.load_string(
             # BODY
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.875*app.height)
-                padding:[0, dp(0.0208333333333)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(420.0)
+                padding: app.get_scaled_tuple([0.0, 10.0])
                 spacing: 0
                 orientation: 'vertical'
                 
                 # METADATA AND PRODUCTION NOTES
                 BoxLayout:
                     size_hint_y: None
-                    height: dp(0.270833333333*app.height)
+                    height: app.get_scaled_height(130.0)
                     orientation: 'horizontal'
-                    padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 10.0])
 
                     BoxLayout:
                         orientation: 'vertical'
@@ -90,9 +90,9 @@ Builder.load_string(
                         Label: 
                             id: metadata_label
                             size_hint_y: None
-                            height: dp(0.1875*app.height)
+                            height: app.get_scaled_height(90.0)
                             color: hex('#333333ff') #grey
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             markup: True
                             text_size: self.size
                             halign: "left"
@@ -101,14 +101,14 @@ Builder.load_string(
                         BoxLayout:
                             id: parts_completed_container
                             size_hint_y: None
-                            height: dp(0.0625*app.height)
+                            height: app.get_scaled_height(30.0)
                             orientation: 'horizontal'
 
                             Label: 
                                 id: parts_completed_label
                                 size_hint_x: None
                                 color: hex('#333333ff') #grey
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -116,15 +116,15 @@ Builder.load_string(
 
                             TextInput:
                                 id: parts_completed_input
-                                padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                                padding: app.get_scaled_tuple([4.0, 2.0])
                                 size_hint_x: None
-                                width: dp(0.0625*app.width)
+                                width: app.get_scaled_width(50.0)
                                 color: hex('#333333ff')
                                 text_size: self.size
                                 halign: "left"
                                 valign: "top"
                                 markup: True
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 multiline: False
                                 background_color: hex('#e5e5e5ff')
                                 input_filter: 'int'
@@ -133,7 +133,7 @@ Builder.load_string(
                                 id: out_of_total_parts_label
                                 size_hint_x: None
                                 color: hex('#333333ff') #grey
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 markup: True
                                 halign: "left"
                                 valign: "top"
@@ -146,15 +146,15 @@ Builder.load_string(
                         BoxLayout: 
                             id: batch_number_container
                             size_hint_y: None
-                            height: dp(0.0854166666667*app.height)
+                            height: app.get_scaled_height(41.0)
                             orientation: 'horizontal'
-                            padding:[0, dp(0.0229166666667)*app.height, 0, 0]
+                            padding: app.get_scaled_tuple([0.0, 11.0, 0.0, 0.0])
 
                             Label:
                                 id: batch_number_label
                                 size_hint_x: 0.45
                                 color: hex('#333333ff') #grey
-                                font_size: dp(0.025*app.width)
+                                font_size: app.get_scaled_width(20.0)
                                 halign: "left"
                                 valign: "bottom"
                                 markup: True
@@ -165,16 +165,16 @@ Builder.load_string(
                                 size_hint_x: 0.55
                                 TextInput:
                                     id: batch_number_input
-                                    padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                                    padding: app.get_scaled_tuple([4.0, 2.0])
                                     color: hex('#333333ff')
                                     # foreground_color: hex('#333333ff')
                                     text_size: self.size
                                     size_hint_x: 1
-                                    width: dp(0.125*app.width)
+                                    width: app.get_scaled_width(100.0)
                                     halign: "left"
                                     valign: "bottom"
                                     markup: True
-                                    font_size: dp(0.025*app.width)
+                                    font_size: app.get_scaled_width(20.0)
                                     multiline: False
                                     background_color: hex('#e5e5e5ff')
 
@@ -183,7 +183,7 @@ Builder.load_string(
                             id: post_production_notes_label
                             text: "Production notes"
                             color: hex('#333333ff') #grey
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             halign: "left"
                             valign: "top"
                             markup: True
@@ -192,8 +192,8 @@ Builder.load_string(
                         TextInput:
                             id: post_production_notes
                             size_hint_y: None
-                            height: dp(0.116666666667*app.height)
-                            padding:[dp(0.005)*app.width, dp(0.00416666666667)*app.height]
+                            height: app.get_scaled_height(56.0)
+                            padding: app.get_scaled_tuple([4.0, 2.0])
                             text: ""
                             color: hex('#333333ff')
                             # foreground_color: hex('#333333ff')
@@ -201,7 +201,7 @@ Builder.load_string(
                             halign: "left"
                             valign: "top"
                             markup: True
-                            font_size: dp(0.025*app.width)
+                            font_size: app.get_scaled_width(20.0)
                             multiline: True
                             background_color: hex('#e5e5e5ff')
 
@@ -209,11 +209,11 @@ Builder.load_string(
                 Label:
                     id: job_cancelled_label
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     # color: hex('#f9f9f9ff')
                     color: hex('#333333ff') #grey
-                    font_size: dp(0.0375*app.width)
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
@@ -221,62 +221,62 @@ Builder.load_string(
                 # Event details
                 BoxLayout:
                     size_hint: (None,None)
-                    height: dp(0.4375*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(210.0)
+                    width: app.get_scaled_width(800.0)
                     orientation: 'vertical'
                     spacing: 0
-                    padding:[0, 0]
+                    padding: app.get_scaled_tuple([0.0, 0.0])
 
                     Label: 
                         id: event_details_label
-                        padding:[dp(0.025)*app.width, 0]
+                        padding: app.get_scaled_tuple([20.0, 0.0])
                         color: hex('#333333ff') #grey
                         text_size: self.size
                         halign: "left"
                         valign: "middle"
                         markup: True
-                        font_size: dp(0.025*app.width)
+                        font_size: app.get_scaled_width(20.0)
 
                     # Buttons
                     BoxLayout: 
-                        padding:[dp(0.0125)*app.width, 0, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        padding: app.get_scaled_tuple([10.0, 0.0, 10.0, 10.0])
                         size_hint: (None, None)
-                        height: dp(0.185416666667*app.height)
-                        width: dp(1.0*app.width)
+                        height: app.get_scaled_height(89.0)
+                        width: app.get_scaled_width(800.0)
                         orientation: 'horizontal'
                         BoxLayout: 
                             size_hint: (None, None)
-                            height: dp(0.164583333333*app.height)
-                            width: dp(0.305625*app.width)
-                            padding:[0, 0, dp(0.230625)*app.width, 0]
+                            height: app.get_scaled_height(79.0)
+                            width: app.get_scaled_width(244.5)
+                            padding: app.get_scaled_tuple([0.0, 0.0, 184.5, 0.0])
 
                         BoxLayout: 
                             size_hint: (None, None)
-                            height: dp(0.164583333333*app.height)
-                            width: dp(0.36375*app.width)
-                            # padding: [0,0,0,dp(52)]
+                            height: app.get_scaled_height(79.0)
+                            width: app.get_scaled_width(291.0)
+                            # padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 52.0])
                             Button:
                                 id: next_button
                                 background_normal: "./asmcnc/skavaUI/img/next.png"
                                 background_down: "./asmcnc/skavaUI/img/next.png"
                                 background_disabled_down: "./asmcnc/skavaUI/img/next.png"
                                 background_disabled_normal: "./asmcnc/skavaUI/img/next.png"
-                                border: [dp(14.5)]*4
+                                border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
                                 size_hint: (None,None)
-                                width: dp(0.36375*app.width)
-                                height: dp(0.164583333333*app.height)
+                                width: app.get_scaled_width(291.0)
+                                height: app.get_scaled_height(79.0)
                                 on_press: root.press_ok()
                                 text: 'OK'
-                                font_size: str(0.03375*app.width) + 'sp'
+                                font_size: app.get_scaled_sp('27.0sp')
                                 color: hex('#f9f9f9ff')
                                 markup: True
                                 center: self.parent.center
                                 pos: self.parent.pos
                         BoxLayout: 
                             size_hint: (None, None)
-                            height: dp(0.164583333333*app.height)
-                            width: dp(0.305625*app.width)
-                            padding:[dp(0.241875)*app.width, 0, 0, 0]
+                            height: app.get_scaled_height(79.0)
+                            width: app.get_scaled_width(244.5)
+                            padding: app.get_scaled_tuple([193.5, 0.0, 0.0, 0.0])
  
 """
 )

--- a/src/asmcnc/skavaUI/screen_job_recovery.py
+++ b/src/asmcnc/skavaUI/screen_job_recovery.py
@@ -35,7 +35,7 @@ Builder.load_string(
         BoxLayout:
             orientation: 'horizontal'
             size_hint_y: 0.9
-            spacing:dp(0.01875)*app.width
+            spacing: app.get_scaled_width(15.0)
             canvas:
                 Color:
                     rgba: hex('#E2E2E2FF')
@@ -44,16 +44,16 @@ Builder.load_string(
                     pos: self.pos
 
             BoxLayout:
-                padding:[dp(0.01875)*app.width, dp(0.03125)*app.height, 0, dp(0.03125)*app.height]
+                padding: app.get_scaled_tuple([15.0, 15.0, 0.0, 15.0])
 
                 BoxLayout:
                     orientation: 'vertical'
-                    spacing:dp(0.03125)*app.height
+                    spacing: app.get_scaled_width(15.0)
 
                     BoxLayout:
                         orientation: 'vertical'
                         size_hint_y: 3.5
-                        spacing:dp(0.03125)*app.height
+                        spacing: app.get_scaled_width(15.0)
 
                         BoxLayout:
                             orientation: 'vertical'
@@ -63,10 +63,10 @@ Builder.load_string(
                                 text: "Go to line:"
                                 color: hex('#333333FF')
                                 bold: True
-                                font_size: dp(0.03125*app.width)
+                                font_size: app.get_scaled_width(25.0)
 
                             BoxLayout:
-                                padding:[0, dp(0.00833333333333)*app.height, 0, 0]
+                                padding: app.get_scaled_tuple([0.0, 4.0, 0.0, 0.0])
                                 canvas:
                                     Color:
                                         rgba: 1,1,1,1
@@ -76,7 +76,7 @@ Builder.load_string(
 
                                 TextInput:
                                     id: line_input
-                                    font_size: dp(0.03125*app.width)
+                                    font_size: app.get_scaled_width(25.0)
                                     halign: 'center'
                                     input_filter: 'int'
                                     multiline: False
@@ -86,11 +86,11 @@ Builder.load_string(
                         BoxLayout:
                             orientation: 'vertical'
                             size_hint_y: 2
-                            padding:[dp(0.0625)*app.width, 0]
-                            spacing:dp(0.0208333333333)*app.height
+                            padding: app.get_scaled_tuple([50.0, 0.0])
+                            spacing: app.get_scaled_width(10.0)
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 background_color: [0,0,0,0]
                                 on_press:
                                     root.start_scrolling_up()
@@ -110,7 +110,7 @@ Builder.load_string(
                                         allow_stretch: True
 
                             Button:
-                                font_size: str(0.01875 * app.width) + 'sp'
+                                font_size: app.get_scaled_sp('15.0sp')
                                 background_color: [0,0,0,0]
                                 on_press:
                                     root.start_scrolling_down()
@@ -134,7 +134,7 @@ Builder.load_string(
                         valign: "middle"
                         halign: "center"
                         markup: True
-                        font_size: dp(0.0375*app.width)
+                        font_size: app.get_scaled_width(30.0)
                         text_size: self.size[0] - dp(20), self.size[1]
                         text: "GO XY"
                         background_normal: "./asmcnc/skavaUI/img/blank_small_button.png"
@@ -143,17 +143,17 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint_x: 2
-                padding:[0, dp(0.03125)*app.height]
+                padding: app.get_scaled_tuple([0.0, 15.0])
 
                 BoxLayout:
                     orientation: 'vertical'
-                    spacing:dp(0.03125)*app.height
+                    spacing: app.get_scaled_width(15.0)
 
                     BoxLayout:
                         id: gcode_container
                         orientation: 'vertical'
                         size_hint_y: 3.5
-                        padding:[dp(0.015)*app.width, dp(0.025)*app.height, dp(0.015)*app.width, 0]
+                        padding: app.get_scaled_tuple([12.0, 12.0, 12.0, 0.0])
                         canvas:
                             Color:
                                 rgba: 1,1,1,1
@@ -165,7 +165,7 @@ Builder.load_string(
                             Label:
                                 id: gcode_label
                                 color: 0,0,0,1
-                                font_size: dp(0.02*app.width)
+                                font_size: app.get_scaled_width(16.0)
                                 halign: "left"
                                 valign: "top"
                                 text_size: self.size[0] * 2, self.size[1]
@@ -184,7 +184,7 @@ Builder.load_string(
                             id: stopped_on_label
                             size_hint_y: 0.13
                             color: 1,0,0,1
-                            font_size: dp(0.02*app.width)
+                            font_size: app.get_scaled_width(16.0)
                             halign: "left"
                             valign: "top"
                             text_size: self.size
@@ -193,8 +193,8 @@ Builder.load_string(
 
                     BoxLayout:
                         orientation: 'vertical'
-                        padding:[dp(0.015)*app.width, dp(0.025)*app.height]
-                        spacing:dp(0.0145833333333)*app.height
+                        padding: app.get_scaled_tuple([12.0, 12.0])
+                        spacing: app.get_scaled_width(7.0)
                         canvas:
                             Color:
                                 rgba: 1,1,1,1
@@ -207,7 +207,7 @@ Builder.load_string(
                             text: "Job resumes at:"
                             color: hex('#333333FF')
                             bold: True
-                            font_size: dp(0.01875*app.width)
+                            font_size: app.get_scaled_width(15.0)
                             halign: 'left'
                             valign: 'middle'
                             text_size: self.size
@@ -216,7 +216,7 @@ Builder.load_string(
                             id: pos_label
                             text: "wX: | wY: | wZ:"
                             color: 0,0,0,1
-                            font_size: dp(0.02*app.width)
+                            font_size: app.get_scaled_width(16.0)
                             halign: 'left'
                             valign: 'middle'
                             text_size: self.size
@@ -225,23 +225,23 @@ Builder.load_string(
                             id: speed_label
                             text: "F: | S:"
                             color: 0,0,0,1
-                            font_size: dp(0.02*app.width)
+                            font_size: app.get_scaled_width(16.0)
                             halign: 'left'
                             valign: 'middle'
                             text_size: self.size
 
             BoxLayout:
                 orientation: 'vertical'
-                spacing:dp(0.03125)*app.height
+                spacing: app.get_scaled_width(15.0)
 
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing:dp(0.03125)*app.width
+                    spacing: app.get_scaled_width(25.0)
 
                     BoxLayout:
-                        padding:[dp(0.01875)*app.width, dp(0.03125)*app.height, 0, dp(0.03125)*app.height]
+                        padding: app.get_scaled_tuple([15.0, 15.0, 0.0, 15.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             background_color: [0,0,0,0]
                             on_press: root.get_info()
                             BoxLayout:
@@ -255,7 +255,7 @@ Builder.load_string(
                                     allow_stretch: True   
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         background_color: [0,0,0,0]
                         on_press: root.back_to_home()
                         BoxLayout:
@@ -271,8 +271,8 @@ Builder.load_string(
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_y: 4
-                    padding:[0, 0, dp(0.01875)*app.width, dp(0.03125)*app.height]
-                    spacing:dp(0.03125)*app.height
+                    padding: app.get_scaled_tuple([0.0, 0.0, 15.0, 15.0])
+                    spacing: app.get_scaled_width(15.0)
 
                     BoxLayout:
                         id: z_move_container
@@ -286,15 +286,15 @@ Builder.load_string(
 
                     BoxLayout:
 
-                        padding:[0, dp(0.00208333333333)*app.height]
+                        padding: app.get_scaled_tuple([0.0, 1.0])
 
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             background_color: [0,0,0,0]
                             on_press: root.next_screen()
                             size_hint: (None, None)
-                            height: dp(0.139583333333*app.height)
-                            width: dp(0.11*app.width)
+                            height: app.get_scaled_height(67.0)
+                            width: app.get_scaled_width(88.0)
                             BoxLayout:
                                 size: self.parent.size
                                 pos: self.parent.pos
@@ -321,7 +321,7 @@ Builder.load_string(
             Label:
                 id: arc_movement_error_label
                 color: 1,0,0,1
-                font_size: dp(0.0175*app.width)
+                font_size: app.get_scaled_width(14.0)
                 halign: "left"
                 valign: "top"
                 text_size: self.size

--- a/src/asmcnc/skavaUI/screen_jobstart_warning.py
+++ b/src/asmcnc/skavaUI/screen_jobstart_warning.py
@@ -36,8 +36,8 @@ Builder.load_string(
     confirm_button : confirm_button
 
     BoxLayout:
-        height: dp(1.0*app.height)
-        width: dp(1.0*app.width)
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
         canvas.before:
             Color: 
                 rgba: hex('#E5E5E5FF')
@@ -48,7 +48,7 @@ Builder.load_string(
         BoxLayout:
             padding: 0
             orientation: "vertical"
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
 
             BoxLayout:
                 padding: 0
@@ -62,11 +62,11 @@ Builder.load_string(
                 Label:
                     id: header_label
                     size_hint: (None,None)
-                    height: dp(0.125*app.height)
-                    width: dp(1.0*app.width)
+                    height: app.get_scaled_height(60.0)
+                    width: app.get_scaled_width(800.0)
                     text: "Safety Warning"
                     color: hex('#f9f9f9ff')
-                    font_size: 0.0375*app.width
+                    font_size: app.get_scaled_width(30.0)
                     halign: "center"
                     valign: "bottom"
                     markup: True
@@ -74,18 +74,18 @@ Builder.load_string(
                     
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.666666666667*app.height)
-                padding:[dp(0.025)*app.width, dp(0.0208333333333)*app.height, dp(0.025)*app.width, 0]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(320.0)
+                padding: app.get_scaled_tuple([20.0, 10.0, 20.0, 0.0])
                 spacing: 0
                 orientation: 'vertical'
              
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing:0.0125*app.width
+                    spacing: app.get_scaled_width(10.0)
                     size_hint_y: 1.22
                     BoxLayout:
-                        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                        padding: app.get_scaled_tuple([20.0, 20.0])
                         size_hint_x: 0.2
                         Image:
                             keep_ratio: True
@@ -95,13 +95,13 @@ Builder.load_string(
                     BoxLayout:
                         orientation: 'vertical'
                         size_hint_x: 0.8
-                        padding:[0, 0, dp(0.025)*app.width, 0]
+                        padding: app.get_scaled_tuple([0.0, 0.0, 20.0, 0.0])
                         Label:
                             id: risk_of_fire
                             size_hint_y: 0.2
                             markup: True
                             halign: 'left'
-                            font_size: str(0.04*app.width) + 'sp' 
+                            font_size: app.get_scaled_sp('32.0sp')
                             markup: True
                             valign: 'top'
                             size:self.texture_size
@@ -118,7 +118,7 @@ Builder.load_string(
                             text_size: self.size
                             color: hex('#333333FF')
                             markup: True
-                            font_size: str(0.025*app.width) + 'sp' 
+                            font_size: app.get_scaled_sp('20.0sp')
 
                 BoxLayout:
                     orientation: 'horizontal'
@@ -127,7 +127,7 @@ Builder.load_string(
 
                     BoxLayout:
                         orientation: 'horizontal'
-                        spacing:0.0125*app.width
+                        spacing: app.get_scaled_width(10.0)
                         size_hint_x: 0.75
 
                         BoxLayout:
@@ -144,7 +144,7 @@ Builder.load_string(
                                 id: never_unattended
                                 markup: True
                                 halign: 'left'
-                                font_size: str(0.04*app.width) + 'sp' 
+                                font_size: app.get_scaled_sp('32.0sp')
                                 markup: True
                                 size:self.size
                                 valign: 'middle'
@@ -167,7 +167,7 @@ Builder.load_string(
                             size_hint_y: 0.18
                             markup: True
                             halign: 'center'
-                            font_size: str(0.0275*app.width) + 'sp' 
+                            font_size: app.get_scaled_sp('22.0sp')
                             markup: True
                             size:self.size
                             valign: 'middle'
@@ -178,9 +178,9 @@ Builder.load_string(
 
             BoxLayout:
                 size_hint: (None,None)
-                width: dp(1.0*app.width)
-                height: dp(0.166666666667*app.height)
-                padding:[dp(0.3125)*app.width, 0, dp(0.3125)*app.width, dp(0.0208333333333)*app.height]
+                width: app.get_scaled_width(800.0)
+                height: app.get_scaled_height(80.0)
+                padding: app.get_scaled_tuple([250.0, 0.0, 250.0, 10.0])
                 orientation: 'horizontal'
 
                 Button:
@@ -189,10 +189,10 @@ Builder.load_string(
                     on_press: root.continue_to_go_screen()
                     background_normal: "./asmcnc/skavaUI/img/next.png"
                     background_down: "./asmcnc/skavaUI/img/next.png"
-                    border: [dp(14.5)]*4
-                    width: dp(0.36375*app.width)
-                    height: dp(0.164583333333*app.height)
-                    font_size: str(0.035*app.width) + 'sp'
+                    border: app.get_scaled_tuple([14.5, 14.5, 14.5, 14.5])
+                    width: app.get_scaled_width(291.0)
+                    height: app.get_scaled_height(79.0)
+                    font_size: app.get_scaled_sp('28.0sp')
                     color: hex('#f9f9f9ff')
                     markup: True
                     center: self.parent.center

--- a/src/asmcnc/skavaUI/screen_lift_z_on_pause_decision.py
+++ b/src/asmcnc/skavaUI/screen_lift_z_on_pause_decision.py
@@ -34,7 +34,7 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         orientation: 'vertical'
 
         Label:
@@ -50,8 +50,8 @@ Builder.load_string(
     
         BoxLayout:
             orientation: 'horizontal'
-            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
-            spacing:0.05*app.width
+            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
+            spacing: app.get_scaled_width(40.0)
             size_hint_y: 3
 
             Button:
@@ -65,11 +65,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 0.3
                 background_color: hex('#FFFFFF00')
                 on_press: root.popup_help()
@@ -92,11 +92,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: .5                
 
 """

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -64,7 +64,7 @@ Builder.load_string("""
 
         BoxLayout:
             size_hint_y: 70
-            padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height, dp(0.9175)*app.width, 0]
+            padding: app.get_scaled_tuple([10.0, 10.0, 734.0, 0.0])
             orientation: 'horizontal'
 
         Carousel:
@@ -75,17 +75,17 @@ Builder.load_string("""
             BoxLayout:
                 id: carousel_pane_1
                 orientation: 'horizontal'
-                padding:[dp(0.125)*app.width, dp(0.0416666666667)*app.height, dp(0.125)*app.width, dp(0.104166666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([100.0, 20.0, 100.0, 50.0])
+                spacing: app.get_scaled_width(20.0)
 
                 BoxLayout:
                     id: pro_app_container
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -108,7 +108,7 @@ Builder.load_string("""
                     Label:
                         id: pro_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'CAD / CAM'
 
 
@@ -117,10 +117,10 @@ Builder.load_string("""
                     id: shapecutter_container
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
                                              
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         
                         disabled: False
                         size_hint_y: 8
@@ -144,17 +144,17 @@ Builder.load_string("""
                     Label:
                         id: shapecutter_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Shape Cutter'
 
                 BoxLayout:
                     id: yeti_cut_apps_container
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
                                              
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         disabled: False
                         size_hint_y: 8
                         background_color: hex('#FFFFFF00')
@@ -171,18 +171,18 @@ Builder.load_string("""
                                 allow_stretch: True 
                     Label:
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'YetiCut'
 
                 BoxLayout:
                     id: drywall_app_container
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
-                    padding:[dp(0.08125)*app.width, 0]
+                    spacing: app.get_scaled_width(20.0)
+                    padding: app.get_scaled_tuple([65.0, 0.0])
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -203,7 +203,7 @@ Builder.load_string("""
                                 allow_stretch: True
                     Label:
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Drywall cutter'
                         markup: True
 
@@ -211,16 +211,16 @@ Builder.load_string("""
             # Carousel pane 2
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.125)*app.width, dp(0.0416666666667)*app.height, dp(0.125)*app.width, dp(0.104166666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([100.0, 20.0, 100.0, 50.0])
+                spacing: app.get_scaled_width(20.0)
 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -243,17 +243,17 @@ Builder.load_string("""
                     Label:
                         id: wifi_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Wi-Fi'
                 
                 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -276,23 +276,23 @@ Builder.load_string("""
                     Label:
                         id: calibrate_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Calibrate'
                         markup: True
 
             # Carousel pane 3
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.125)*app.width, dp(0.0416666666667)*app.height, dp(0.125)*app.width, dp(0.104166666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([100.0, 20.0, 100.0, 50.0])
+                spacing: app.get_scaled_width(20.0)
 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -315,17 +315,17 @@ Builder.load_string("""
                     Label:
                         id: update_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Update'
                 
                 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -348,23 +348,23 @@ Builder.load_string("""
                     Label:
                         id: maintenance_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Maintenance'
 
             # Carousel pane 4
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.125)*app.width, dp(0.0416666666667)*app.height, dp(0.125)*app.width, dp(0.104166666667)*app.height]
-                spacing:0.0416666666667*app.height
+                padding: app.get_scaled_tuple([100.0, 20.0, 100.0, 50.0])
+                spacing: app.get_scaled_width(20.0)
 
                 BoxLayout:
                     id: upgrade_app_container
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -387,17 +387,17 @@ Builder.load_string("""
                     Label:
                         id: upgrade_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'Upgrade'
                         markup: True
 
                 BoxLayout:
                     orientation: 'vertical'
                     size_hint_x: 1
-                    spacing:0.0416666666667*app.height
+                    spacing: app.get_scaled_width(20.0)
                 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         size_hint_y: 8
                         disabled: False
                         background_color: hex('#FFFFFF00')
@@ -420,7 +420,7 @@ Builder.load_string("""
                     Label:
                         id: system_tools_app_label
                         size_hint_y: 1
-                        font_size: str(0.03125*app.width) + 'sp'
+                        font_size: app.get_scaled_sp('25.0sp')
                         text: 'System Tools'
                         markup: True
 
@@ -438,13 +438,13 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint_x: None
-                width: 0.9*app.width
+                width: app.get_scaled_width(720.0)
                 height: self.parent.height
-                padding:[dp(0.1)*app.width, dp(0.0833333333333)*app.height, 0, dp(0.0833333333333)*app.height]
+                padding: app.get_scaled_tuple([80.0, 40.0, 0.0, 40.0])
                 orientation: 'horizontal'
                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     disabled: False
                     size_hint_y: 1
                     background_color: hex('#FFFFFF00')
@@ -464,11 +464,11 @@ Builder.load_string("""
                             size: self.parent.width, self.parent.height
                             allow_stretch: True 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 0.8
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: shutdown_button
                     size_hint_y: 1
                     background_color: hex('#FFFFFF00')
@@ -486,11 +486,11 @@ Builder.load_string("""
                             allow_stretch: True
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 0.8
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: load_button
                     disabled: False
                     size_hint_y: 1
@@ -513,11 +513,11 @@ Builder.load_string("""
 
             BoxLayout:
                 size_hint: (None, None)
-                size: (dp(80.0/800.0)*app.width,dp(80.0/480.0)*app.height)
+                size: app.get_scaled_tuple([80.0, 80.0])
                 orientation: 'horizontal'
-                padding:[dp(0.03625)*app.width, dp(0.0604166666667)*app.height, dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([29.0, 29.0, 10.0, 10.0])
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     disabled: False
                     background_color: hex('#FFFFFF00')
                     on_press: root.help_popup()

--- a/src/asmcnc/skavaUI/screen_local_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_local_filechooser.py
@@ -57,7 +57,7 @@ Builder.load_string(
 
     BoxLayout:
         padding: 0
-        spacing:0.0208333333333*app.height
+        spacing: app.get_scaled_width(10.0)
         size: root.size
         pos: root.pos
         orientation: "vertical"
@@ -69,7 +69,7 @@ Builder.load_string(
             spacing: 0
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: usb_status_label
                 canvas.before:
                     Color:
@@ -79,14 +79,14 @@ Builder.load_string(
                         pos: self.pos
                 size_hint_y: 0.7
                 markup: True
-                font_size: str(0.0225*app.width) + 'sp'   
+                font_size: app.get_scaled_sp('18.0sp')
                 valign: 'middle'
                 halign: 'left'
                 text_size: self.size
-                padding:[dp(0.0125)*app.width, 0]
+                padding: app.get_scaled_tuple([10.0, 0.0])
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 canvas.before:
                     Color:
                         rgba: hex('#333333FF')
@@ -97,7 +97,7 @@ Builder.load_string(
                 size_hint_y: 1
                 text: root.filename_selected_label_text
                 markup: True
-                font_size: str(0.0225*app.width) + 'sp'   
+                font_size: app.get_scaled_sp('18.0sp')
                 valign: 'middle'
                 halign: 'center'
                 bold: True
@@ -126,27 +126,27 @@ Builder.load_string(
                     scroll_type: ['bars', 'content']
 
                     Label:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: metadata_preview
                         size_hint_y: None
                         height: self.texture_size[1]
                         text_size: self.width, None
-                        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                        padding: app.get_scaled_tuple([10.0, 10.0])
                         markup: True
                
 
         BoxLayout:
             size_hint_y: None
-            height: dp(100.0/480.0)*app.height
+            height: app.get_scaled_height(100.0)
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: toggle_view_button
                 size_hint_x: 1
                 on_press: root.switch_view()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -158,13 +158,13 @@ Builder.load_string(
                         allow_stretch: True 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: sort_button
                 size_hint_x: 1
                 on_press: root.switch_sort()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -176,7 +176,7 @@ Builder.load_string(
                         allow_stretch: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: button_usb
                 disabled: True
                 size_hint_x: 1
@@ -187,7 +187,7 @@ Builder.load_string(
                     root.open_USB()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -198,7 +198,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -209,7 +209,7 @@ Builder.load_string(
                     root.refresh_filechooser() 
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -220,7 +220,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: delete_selected_button
                 disabled: True
                 size_hint_x: 1
@@ -231,7 +231,7 @@ Builder.load_string(
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -242,7 +242,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: delete_all_button
                 disabled: False
                 size_hint_x: 1
@@ -253,7 +253,7 @@ Builder.load_string(
                     root.delete_popup(file_selection = 'all')
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -264,7 +264,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -274,7 +274,7 @@ Builder.load_string(
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -285,7 +285,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: load_button
                 disabled: True
                 size_hint_x: 1
@@ -295,7 +295,7 @@ Builder.load_string(
                     root.go_to_loading_screen()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:

--- a/src/asmcnc/skavaUI/screen_mstate_warning.py
+++ b/src/asmcnc/skavaUI/screen_mstate_warning.py
@@ -31,20 +31,20 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.075)*app.width, dp(0.125)*app.height]
-        spacing:0.0625*app.height
+        padding: app.get_scaled_tuple([60.0, 60.0])
+        spacing: app.get_scaled_width(30.0)
         size_hint_x: 1
 
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 1
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
              
             Label:
                 id: title_label
                 size_hint_y: 1
                 text_size: self.size
-                font_size: str(0.03625*app.width) + 'sp'
+                font_size: app.get_scaled_sp('29.0sp')
                 markup: True
                 halign: 'left'
                 vallign: 'top'
@@ -53,7 +53,7 @@ Builder.load_string(
                 id: cannot_start_job
                 size_hint_y: 1
                 text_size: self.size
-                font_size: str(0.0275*app.width) + 'sp'
+                font_size: app.get_scaled_sp('22.0sp')
                 halign: 'left'
                 valign: 'middle'
                 text: 'Cannot start job.'
@@ -61,7 +61,7 @@ Builder.load_string(
                 
             Label:
                 size_hint_y: 1
-                font_size: str(0.0275*app.width) + 'sp'
+                font_size: app.get_scaled_sp('22.0sp')
                 text_size: self.size
                 halign: 'left'
                 valign: 'middle'
@@ -70,10 +70,10 @@ Builder.load_string(
                 
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.1625)*app.width, 0]
+                padding: app.get_scaled_tuple([130.0, 0.0])
             
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y:0.9
                     id: getout_button
                     size: self.texture_size
@@ -89,13 +89,13 @@ Builder.load_string(
                         root.button_release()
                         
                     BoxLayout:
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         size: self.parent.size
                         pos: self.parent.pos
                         
                         Label:
                             id: return_label
-                            font_size: str(0.025*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('20.0sp')
                         
   
             

--- a/src/asmcnc/skavaUI/screen_nudge.py
+++ b/src/asmcnc/skavaUI/screen_nudge.py
@@ -25,7 +25,7 @@ Builder.load_string(
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: 0.9
-            spacing:dp(0.0166666666667)*app.height
+            spacing: app.get_scaled_width(8.0)
             canvas:
                 Color:
                     rgba: hex('#E2E2E2FF')
@@ -42,20 +42,20 @@ Builder.load_string(
                     text: 'Optional Nudge:'
                     bold: True
                     color: hex('#333333ff')
-                    font_size: dp(0.03125*app.width)
+                    font_size: app.get_scaled_width(25.0)
                     halign: 'left'
                     valign: 'middle'
                     text_size: self.size
-                    padding:[dp(0.0625)*app.width, 0]
+                    padding: app.get_scaled_tuple([50.0, 0.0])
 
                 BoxLayout:
                     orientation: 'horizontal'
-                    spacing:dp(0.03125)*app.width
+                    spacing: app.get_scaled_width(25.0)
 
                     BoxLayout:
-                        padding:[dp(0.01875)*app.width, dp(0.03125)*app.height, 0, dp(0.03125)*app.height]
+                        padding: app.get_scaled_tuple([15.0, 15.0, 0.0, 15.0])
                         Button:
-                            font_size: str(0.01875 * app.width) + 'sp'
+                            font_size: app.get_scaled_sp('15.0sp')
                             background_color: [0,0,0,0]
                             on_press: root.get_info()
                             BoxLayout:
@@ -69,7 +69,7 @@ Builder.load_string(
                                     allow_stretch: True   
 
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         background_color: [0,0,0,0]
                         on_press: root.back_to_home()
                         BoxLayout:
@@ -85,12 +85,12 @@ Builder.load_string(
             BoxLayout:
                 orientation: 'horizontal'
                 size_hint_y: 3
-                padding:[dp(0.125)*app.width, 0]
-                spacing:dp(0.0375)*app.width
+                padding: app.get_scaled_tuple([100.0, 0.0])
+                spacing: app.get_scaled_width(30.0)
 
                 BoxLayout:
                     size_hint_x: 2.5
-                    padding:[0, dp(0.00208333333333)*app.height]
+                    padding: app.get_scaled_tuple([0.0, 1.0])
                     canvas:
                         Color:
                             rgba: 1,1,1,1
@@ -101,8 +101,8 @@ Builder.load_string(
                     BoxLayout:
                         id: xy_move_container
                         size_hint: (None, None)
-                        height: dp(0.572916666667*app.height)
-                        width: dp(0.34375*app.width)
+                        height: app.get_scaled_height(275.0)
+                        width: app.get_scaled_width(275.0)
 
                 BoxLayout:
                     id: nudge_speed_container
@@ -125,16 +125,16 @@ Builder.load_string(
 
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.0875)*app.width, dp(0.0208333333333)*app.height, 0, dp(0.0208333333333)*app.height]
-                spacing:dp(0.25)*app.width
+                padding: app.get_scaled_tuple([70.0, 10.0, 0.0, 10.0])
+                spacing: app.get_scaled_width(200.0)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     on_press: root.previous_screen()
                     background_color: [0,0,0,0]
                     size_hint: (None, None)
-                    height: dp(0.139583333333*app.height)
-                    width: dp(0.11*app.width)
+                    height: app.get_scaled_height(67.0)
+                    width: app.get_scaled_width(88.0)
                     BoxLayout:
                         size: self.parent.size
                         pos: self.parent.pos
@@ -147,16 +147,16 @@ Builder.load_string(
 
                 BoxLayout:
                     size_hint: (None, None)
-                    height: dp(0.139583333333*app.height)
-                    width: dp(0.08375*app.width)
+                    height: app.get_scaled_height(67.0)
+                    width: app.get_scaled_width(67.0)
 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     on_press: root.next_screen()
                     background_color: [0,0,0,0]
                     size_hint: (None, None)
-                    height: dp(0.139583333333*app.height)
-                    width: dp(0.11*app.width)
+                    height: app.get_scaled_height(67.0)
+                    width: app.get_scaled_width(88.0)
                     BoxLayout:
                         size: self.parent.size
                         pos: self.parent.pos
@@ -178,13 +178,13 @@ Builder.load_string(
             x: dp(110.0/800.0)*app.width
             y: dp(345.0/480.0)*app.height
             size_hint: None, None
-            height: dp(0.0625*app.height)
-            width: dp(0.0375*app.width)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             text: 'XY'
             markup: True
             bold: True
             color: hex('#333333ff')
-            font_size: dp(0.025*app.width)
+            font_size: app.get_scaled_width(20.0)
 
 """
 )

--- a/src/asmcnc/skavaUI/screen_powercycle_alert.py
+++ b/src/asmcnc/skavaUI/screen_powercycle_alert.py
@@ -31,8 +31,8 @@ Builder.load_string("""
              
     BoxLayout:
         orientation: 'horizontal'
-        padding: 70
-        spacing: 70
+        padding: app.get_scaled_width(70.0)
+        spacing: app.get_scaled_width(70.0)
         size_hint_x: 1
 
         BoxLayout:
@@ -45,7 +45,7 @@ Builder.load_string("""
                 size_hint_y: 0.33
                 color: hex('#333333')
                 markup: True
-                font_size: '40sp'   
+                font_size: app.get_scaled_sp('40sp')
                 valign: 'middle'
                 halign: 'center'
 
@@ -56,7 +56,7 @@ Builder.load_string("""
                 text: "..."
                 color: hex('1976d2ff')
                 markup: True
-                font_size: '200sp'   
+                font_size: app.get_scaled_sp('200sp')
                 valign: 'bottom'
                 halign: 'center'
 
@@ -67,7 +67,7 @@ Builder.load_string("""
                 size_hint_y: 0.33
                 color: hex('#333333')
                 markup: True
-                font_size: '40sp'
+                font_size: app.get_scaled_sp('40sp')
                 valign: 'middle'
                 halign: 'center'
 

--- a/src/asmcnc/skavaUI/screen_probing.py
+++ b/src/asmcnc/skavaUI/screen_probing.py
@@ -27,20 +27,20 @@ Builder.load_string("""
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([40.0, 40.0])
         orientation: 'vertical'
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.025*app.width
+            spacing: app.get_scaled_width(20.0)
             size_hint_y: 1.5
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.probe_button_press()
@@ -64,7 +64,7 @@ Builder.load_string("""
                 color: hex('#333333ff')
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.stop_button_press()
@@ -77,7 +77,7 @@ Builder.load_string("""
                         allow_stretch: True 
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1                
 
 """

--- a/src/asmcnc/skavaUI/screen_rebooting.py
+++ b/src/asmcnc/skavaUI/screen_rebooting.py
@@ -29,8 +29,8 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.0875)*app.width, dp(0.145833333333)*app.height]
-        spacing:0.145833333333*app.height
+        padding: app.get_scaled_tuple([70.0, 70.0])
+        spacing: app.get_scaled_width(70.0)
         size_hint_x: 1
 
         BoxLayout:
@@ -42,7 +42,7 @@ Builder.load_string(
                 text_size: self.size
                 size_hint_y: 0.5
                 markup: True
-                font_size: str(0.05*app.width) + 'sp'   
+                font_size: app.get_scaled_sp('40.0sp')
                 valign: 'middle'
                 halign: 'center'            
 

--- a/src/asmcnc/skavaUI/screen_recovery_decision.py
+++ b/src/asmcnc/skavaUI/screen_recovery_decision.py
@@ -28,10 +28,10 @@ Builder.load_string(
 
         BoxLayout:
             size_hint_y: 0.75
-            padding:[dp(0.895)*app.width, 0, 0, 0]
+            padding: app.get_scaled_tuple([716.0, 0.0, 0.0, 0.0])
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: [0,0,0,0]
                 on_press: root.back_to_home()
                 BoxLayout:
@@ -53,12 +53,12 @@ Builder.load_string(
                 text: "[b]Last job:[/b]"
                 color: hex('#333333ff')
                 markup: True
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
 
             Label:
                 id: job_name_label
                 color: hex('#333333ff')
-                font_size: dp(0.03125*app.width)
+                font_size: app.get_scaled_width(25.0)
                 text_size: self.size
                 halign: "center"
                 valign: "middle"
@@ -67,18 +67,18 @@ Builder.load_string(
             Label:
                 id: completion_label
                 color: hex('#333333ff')
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
 
         BoxLayout:
             orientation: 'horizontal'
             size_hint_y: 2.23
-            padding:[dp(0.0625)*app.width, dp(0.0625)*app.height]
-            spacing:dp(0.0625)*app.width
+            padding: app.get_scaled_tuple([50.0, 30.0])
+            spacing: app.get_scaled_width(50.0)
 
             Button:
                 id: repeat_job_button
                 text: "Repeat job from the beginning"
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
                 valign: "middle"
                 halign: "center"
                 text_size: self.size[0] - dp(50), self.size[1]
@@ -89,7 +89,7 @@ Builder.load_string(
             Button:
                 id: recover_job_button
                 text: "Recover job"
-                font_size: dp(0.0375*app.width)
+                font_size: app.get_scaled_width(30.0)
                 valign: "middle"
                 halign: "center"
                 text_size: self.size[0] - dp(50), self.size[1]

--- a/src/asmcnc/skavaUI/screen_restart_smartbench.py
+++ b/src/asmcnc/skavaUI/screen_restart_smartbench.py
@@ -23,8 +23,8 @@ Builder.load_string("""
 
     Label:
         id: restart_label
-        padding: [dp(10),dp(0)]
-        font_size: '40sp'
+        padding: app.get_scaled_tuple([10.0, 0.0])
+        font_size: app.get_scaled_sp('40sp')
         color: hex('#333333')
         text_size: self.size
         size: self.texture_size
@@ -35,10 +35,10 @@ Builder.load_string("""
     BoxLayout:
         valign: 'bottom'
         halign: 'left'
-        padding: dp(30)
+        padding: app.get_scaled_width(30.0)
 
         Button:
-            size: dp(80), dp(70) # Slightly bigger than image size, but image is tiny and I think slightly bigger looks fine
+            size: app.get_scaled_tuple([80.0, 70.0])
             size_hint: None, None
             background_color: 0,0,0,0
             on_press: root.switch_screen()

--- a/src/asmcnc/skavaUI/screen_serial_failure.py
+++ b/src/asmcnc/skavaUI/screen_serial_failure.py
@@ -34,31 +34,31 @@ Builder.load_string(
              
     BoxLayout:
         orientation: 'horizontal'
-        padding:[dp(0.0625)*app.width, dp(0.104166666667)*app.height]
-        spacing:0.0625*app.height
+        padding: app.get_scaled_tuple([50.0, 50.0])
+        spacing: app.get_scaled_width(30.0)
         size_hint_x: 1
 
         BoxLayout:
             orientation: 'vertical'
             size_hint_x: 1
-            spacing:0.0416666666667*app.height
+            spacing: app.get_scaled_width(20.0)
              
             Label:
                 id: title_string
                 size_hint_y: 1.2
                 text_size: self.size
-                font_size: str(0.03*app.width) + 'sp'
+                font_size: app.get_scaled_sp('24.0sp')
                 markup: True
                 halign: 'left'
                 vallign: 'top'
  
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.025)*app.width, 0, 0, 0]
+                padding: app.get_scaled_tuple([20.0, 0.0, 0.0, 0.0])
                 size_hint_y: 1
                 Label:
                     text_size: self.size
-                    font_size: str(0.03*app.width) + 'sp'
+                    font_size: app.get_scaled_sp('24.0sp')
                     halign: 'left'
                     valign: 'middle'
                     text: root.error_description 
@@ -66,7 +66,7 @@ Builder.load_string(
 
             Label:
                 size_hint_y: 1
-                font_size: str(0.03*app.width) + 'sp'
+                font_size: app.get_scaled_sp('24.0sp')
                 text_size: self.size
                 halign: 'left'
                 valign: 'top'
@@ -75,11 +75,11 @@ Builder.load_string(
                     
             BoxLayout:
                 orientation: 'horizontal'
-                padding:[dp(0.25)*app.width, 0]
-                spacing:0.05*app.width
+                padding: app.get_scaled_tuple([200.0, 0.0])
+                spacing: app.get_scaled_width(40.0)
                         
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     size_hint_y: 0.9
                     size_hint_x: 0.3
                     id: reboot_button
@@ -91,7 +91,7 @@ Builder.load_string(
                         root.reboot_button_press()
                         
                     BoxLayout:
-                        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+                        padding: app.get_scaled_tuple([5.0, 5.0])
                         size: self.parent.size
                         pos: self.parent.pos
                         
@@ -100,7 +100,7 @@ Builder.load_string(
                             valign: 'middle'
                             halign: 'center'
                             text_size: self.size
-                            font_size: str(0.0375*app.width) + 'sp'
+                            font_size: app.get_scaled_sp('30.0sp')
 """
 )
 

--- a/src/asmcnc/skavaUI/screen_spindle_cooldown.py
+++ b/src/asmcnc/skavaUI/screen_spindle_cooldown.py
@@ -20,11 +20,11 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         orientation: 'vertical'
         size_hint: (None, None)
-        height: dp(1.0)*app.height
-        width: 1.0*app.width
+        height: app.get_scaled_height(480.0)
+        width: app.get_scaled_width(800.0)
         canvas:
             Color: 
                 rgba: hex('#E5E5E5FF')
@@ -57,21 +57,21 @@ Builder.load_string(
 
             BoxLayout: 
                 spacing: 0
-                padding:[dp(0.125)*app.width, 0, dp(0.125)*app.width, dp(0.270833333333)*app.height]
+                padding: app.get_scaled_tuple([100.0, 0.0, 100.0, 130.0])
                 orientation: 'horizontal'          
                 size_hint: (None, None)
-                height: dp(251.0/480.0)*app.height
-                width: 1.0*app.width
+                height: app.get_scaled_height(251.0)
+                width: app.get_scaled_width(800.0)
                 pos: self.parent.pos
 
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[dp(0.01)*app.width, 0, dp(0.07125)*app.width, 0]
+                    padding: app.get_scaled_tuple([8.0, 0.0, 57.0, 0.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.225*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(180.0)
                     Image:
                         id: spindle_icon
                         source: "./asmcnc/skavaUI/img/spindle_cooldown_on.png"
@@ -80,16 +80,16 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
                         size_hint: (None, None)
-                        height: dp(0.252083333333*app.height)
-                        width: dp(0.14375*app.width) 
+                        height: app.get_scaled_height(121.0)
+                        width: app.get_scaled_width(115.0)
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[0, 0, 0, 0]
+                    padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 0.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.25*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(200.0)
                     Label:
                         id: countdown
                         markup: True
@@ -103,11 +103,11 @@ Builder.load_string(
 
                 BoxLayout: 
                     spacing: 0
-                    padding:[dp(0.0875)*app.width, 0, dp(0.0125)*app.width, dp(0.00625)*app.height]
+                    padding: app.get_scaled_tuple([70.0, 0.0, 10.0, 3.0])
                     orientation: 'horizontal'          
                     size_hint: (None, None)
-                    height: dp(121.0/480.0)*app.height
-                    width: 0.225*app.width
+                    height: app.get_scaled_height(121.0)
+                    width: app.get_scaled_width(180.0)
                     Image:
                         id: countdown_icon
                         source: "./asmcnc/skavaUI/img/countdown_big.png"
@@ -116,8 +116,8 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True
                         size_hint: (None, None)
-                        height: dp(0.245833333333*app.height)
-                        width: dp(0.125*app.width) 
+                        height: app.get_scaled_height(118.0)
+                        width: app.get_scaled_width(100.0)
 
 
 """

--- a/src/asmcnc/skavaUI/screen_spindle_shutdown.py
+++ b/src/asmcnc/skavaUI/screen_spindle_shutdown.py
@@ -31,11 +31,11 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([40.0, 40.0])
         orientation: 'vertical'
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1 
             
         Label:
@@ -61,11 +61,11 @@ Builder.load_string(
             color: hex('#333333ff')
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1                        
 
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 4
             background_color: hex('#FFFFFF00')
             BoxLayout:
@@ -77,7 +77,7 @@ Builder.load_string(
                     allow_stretch: True 
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1                
 
 """

--- a/src/asmcnc/skavaUI/screen_squaring_active.py
+++ b/src/asmcnc/skavaUI/screen_squaring_active.py
@@ -29,21 +29,21 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         orientation: 'vertical'
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 1
 
         BoxLayout:
-            padding:[dp(0.025)*app.width, 0]
+            padding: app.get_scaled_tuple([20.0, 0.0])
             orientation: 'horizontal'
-            spacing:0.0375*app.width
+            spacing: app.get_scaled_width(30.0)
             size_hint_y: 1.5
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.windows_cheat_to_procede()
@@ -67,7 +67,7 @@ Builder.load_string(
                 color: hex('#333333ff')
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.stop_button_press()

--- a/src/asmcnc/skavaUI/screen_squaring_manual_vs_square.py
+++ b/src/asmcnc/skavaUI/screen_squaring_manual_vs_square.py
@@ -35,27 +35,27 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.05)*app.width, dp(0.0833333333333)*app.height]
+        padding: app.get_scaled_tuple([40.0, 40.0])
         orientation: 'vertical'
 
         # Cancel button
         BoxLayout:
             size_hint: (None,None)
-            height: dp(0.0416666666667*app.height)
-            padding:[dp(0.025)*app.width, 0, dp(0.025)*app.width, 0]
-            spacing:0.85*app.width
+            height: app.get_scaled_height(20.0)
+            padding: app.get_scaled_tuple([20.0, 0.0, 20.0, 0.0])
+            spacing: app.get_scaled_width(680.0)
             orientation: 'horizontal'
             pos: self.parent.pos
 
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 text: ""
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint: (None,None)
-                height: dp(0.104166666667*app.height)
-                width: dp(0.0625*app.width)
+                height: app.get_scaled_height(50.0)
+                width: app.get_scaled_width(50.0)
                 background_color: hex('#FFFFFF00')
                 opacity: 1
                 on_press: root.cancel()
@@ -71,13 +71,13 @@ Builder.load_string(
                         allow_stretch: True
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: 0.1
 
         BoxLayout:
             orientation: 'vertical'
-            spacing:0.0208333333333*app.height
-            padding:[0, dp(0.0416666666667)*app.height, 0, dp(0.0416666666667)*app.height]
+            spacing: app.get_scaled_width(10.0)
+            padding: app.get_scaled_tuple([0.0, 20.0, 0.0, 20.0])
             size_hint_y: 3
             
 
@@ -105,7 +105,7 @@ Builder.load_string(
      
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0375*app.width
+            spacing: app.get_scaled_width(30.0)
             size_hint_y: 3
 
             Button:
@@ -119,11 +119,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 0.3
                 background_color: hex('#FFFFFF00')
                 on_press: root.popup_help()
@@ -147,11 +147,11 @@ Builder.load_string(
                 text_size: self.size
                 background_normal: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
                 background_down: "./asmcnc/skavaUI/img/blank_blue_btn_2-1_rectangle.png"
-                border: [dp(30)]*4
-                padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+                border: app.get_scaled_tuple([30.0, 30.0, 30.0, 30.0])
+                padding: app.get_scaled_tuple([20.0, 20.0])
                         
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_y: .5                
 
 """

--- a/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
+++ b/src/asmcnc/skavaUI/screen_stop_or_resume_decision.py
@@ -33,14 +33,14 @@ Builder.load_string(
 
     BoxLayout: 
         spacing: 0
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
+        padding: app.get_scaled_tuple([20.0, 20.0])
         orientation: 'vertical'
 
 
         BoxLayout:
             orientation: 'vertical'
-            spacing:0.0*app.height
-            padding:[0, 0, 0, dp(0.0208333333333)*app.height]
+            spacing: 0
+            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 10.0])
             size_hint_y: 5
             
 
@@ -72,7 +72,7 @@ Builder.load_string(
             size_hint_y: 3
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.cancel_job()
@@ -85,7 +85,7 @@ Builder.load_string(
                         allow_stretch: True 
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 0.3
                 background_color: hex('#FFFFFF00')
                 on_press: root.popup_help()
@@ -98,7 +98,7 @@ Builder.load_string(
                         allow_stretch: True 
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
                 on_press: root.resume_job()

--- a/src/asmcnc/skavaUI/screen_tool_selection.py
+++ b/src/asmcnc/skavaUI/screen_tool_selection.py
@@ -25,13 +25,13 @@ Builder.load_string(
 
     BoxLayout:
         orientation: 'vertical'
-        padding:[dp(0.0625)*app.width, dp(0.104166666667)*app.height]
+        padding: app.get_scaled_tuple([50.0, 50.0])
 
         # Top text
 
         BoxLayout:
             orientation: 'vertical'
-            padding:[0, dp(0.075)*app.height, 0, 0]
+            padding: app.get_scaled_tuple([0.0, 36.0, 0.0, 0.0])
             
 
             Label:
@@ -48,9 +48,9 @@ Builder.load_string(
 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:dp(0.055)*app.width
+            spacing: app.get_scaled_width(44.0)
             size_hint_y: dp(2.5)
-            padding:[0, 0, 0, dp(0.0416666666667)*app.height]
+            padding: app.get_scaled_tuple([0.0, 0.0, 0.0, 20.0])
 
             # Stylus button
 

--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -50,7 +50,7 @@ Builder.load_string(
         orientation: "vertical"
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             canvas.before:
                 Color:
                     rgba: hex('#333333FF')
@@ -60,14 +60,14 @@ Builder.load_string(
             id: usb_status_label
             size_hint_y: 0.7
             markup: True
-            font_size: str(0.0225*app.width) + 'sp'   
+            font_size: app.get_scaled_sp('18.0sp')
             valign: 'middle'
             halign: 'left'
             text_size: self.size
-            padding:[dp(0.0125)*app.width, 0]
+            padding: app.get_scaled_tuple([10.0, 0.0])
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             canvas.before:
                 Color:
                     rgba: hex('#333333FF')
@@ -78,7 +78,7 @@ Builder.load_string(
             size_hint_y: 1
             text: root.filename_selected_label_text
             markup: True
-            font_size: str(0.025*app.width) + 'sp'   
+            font_size: app.get_scaled_sp('20.0sp')
             valign: 'middle'
             halign: 'center' 
             bold: True               
@@ -88,7 +88,7 @@ Builder.load_string(
             size_hint_y: 5
 
             FileChooser:
-                padding:[0, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([0.0, 10.0])
                 id: filechooser_usb
                 show_hidden: False
                 filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
@@ -106,26 +106,26 @@ Builder.load_string(
                 scroll_type: ['bars', 'content']
 
                 Label:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: metadata_preview
                     size_hint_y: None
                     height: self.texture_size[1]
                     text_size: self.width, None
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     markup: True
                
         BoxLayout:
             size_hint_y: None
-            height: dp(100.0/480.0)*app.height
+            height: app.get_scaled_height(100.0)
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: toggle_view_button
                 size_hint_x: 1
                 on_press: root.switch_view()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -137,13 +137,13 @@ Builder.load_string(
                         allow_stretch: True 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: sort_button
                 size_hint_x: 1
                 on_press: root.switch_sort()
                 background_color: hex('#FFFFFF00')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -155,7 +155,7 @@ Builder.load_string(
                         allow_stretch: True
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -165,7 +165,7 @@ Builder.load_string(
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -177,7 +177,7 @@ Builder.load_string(
                         allow_stretch: True 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 disabled: False
                 size_hint_x: 1
                 background_color: hex('#FFFFFF00')
@@ -187,7 +187,7 @@ Builder.load_string(
                     root.quit_to_local()
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:
@@ -198,7 +198,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: load_button
                 disabled: True
                 size_hint_x: 1
@@ -209,7 +209,7 @@ Builder.load_string(
                 on_press:
                     self.background_color = hex('#FFFFFFFF')
                 BoxLayout:
-                    padding:[dp(0.03125)*app.width, dp(0.0520833333333)*app.height]
+                    padding: app.get_scaled_tuple([25.0, 25.0])
                     size: self.parent.size
                     pos: self.parent.pos
                     Image:

--- a/src/asmcnc/skavaUI/widget_common_move.py
+++ b/src/asmcnc/skavaUI/widget_common_move.py
@@ -28,13 +28,13 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
 
-        spacing:0.0416666666667*app.height
+        spacing: app.get_scaled_width(20.0)
         
         orientation: "vertical"
         
         BoxLayout:
             spacing: 0
-            padding:dp(0)
+            padding: 0
             size_hint_y: 1
             orientation: 'vertical'
             canvas:
@@ -45,12 +45,12 @@ Builder.load_string(
                     pos: self.pos 
 
             ToggleButton:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: speed_toggle
                 on_press: root.set_jog_speeds()
                 background_color: 1, 1, 1, 0 
                 BoxLayout:
-                    padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                    padding: app.get_scaled_tuple([10.0, 10.0])
                     size: self.parent.size
                     pos: self.parent.pos      
                     Image:
@@ -63,7 +63,7 @@ Builder.load_string(
             
         BoxLayout:
             spacing: 0
-            padding:dp(0)
+            padding: 0
             size_hint_y: 2
             orientation: 'vertical'
             id: vacuum_spindle_container

--- a/src/asmcnc/skavaUI/widget_feed_override.py
+++ b/src/asmcnc/skavaUI/widget_feed_override.py
@@ -23,17 +23,17 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
 
-        spacing:0.0*app.height
+        spacing: 0
         
         orientation: "vertical"
         
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             id: up_5
             on_press: root.feed_up()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding:[dp(0.0025)*app.width, dp(0.00416666666667)*app.height]
+                padding: app.get_scaled_tuple([2.0, 2.0])
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:
@@ -48,7 +48,7 @@ Builder.load_string(
             size: self.parent.size
             pos: self.parent.pos  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: norm_button
                 on_press: root.feed_norm()
                 background_color: 1, 1, 1, 0 
@@ -60,19 +60,19 @@ Builder.load_string(
                 size: self.parent.size
                 allow_stretch: True  
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: feed_rate_label
                 pos_hint: {'center_x':0.5, 'center_y': .5}
                 size: self.parent.size
                 text: "100%"           
         
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             id: down_5
             on_press: root.feed_down()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding:[dp(0.0025)*app.width, dp(0.00416666666667)*app.height]
+                padding: app.get_scaled_tuple([2.0, 2.0])
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:

--- a/src/asmcnc/skavaUI/widget_gcode_monitor.py
+++ b/src/asmcnc/skavaUI/widget_gcode_monitor.py
@@ -28,7 +28,7 @@ Builder.load_string(
             pos: self.pos
     
     Label:
-        font_size: str(0.01875 * app.width) + 'sp'
+        font_size: app.get_scaled_sp('15.0sp')
         size_hint_y: None
         height: self.texture_size[1]
         text_size: self.width, None
@@ -49,7 +49,7 @@ Builder.load_string(
         size_hint_y: None
         height: self.texture_size[1]
         text_size: self.width, None
-        font_size: str(0.015*app.width) + 'sp'
+        font_size: app.get_scaled_sp('12.0sp')
         text: root.text
         max_lines: 3
 
@@ -74,8 +74,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos
         orientation: "vertical"
-        padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
-        spacing:0.0104166666667*app.height
+        padding: app.get_scaled_tuple([5.0, 5.0])
+        spacing: app.get_scaled_width(5.0)
         
         canvas:
             Color:
@@ -87,18 +87,18 @@ Builder.load_string(
         BoxLayout:      
             size: self.parent.size
             pos: self.parent.pos      
-            spacing:0.00625*app.width
+            spacing: app.get_scaled_width(5.0)
             orientation: "horizontal"    
             
             BoxLayout:
                 padding_horizontal: 5
-                spacing:0.0104166666667*app.height
+                spacing: app.get_scaled_width(5.0)
                 orientation: "vertical"
                 size_hint_x: 0.9
                 
                 BoxLayout:
                     padding: 0
-                    spacing:0.0025*app.width
+                    spacing: app.get_scaled_width(2.0)
                     orientation: 'horizontal'
                     size_hint_y: 0.1
      
@@ -106,11 +106,11 @@ Builder.load_string(
                         id:gCodeInput
                         multiline: False
                         text: ''
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         on_text_validate: root.send_gcode_textinput()
                     
                     Button:
-                        font_size: str(0.01875 * app.width) + 'sp'
+                        font_size: app.get_scaled_sp('15.0sp')
                         id: enter_button
                         text: "Enter"
                         on_press: root.send_gcode_textinput()
@@ -123,12 +123,12 @@ Builder.load_string(
                                          
             BoxLayout:
                 padding_horizontal: 5
-                spacing:0.0104166666667*app.height
+                spacing: app.get_scaled_width(5.0)
                 orientation: "vertical"
                 size_hint_x: 0.24
         
                 ToggleButton:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: hide_ok_button
                     state: root.hide_received_ok
                     markup: True
@@ -139,37 +139,37 @@ Builder.load_string(
 # FOR USER
                     
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: settings_button
                     text: "Settings"
                     on_press: root.send_gcode_preset("$$")
                     size_hint_y:0.1
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: params_button
                     text: "Params"
                     on_press: root.send_gcode_preset("$#")
                     size_hint_y:0.1
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: state_button
                     text: "State"
                     on_press: root.send_gcode_preset("$G")
                     size_hint_y:0.1
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: build_button
                     text: "Build"
                     size_hint_y:0.1
                     on_press: root.send_gcode_preset("$I")
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: check_button
                     text: "Check $C"
                     on_press: root.toggle_check_mode()
                     size_hint_y:0.1
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: help_button
                     text: "Help"
                     on_press: root.send_gcode_preset("$")
@@ -181,7 +181,7 @@ Builder.load_string(
 ######### END ############
  
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     id: clear_button
                     text: "Clear"
                     on_press: root.clear_monitor()
@@ -189,7 +189,7 @@ Builder.load_string(
                     background_color: 1, .8, 0, 1
         
         BoxLayout:
-            padding:[dp(0.00625)*app.width, dp(0.0104166666667)*app.height]
+            padding: app.get_scaled_tuple([5.0, 5.0])
             spacing: 0
             orientation: 'horizontal'
             size_hint_y: 0.09
@@ -203,7 +203,7 @@ Builder.load_string(
                     
                       
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: status_label
                 text: 'Status'
                 text_size: self.size

--- a/src/asmcnc/skavaUI/widget_gcode_summary.py
+++ b/src/asmcnc/skavaUI/widget_gcode_summary.py
@@ -17,7 +17,7 @@ Builder.load_string(
     text_container: text_container
 
     Label:
-        font_size: str(0.01875 * app.width) + 'sp'
+        font_size: app.get_scaled_sp('15.0sp')
         id: text_container
         color: [0, 0, 0, 1]
         size_hint_y: None

--- a/src/asmcnc/skavaUI/widget_nudge_speed.py
+++ b/src/asmcnc/skavaUI/widget_nudge_speed.py
@@ -12,8 +12,8 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos
         orientation: 'vertical'
-        spacing: 10
-        padding: 10
+        spacing: app.get_scaled_width(10.0)
+        padding: app.get_scaled_width(10.0)
 
         ToggleButton:
             id: speed_toggle
@@ -38,7 +38,7 @@ Builder.load_string("""
                 root.set_datum()
                 self.background_color = hex('#F44336FF')
             BoxLayout:
-                padding: 5
+                padding: app.get_scaled_width(5.0)
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -31,7 +31,7 @@ Builder.load_string("""
         pos: self.parent.pos      
 
         padding: 0
-        spacing: 0.0208333333333333*app.height
+        spacing: app.get_scaled_width(10.0)
         orientation: "vertical"
 
         Button:

--- a/src/asmcnc/skavaUI/widget_speed_override.py
+++ b/src/asmcnc/skavaUI/widget_speed_override.py
@@ -23,17 +23,17 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
 
-        spacing:0.0*app.height
+        spacing: 0
         
         orientation: "vertical"
         
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             id: up_5
             on_press: root.speed_up()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding:[dp(0.0025)*app.width, dp(0.00416666666667)*app.height]
+                padding: app.get_scaled_tuple([2.0, 2.0])
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:
@@ -48,7 +48,7 @@ Builder.load_string(
             size: self.parent.size
             pos: self.parent.pos  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: norm_button
                 on_press: root.speed_norm()
                 background_color: 1, 1, 1, 0 
@@ -60,19 +60,19 @@ Builder.load_string(
                 size: self.parent.size
                 allow_stretch: True  
             Label:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 id: speed_rate_label
                 pos_hint: {'center_x':0.5, 'center_y': .5}
                 size: self.parent.size
                 text: "100%"           
         
         Button:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             id: down_5
             on_press: root.speed_down()
             background_color: 1, 1, 1, 0 
             BoxLayout:
-                padding:[dp(0.0025)*app.width, dp(0.00416666666667)*app.height]
+                padding: app.get_scaled_tuple([2.0, 2.0])
                 size: self.parent.size
                 pos: self.parent.pos      
                 Image:

--- a/src/asmcnc/skavaUI/widget_status_bar.py
+++ b/src/asmcnc/skavaUI/widget_status_bar.py
@@ -46,8 +46,8 @@ Builder.load_string(
             size: self.size
 
     BoxLayout:
-        padding:[dp(0.00125)*app.width, dp(0.00208333333333)*app.height]
-        spacing:0.0075*app.width
+        padding: app.get_scaled_tuple([1.0, 1.0])
+        spacing: app.get_scaled_width(6.0)
         orientation: "horizontal"
         size: self.parent.size
         pos: self.parent.pos
@@ -69,7 +69,7 @@ Builder.load_string(
             size: self.parent.width, self.parent.height
             allow_stretch: True
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.2
             id: ip_status_label
             text_size: self.size
@@ -81,7 +81,7 @@ Builder.load_string(
 #             size_hint_x: 0.1
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_xm_label
             text: 'mX:\\n-9999.99'
@@ -90,7 +90,7 @@ Builder.load_string(
             valign: 'middle'
             markup: True
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_ym_label
             text: 'mY:\\n-9999.99'
@@ -99,7 +99,7 @@ Builder.load_string(
             valign: 'middle'
             markup: True
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_zm_label
             text: 'mZ:\\n-9999.99'
@@ -110,7 +110,7 @@ Builder.load_string(
 
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_xw_label
             text: 'wX:\\n-9999.99'
@@ -118,7 +118,7 @@ Builder.load_string(
             halign: 'left'
             valign: 'middle'
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_yw_label
             text: 'wY:\\n-9999.99'
@@ -126,7 +126,7 @@ Builder.load_string(
             halign: 'left'
             valign: 'middle'
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_zw_label
             text: 'wZ:\\n-9999.99'
@@ -135,7 +135,7 @@ Builder.load_string(
             valign: 'middle'
 
         Label:
-            font_size: str(0.01875 * app.width) + 'sp'
+            font_size: app.get_scaled_sp('15.0sp')
             size_hint_x: 0.1
             id: grbl_status_label
             text: 'Status'

--- a/src/asmcnc/skavaUI/widget_virtual_bed_control.py
+++ b/src/asmcnc/skavaUI/widget_virtual_bed_control.py
@@ -23,15 +23,15 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos   
         padding: 0
-        spacing: 20
+        spacing: app.get_scaled_width(20.0)
         orientation: "horizontal"
 
         BoxLayout:
             size_hint_x: 2 
             size: self.parent.size
             pos: self.parent.pos   
-            padding: 5
-            spacing: 5
+            padding: app.get_scaled_width(5.0)
+            spacing: app.get_scaled_width(5.0)
             orientation: "horizontal"
             canvas:
                 Color: 
@@ -45,7 +45,7 @@ Builder.load_string("""
                 size_hint_x: 1 
                 markup: True
                 color: hex('#ff9800ff')
-                font_size: 20.0 / 800 * app.width
+                font_size: app.get_scaled_width(20.0)
 
             Button:
                 background_color: hex('#F4433600')
@@ -88,8 +88,8 @@ Builder.load_string("""
             size_hint_x: 2 
             size: self.parent.size
             pos: self.parent.pos   
-#             padding: 5
-#             spacing: 5
+#             padding: app.get_scaled_width(5.0)
+#             spacing: app.get_scaled_width(5.0)
 #             orientation: "horizontal"
 #             canvas:
 #                 Color: 
@@ -103,8 +103,8 @@ Builder.load_string("""
             size_hint_x: 2 
             size: self.parent.size
             pos: self.parent.pos   
-            padding: 5
-            spacing: 5
+            padding: app.get_scaled_width(5.0)
+            spacing: app.get_scaled_width(5.0)
             orientation: "horizontal"
             canvas:
                 Color: 
@@ -117,7 +117,7 @@ Builder.load_string("""
                 size_hint_x: 1 
                 markup: True
                 color: hex('#4caf50ff')
-                font_size: 20.0 / 800 * app.width    
+                font_size: app.get_scaled_width(20.0)
             Button:
                 background_color: hex('#F4433600')
                 on_release: 

--- a/src/asmcnc/skavaUI/widget_vj_polygon.py
+++ b/src/asmcnc/skavaUI/widget_vj_polygon.py
@@ -18,8 +18,8 @@ Builder.load_string("""
     rad_textinput2 : rad_textinput
 
     BoxLayout:
-        padding: 20
-        spacing: 20
+        padding: app.get_scaled_width(20.0)
+        spacing: app.get_scaled_width(20.0)
         size: root.size
         pos: root.pos
         orientation: "vertical"
@@ -29,7 +29,7 @@ Builder.load_string("""
             orientation: 'horizontal'
             size: self.parent.size
             pos: self.parent.pos
-            padding: 15
+            padding: app.get_scaled_width(15.0)
 
             canvas.before:
                 Color: 
@@ -41,36 +41,36 @@ Builder.load_string("""
             Label:
                 text: 'Bit dia:'
                 size_hint_x:1
-                font_size:20
+                font_size: app.get_scaled_width(20.0)
                 color: 0,0,0,.8
             TextInput:
                 id: bit_dia_textinput
                 size_hint_x: 1
-                font_size:24
+                font_size: app.get_scaled_width(24.0)
                 multiline: False
 
             Label:
                 text: 'Depth:'
                 size_hint_x: 1
-                font_size:20
+                font_size: app.get_scaled_width(20.0)
                 color: 0,0,0,.8
             TextInput:
                 id: depth_textinput
                 size_hint_x: 1
-                font_size:24
+                font_size: app.get_scaled_width(24.0)
                 multiline: False
 
             Label:
                 #id: sides_textinput_
                 text: 'Sides:'
                 size_hint_x: 1
-                font_size:20
+                font_size: app.get_scaled_width(20.0)
                 color: 0,0,0,.8
             TextInput:
                 id: sides_textinput
                 text: "3"
                 size_hint_x: 1
-                font_size:24
+                font_size: app.get_scaled_width(24.0)
                 multiline: False
                 on_touch_up: self.select_all()
                 on_text: root.on_sides_textinput()
@@ -78,13 +78,13 @@ Builder.load_string("""
             Label:
                 text: 'Rad:'
                 size_hint_x: 1
-                font_size:20
+                font_size: app.get_scaled_width(20.0)
                 color: 0,0,0,.8
             TextInput:
                 id: rad_textinput
                 text: "80"
                 size_hint_x: 1
-                font_size:24
+                font_size: app.get_scaled_width(24.0)
                 multiline: False
                 on_touch_up: self.select_all()
                 on_text: root.on_sides_textinput()
@@ -92,12 +92,12 @@ Builder.load_string("""
 #             Label:
 #                 text: 'B:'
 #                 size_hint_x: 1
-#                 font_size:20
+#                 font_size: app.get_scaled_width(20.0)
 #                 color: 0,0,0,.8
 #             TextInput:
 #                 id: b_textinput
 #                 size_hint_x: 1
-#                 font_size:24
+#                 font_size: app.get_scaled_width(24.0)
 #                 multiline: False
         
         BoxLayout:
@@ -106,13 +106,13 @@ Builder.load_string("""
             size: self.parent.size
             pos: self.parent.pos
             padding: 0
-            spacing: 20
+            spacing: app.get_scaled_width(20.0)
             
             BoxLayout:
                 size_hint_x: 6
                 size: self.parent.size
                 pos: self.parent.pos
-                padding: 20
+                padding: app.get_scaled_width(20.0)
 
                 canvas:
                     Color: 
@@ -125,12 +125,12 @@ Builder.load_string("""
                     Line:
                         points: root.points
                         close: True
-                        width: 5
+                        width: app.get_scaled_width(5.0)
 
             StackLayout:
                 #size_hint_x: 1
                 orientation: 'bt-lr'
-                spacing: 10
+                spacing: app.get_scaled_width(10.0)
 
                 canvas:
                     Color: 
@@ -144,7 +144,7 @@ Builder.load_string("""
 #                    text: 'OK'
                     disabled: False
                     size_hint_y: 0.25
-                    #size: [50,50]
+                    #size: app.get_scaled_tuple([50.0, 50.0])
                     background_color: hex('#FFFFFF00')
                     on_release:
                         self.background_color = hex('#FFFFFF00')
@@ -152,7 +152,7 @@ Builder.load_string("""
                         self.background_color = hex('#FFFFFFFF')
                         root.on_ok()
                     BoxLayout:
-                        padding: 20
+                        padding: app.get_scaled_width(20.0)
                         size: self.parent.size
                         pos: self.parent.pos
                         Image:
@@ -168,7 +168,7 @@ Builder.load_string("""
 #                    text: 'Cancel'
                     disabled: False
                     size_hint_y:0.25
-                    #size: [50,50]
+                    #size: app.get_scaled_tuple([50.0, 50.0])
                     background_color: hex('#FFFFFF00')
                     on_release:
 #                        root.manager.current = 'lobby'
@@ -177,7 +177,7 @@ Builder.load_string("""
                         root.sm.current = 'lobby'
                         self.background_color = hex('#FFFFFFFF')
                     BoxLayout:
-                        padding: 20
+                        padding: app.get_scaled_width(20.0)
                         size: self.parent.size
                         pos: self.parent.pos
                         Image:
@@ -201,7 +201,7 @@ Builder.load_string("""
                         root.sm.current = 'template'
                         self.background_color = hex('#FFFFFFFF')
                     BoxLayout:
-                        padding: 10
+                        padding: app.get_scaled_width(10.0)
                         size: self.parent.size
                         pos: self.parent.pos
                         Image:
@@ -224,7 +224,7 @@ Builder.load_string("""
                         root.sm.current = 'template'
                         self.background_color = hex('#FFFFFFFF')
                     BoxLayout:
-                        padding: 10
+                        padding: app.get_scaled_width(10.0)
                         size: self.parent.size
                         pos: self.parent.pos
                         Image:

--- a/src/asmcnc/skavaUI/widget_xy_move.py
+++ b/src/asmcnc/skavaUI/widget_xy_move.py
@@ -28,8 +28,8 @@ Builder.load_string(
         size: self.parent.size
         pos: self.parent.pos      
         orientation: 'vertical'
-        padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
-        spacing:0.0208333333333*app.height
+        padding: app.get_scaled_tuple([10.0, 10.0])
+        spacing: app.get_scaled_width(10.0)
         
         GridLayout:
             cols: 3
@@ -41,11 +41,11 @@ Builder.load_string(
 
             # go x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -65,7 +65,7 @@ Builder.load_string(
 
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -87,11 +87,11 @@ Builder.load_string(
 
             # go y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -109,7 +109,7 @@ Builder.load_string(
                             allow_stretch: True  
                             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -129,7 +129,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True                                    
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -148,7 +148,7 @@ Builder.load_string(
                         size: self.parent.width, self.parent.height
                         allow_stretch: True  
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release: 
@@ -170,11 +170,11 @@ Builder.load_string(
 
             # set x datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos                 
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -192,7 +192,7 @@ Builder.load_string(
                             allow_stretch: True               
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 always_release: True
                 on_release:
@@ -214,11 +214,11 @@ Builder.load_string(
 
             # set y datum
             BoxLayout:
-                padding:[dp(0.0125)*app.width, dp(0.0208333333333)*app.height]
+                padding: app.get_scaled_tuple([10.0, 10.0])
                 size: self.parent.size
                 pos: self.parent.pos
                 Button:
-                    font_size: str(0.01875 * app.width) + 'sp'
+                    font_size: app.get_scaled_sp('15.0sp')
                     background_color: hex('#F4433600')
                     on_release: 
                         self.background_color = hex('#F4433600')
@@ -238,10 +238,10 @@ Builder.load_string(
                 
         BoxLayout:
             orientation: 'horizontal'
-            spacing:0.0125*app.width
+            spacing: app.get_scaled_width(10.0)
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -249,7 +249,7 @@ Builder.load_string(
                     root.set_standby_to_pos()
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:[0, dp(0.0416666666667)*app.height, dp(0.05)*app.width, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([0.0, 20.0, 40.0, 20.0])
                     size: self.parent.size
                     pos: self.parent.pos      
                     Image:
@@ -260,7 +260,7 @@ Builder.load_string(
                         allow_stretch: True            
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 background_color: hex('#F4433600')
                 on_release: 
                     self.background_color = hex('#F4433600')
@@ -268,7 +268,7 @@ Builder.load_string(
                     root.set_workzone_to_pos_xy()
                     self.background_color = hex('#F44336FF')
                 BoxLayout:
-                    padding:[dp(0.05)*app.width, dp(0.0416666666667)*app.height, 0, dp(0.0416666666667)*app.height]
+                    padding: app.get_scaled_tuple([40.0, 20.0, 0.0, 20.0])
                     size: self.parent.size
                     pos: self.parent.pos      
                     Image:

--- a/src/asmcnc/skavaUI/widget_xy_move_recovery.py
+++ b/src/asmcnc/skavaUI/widget_xy_move_recovery.py
@@ -12,8 +12,8 @@ Builder.load_string("""
         size: self.parent.size
         pos: self.parent.pos
         orientation: 'vertical'
-        padding: 10
-        spacing: 10
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
 
         GridLayout:
             cols: 3
@@ -24,7 +24,7 @@ Builder.load_string("""
 
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 
@@ -49,7 +49,7 @@ Builder.load_string("""
                         allow_stretch: True
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 
@@ -112,7 +112,7 @@ Builder.load_string("""
                         allow_stretch: True
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 
@@ -137,7 +137,7 @@ Builder.load_string("""
                         allow_stretch: True
 
             BoxLayout:
-                padding: 10
+                padding: app.get_scaled_width(10.0)
                 size: self.parent.size
                 pos: self.parent.pos
 """)

--- a/src/asmcnc/skavaUI/widget_z_move.py
+++ b/src/asmcnc/skavaUI/widget_z_move.py
@@ -25,12 +25,12 @@ Builder.load_string(
 
         size: self.parent.size
         pos: self.parent.pos      
-        padding:[dp(0.025)*app.width, dp(0.0416666666667)*app.height]
-        spacing:0.0125*app.width
+        padding: app.get_scaled_tuple([20.0, 20.0])
+        spacing: app.get_scaled_width(10.0)
         orientation: 'horizontal'
         
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             BoxLayout:
@@ -38,7 +38,7 @@ Builder.load_string(
                 id: virtual_z_container
                 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -61,11 +61,11 @@ Builder.load_string(
     
     
         BoxLayout:
-            spacing:0.0208333333333*app.height
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
             
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release:
@@ -86,7 +86,7 @@ Builder.load_string(
                         allow_stretch: True   
 
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -107,12 +107,12 @@ Builder.load_string(
                         allow_stretch: True   
                         
             BoxLayout:
-                padding: 0, dp(10)
+                padding: app.get_scaled_tuple([0.0, 10.0])
                 size_hint_y: 1              
                 id: probe_button_container
                         
             Button:
-                font_size: str(0.01875 * app.width) + 'sp'
+                font_size: app.get_scaled_sp('15.0sp')
                 size_hint_y: 1
                 background_color: hex('#F4433600')
                 on_release: 
@@ -137,13 +137,13 @@ Builder.load_string(
             x: 0.8275*app.width
             y: 0.875*app.height
             size_hint: None, None            
-            height: dp(30.0/480.0)*app.height
-            width: 0.0375*app.width
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             text: 'Z'
             markup: True
             bold: True
             color: 0,0,0,0.2
-            font_size: 0.025*app.width     
+            font_size: app.get_scaled_width(20.0)
         
 """
 )

--- a/src/asmcnc/skavaUI/widget_z_move_nudge.py
+++ b/src/asmcnc/skavaUI/widget_z_move_nudge.py
@@ -14,16 +14,16 @@ Builder.load_string("""
 
         size: self.parent.size
         pos: self.parent.pos
-        padding: dp(10)
-        spacing: dp(10)
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
         orientation: 'horizontal'
 
         BoxLayout:
             id: virtual_z_container
-            padding: dp(10), dp(0)
+            padding: app.get_scaled_tuple([10.0, 0.0])
 
         BoxLayout:
-            spacing: dp(10)
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
 
             Button:
@@ -72,13 +72,13 @@ Builder.load_string("""
             x: up_button.pos[0] + up_button.size[0] * 0.75
             y: up_button.pos[1] + up_button.size[1] * 0.75
             size_hint: None, None
-            height: dp(30)
-            width: dp(30)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             text: 'Z'
             markup: True
             bold: True
             color: hex('#333333ff')
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
 """)
     

--- a/src/asmcnc/skavaUI/widget_z_move_recovery.py
+++ b/src/asmcnc/skavaUI/widget_z_move_recovery.py
@@ -14,12 +14,12 @@ Builder.load_string("""
 
         size: self.parent.size
         pos: self.parent.pos
-        padding: 10
-        spacing: 10
+        padding: app.get_scaled_width(10.0)
+        spacing: app.get_scaled_width(10.0)
         orientation: 'horizontal'
 
         BoxLayout:
-            spacing: 10
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
 
             ToggleButton:
@@ -56,7 +56,7 @@ Builder.load_string("""
                         allow_stretch: True
 
         BoxLayout:
-            spacing: 10
+            spacing: app.get_scaled_width(10.0)
             orientation: "vertical"
 
             Button:
@@ -106,13 +106,13 @@ Builder.load_string("""
             x: up_button.pos[0] + up_button.size[0] * 0.75
             y: up_button.pos[1] + up_button.size[1] * 0.75
             size_hint: None, None
-            height: dp(30)
-            width: dp(30)
+            height: app.get_scaled_height(30.0)
+            width: app.get_scaled_width(30.0)
             text: 'Z'
             markup: True
             bold: True
             color: hex('#333333ff')
-            font_size: dp(20)
+            font_size: app.get_scaled_width(20.0)
 
 """)
     

--- a/src/asmcnc/tests/calibration_buttons_test.py
+++ b/src/asmcnc/tests/calibration_buttons_test.py
@@ -39,7 +39,7 @@ Builder.load_string("""
                     
         Label:
             id: warning_body_label
-            font_size: '60sp'
+            font_size: app.get_scaled_sp('60sp')
             halign: 'center'
             valign: 'bottom'
             size_hint_y: 1

--- a/src/asmcnc/tests/screen_unicode_test.py
+++ b/src/asmcnc/tests/screen_unicode_test.py
@@ -23,7 +23,7 @@ Builder.load_string("""
              
     BoxLayout:
         orientation: 'horizontal'
-        padding: 90,50
+        padding: app.get_scaled_tuple([90.0, 50.0])
         spacing: 0
         size_hint_x: 1
 
@@ -33,7 +33,7 @@ Builder.load_string("""
 
             Label:
                 text_size: self.size
-                font_size: '40sp'
+                font_size: app.get_scaled_sp('40sp')
                 halign: 'center'
                 valign: 'middle'
                 text: root.string_test

--- a/tests/examples/color_provider/color_provider_examples.py
+++ b/tests/examples/color_provider/color_provider_examples.py
@@ -8,7 +8,7 @@ BoxLayout:
     Label:
         text: "Hello, World!"
         color: color_provider.get_rgba("green")
-        font_size: 20
+        font_size: app.get_scaled_width(20.0)
 """
 
 

--- a/tests/manual_tests/experiments/experiment_custom_keyboard.py
+++ b/tests/manual_tests/experiments/experiment_custom_keyboard.py
@@ -37,7 +37,7 @@ Builder.load_string("""
     text_size: self.size
     valign: "top"
     halign: "center"
-    padding: [0,20]
+    padding: app.get_scaled_tuple([0.0, 20.0])
 
 
 <BasicScreen>:


### PR DESCRIPTION
# Clean up scaling format

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/jira/software/projects/YTSS/boards/1?assignee=5f8db15e6bc6340068c0bfc3&selectedIssue=YTSS-2622)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
I wrote a script to reformat the scaling throughout easycut so that it is more consistent, and uses the dp() unit so high dpi displays can run it.

## Notes

## Dependencies for merge

## Testing
I tested on my MacBook - there are a few areas which aren't perfect - but I think this is because they aren't in the builder strings, and my script only targeted them.

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed

## Screenshots (if applicable)