### PR TITLE
stop machine when quitting apps

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
@@ -378,6 +378,7 @@ class DrywallCutterScreen(Screen):
         popup_info.PopupStop(self.m, self.sm, self.l)
 
     def quit_to_lobby(self):
+        self.m.stop_machine_movement()
         self.set_return_screens()
         self.jd.reset_values()
         self.sm.current = 'lobby'

--- a/src/asmcnc/apps/maintenance_app/screen_maintenance.py
+++ b/src/asmcnc/apps/maintenance_app/screen_maintenance.py
@@ -578,6 +578,7 @@ class MaintenanceScreenClass(Screen):
         ]
 
     def quit_to_lobby(self):
+        self.m.stop_machine_movement()
         self.on_tab_switch()
         self.sm.current = "lobby"
 

--- a/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_exit.py
+++ b/src/asmcnc/apps/shapeCutter_app/screens/screen_shapeCutter_exit.py
@@ -72,4 +72,5 @@ class ShapeCutterExitScreenClass(Screen):
         self.poll_for_success = Clock.schedule_once(self.exit_screen, 1)
 
     def exit_screen(self, dt):
+        self.m.stop_machine_movement()
         self.shapecutter_sm.return_to_EC()

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -3926,7 +3926,7 @@ class RouterMachine(EventDispatcher):
             Clock.schedule_once(lambda dt: self.soft_stop(), timer)
             timer += 0.5
             Clock.schedule_once(lambda dt: self.stop_from_soft_stop_cancel(), timer)
-            timer += 0.5
+            timer += 2
         if spindle_on:
             Logger.warning('Stopping spindle and moving up for collet access!')
             Clock.schedule_once(lambda dt: self.turn_off_spindle(), timer)

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -3926,7 +3926,7 @@ class RouterMachine(EventDispatcher):
             Clock.schedule_once(lambda dt: self.soft_stop(), timer)
             timer += 0.5
             Clock.schedule_once(lambda dt: self.stop_from_soft_stop_cancel(), timer)
-            timer += 2
+            timer += 1
         if spindle_on:
             Logger.warning('Stopping spindle and moving up for collet access!')
             Clock.schedule_once(lambda dt: self.turn_off_spindle(), timer)

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -3908,3 +3908,23 @@ class RouterMachine(EventDispatcher):
     def clear_measured_running_data(self):
         self.s.measure_running_data = False
         self.s.running_data = []
+
+    def stop_machine_movement(self):
+        # Don't stop machine movement in final test. Dragos wants this as a feature!
+        if self.s.FINAL_TEST:
+            Logger.warning('Stopping machine movement is disabled in FINAL_TEST!')
+            return
+        spindle_on = self.s.spindle_on
+        if self.state() != 'Idle':
+            Logger.warning('Stopping machine movement!')
+            self.soft_stop()
+            self.stop_from_soft_stop_cancel()
+            self.turn_off_vacuum()
+        if spindle_on:
+            Logger.warning('Stopping spindle and moving up for collet access!')
+            self.turn_off_spindle()
+            self.raise_z_axis_for_collet_access()
+
+
+
+

--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -3915,15 +3915,23 @@ class RouterMachine(EventDispatcher):
             Logger.warning('Stopping machine movement is disabled in FINAL_TEST!')
             return
         spindle_on = self.s.spindle_on
+        # use timer to call machine functions with 0.5s delay in between
+        timer = 0.0
+
+        if self.s.vacuum_on:
+            Clock.schedule_once(lambda dt: self.turn_off_vacuum(), timer)
+            timer += 0.5
         if self.state() != 'Idle':
             Logger.warning('Stopping machine movement!')
-            self.soft_stop()
-            self.stop_from_soft_stop_cancel()
-            self.turn_off_vacuum()
+            Clock.schedule_once(lambda dt: self.soft_stop(), timer)
+            timer += 0.5
+            Clock.schedule_once(lambda dt: self.stop_from_soft_stop_cancel(), timer)
+            timer += 0.5
         if spindle_on:
             Logger.warning('Stopping spindle and moving up for collet access!')
-            self.turn_off_spindle()
-            self.raise_z_axis_for_collet_access()
+            Clock.schedule_once(lambda dt: self.turn_off_spindle(), timer)
+            timer += 0.5
+            Clock.schedule_once(lambda dt: self.raise_z_axis_for_collet_access(), timer)
 
 
 

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -599,7 +599,6 @@ class LobbyScreen(Screen):
             self.upgrade_app_hidden = True
 
     def on_enter(self):
-        self.m.stop_machine_movement()
         if not sys.platform == "win32":
             self.m.set_led_colour('GREEN')
 

--- a/src/asmcnc/skavaUI/screen_lobby.py
+++ b/src/asmcnc/skavaUI/screen_lobby.py
@@ -599,6 +599,7 @@ class LobbyScreen(Screen):
             self.upgrade_app_hidden = True
 
     def on_enter(self):
+        self.m.stop_machine_movement()
         if not sys.platform == "win32":
             self.m.set_led_colour('GREEN')
 

--- a/src/asmcnc/skavaUI/widget_quick_commands.py
+++ b/src/asmcnc/skavaUI/widget_quick_commands.py
@@ -138,6 +138,7 @@ class QuickCommands(Widget):
         self.l=kwargs['localization']
       
     def quit_to_lobby(self):
+        self.m.stop_machine_movement()
         self.sm.current = 'lobby'
             
     def home(self):


### PR DESCRIPTION
# stop machine when quitting apps

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-1581)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [] I have updated documentation (if applicable)
- [x] I have run the unit tests suite and they pass
- [x] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description
When entering the lobby (aka leaving a cutting app), all machine movement is stopped. If the spindle was running it is lifted into safe position.

## Notes



## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [x] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [x] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [x] Completed

## Screenshots (if applicable)