### PR TITLE
Disable geberit datum offset

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/engine.py
+++ b/src/asmcnc/apps/drywall_cutter_app/engine.py
@@ -710,7 +710,7 @@ class GCodeEngine():
                 gcode_lines = self.replace_cut_depth_and_z_safe_distance(gcode_lines, gcode_cut_depth, gcode_z_safe_distance, "[cut depth] ", z_safe_distance)
 
                 # Apply datum offset
-                gcode_lines = self.apply_datum_offset(gcode_lines, self.config.active_config.datum_position.x, self.config.active_config.datum_position.y)
+                gcode_lines = self.apply_datum_offset(gcode_lines, 0, 0)
 
                 # Apply pass depths
                 pass_depths = self.calculate_pass_depths(total_cut_depth, self.config.active_config.cutting_depths.depth_per_pass)


### PR DESCRIPTION
# Geberit shape datuming bugfix

- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [ ] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

Disabled geberit shape datum offsetting. This behaviour was a hangover from an initially proposed approach for dwt logic.

## Notes

## Dependencies for merge

None

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [x] Completed

## Screenshots (if applicable)