### PR TITLE
Allow dwt files to be loaded on dwt machines

### DIFF
--- a/src/asmcnc/skavaUI/screen_usb_filechooser.py
+++ b/src/asmcnc/skavaUI/screen_usb_filechooser.py
@@ -20,6 +20,7 @@ from kivy.properties import (
     StringProperty,
 )
 from kivy.uix.screenmanager import Screen
+from asmcnc.comms.model_manager import ModelManagerSingleton
 
 Builder.load_string(
     """
@@ -91,7 +92,7 @@ Builder.load_string(
                 padding:[0, dp(0.0208333333333)*app.height]
                 id: filechooser_usb
                 show_hidden: False
-                filters: ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
+                filters: ['*.dwt'] if root.model_manager.is_machine_drywall() else ['*.nc','*.NC','*.gcode','*.GCODE','*.GCode','*.Gcode','*.gCode']
                 on_selection: root.refresh_filechooser()
                 FileChooserIconLayout
                     id: icon_layout_fc
@@ -266,6 +267,7 @@ class USBFileChooser(Screen):
     sort_by_date = ObjectProperty(date_order_sort)
     sort_by_date_reverse = ObjectProperty(date_order_sort_reverse)
     is_filechooser_scrolling = False
+    model_manager = ModelManagerSingleton()
 
     def __init__(self, **kwargs):
         super(USBFileChooser, self).__init__(**kwargs)

--- a/src/jobCache/.gitignore
+++ b/src/jobCache/.gitignore
@@ -2,3 +2,4 @@
 *.gcode
 *.GCode
 *.NC
+*.dwt


### PR DESCRIPTION
# DWT file loading

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-3007)
- [x] Ready for review

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass
- [ ] I have updated the [change log](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit)


## Description

Re-enabled USB filechooser on dwt machines. Both local and USB filechoosers now only display .dwt files on dwt machines.

## Notes

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [x] Not applicable
- [ ] Completed

## Screenshots (if applicable)