### PR TITLE
Remove MDF upcut profiles

### DIFF
--- a/src/asmcnc/job/yetipilot/config/profiles.json
+++ b/src/asmcnc/job/yetipilot/config/profiles.json
@@ -895,38 +895,6 @@
           "Value": 22500.0
         }
       ]
-    },
-    {
-      "Material Type": "MDF",
-      "Cutter Diameter": "6 mm",
-      "Cutter Type": "2 flute upcut spiral",
-      "Step Down": "3 mm",
-      "Parameters": [
-        {
-          "Name": "spindle_tool_load_watts",
-          "Value": 360
-        },
-        {
-          "Name": "target_spindle_speed",
-          "Value": 22500.0
-        }
-      ]
-    },
-    {
-      "Material Type": "MDF",
-      "Cutter Diameter": "8 mm",
-      "Cutter Type": "2 flute upcut spiral",
-      "Step Down": "3 mm",
-      "Parameters": [
-        {
-          "Name": "spindle_tool_load_watts",
-          "Value": 370
-        },
-        {
-          "Name": "target_spindle_speed",
-          "Value": 22500.0
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
# Remove MDF upcut profiles 

[Jira Ticket](<link_to_jira_ticket>)

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

YetiPilot profiles for MDF with upcut cutters have been removed, as the tolerances were not as good as with alternative cutters. 

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
~- [ ] I have tested graphical changes on all languages~
~- [ ] I have updated the jira ticket~
- [x] I have added the relevant labels to this PR
~- [ ] I have updated documentation (if applicable)~
~- [ ] I have run the unit tests suite and they pass~

## Description

## Screenshots

## Dependencies for merge
~- [ ] [#<pull_request_number>]~

## Testing

Tested on Martha, checked that selecting MDF no longer brought up "upcut" option. 

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [x] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [x] Console 7"
- [ ] Console 10"

### Unit Tests
- [x] Not applicable
- [ ] Completed