### PR TITLE
Correct typo in profiles.json

### DIFF
--- a/src/asmcnc/job/yetipilot/config/profiles.json
+++ b/src/asmcnc/job/yetipilot/config/profiles.json
@@ -738,7 +738,7 @@
     },
     {
       "Material Type": "Birch Plywood",
-      "Cutter Diameter": "3 mm",
+      "Cutter Diameter": "6 mm",
       "Cutter Type": "2 flute compression",
       "Step Down": "6 mm",
       "Parameters": [


### PR DESCRIPTION
# Reinstated Birch plywood 6 mm 2 flute compression YP profile 

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**
Reinstated Birch plywood 6 mm 2 flute compression YP profile 

## Checklist
- [x] I have completed a self review
- [ ] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [ ] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

Typo caused this profile to go missing in v2.9.2 update

## Screenshots

## Dependencies for merge
None

## Testing

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed