### PR TITLE
Set internal spindle on variable off when cancelling stream

### DIFF
--- a/src/asmcnc/comms/router_machine.py
+++ b/src/asmcnc/comms/router_machine.py
@@ -1460,6 +1460,7 @@ class RouterMachine(EventDispatcher):
         Logger.info('Streaming stopped.')
         if self.s.is_job_streaming: self.s.cancel_stream()
         if self.s.is_sequential_streaming: self.s.cancel_sequential_stream() # Cancel sequential stream to stop it continuing to send stuff after reset
+        self.s.spindle_on = False
 
     def _grbl_resume(self):
         Logger.info('grbl realtime cmd sent: ~ resume')


### PR DESCRIPTION
# Job cancel spindle button flash bug

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-2976)

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

Set internal spindle on variable off when cancelling stream, to stop button flashing when spindle is disabled without using the button.

## Checklist
- [x] I have completed a self review
- [ ] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

## Screenshots

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed