### PR TITLE
Show line toolpath in dwt/shapes

### DIFF
--- a/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
+++ b/src/asmcnc/apps/drywall_cutter_app/screen_drywall_cutter.py
@@ -356,7 +356,7 @@ class DrywallCutterScreen(Screen):
                 # default to 'on'
                 self.select_toolpath('on')
             else:
-                self.drywall_shape_display_widget.shape_toolpath_image.opacity = 0
+                self.drywall_shape_display_widget.select_toolpath(self.dwt_config.active_config.shape_type, 'on', self.rotation)
         else:
             self.select_toolpath(self.dwt_config.active_config.toolpath_offset)
             self.toolpath_selection.disabled = False

--- a/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
+++ b/src/asmcnc/apps/drywall_cutter_app/widget_drywall_shape_display.py
@@ -540,11 +540,13 @@ class DrywallShapeDisplay(Widget):
         text_input.parent.opacity = 0
 
     def select_toolpath(self, shape, toolpath, rotation):
-        if shape in ['line', 'geberit']:
+        if shape == 'geberit':
             self.shape_toolpath_image.opacity = 0
         else:
             if shape == 'rectangle':
                 self.shape_toolpath_image.source = self.image_filepath + shape + "_" + rotation + "_" + toolpath + "_toolpath.png"
+            elif shape == 'line':
+                self.shape_toolpath_image.source = self.image_filepath + shape + "_" + rotation + "_toolpath.png"
             else:
                 self.shape_toolpath_image.source = self.image_filepath + shape + "_" + toolpath + "_toolpath.png"
             self.shape_toolpath_image.opacity = 1


### PR DESCRIPTION
# Show line toolpath in dwt/shapes

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-3056)

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

Made toolpath for line shape visible

## Checklist
- [ ] I have completed a self review
- [ ] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [ ] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

## Screenshots

![image](https://github.com/YetiTool/easycut-smartbench/assets/75572055/33873f4e-34e2-4d86-a360-ca8c5cda4a84)

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed