### PR TITLE
Don't set spindle on variable when in check state

### DIFF
--- a/src/asmcnc/comms/serial_connection.py
+++ b/src/asmcnc/comms/serial_connection.py
@@ -1889,8 +1889,9 @@ class SerialConnection(EventDispatcher):
 
         # Catch and correct all instances of the spindle speed command "M3 S{RPM}"
         if "M3" in serialCommand.upper():
-            # Set spindle_on flag
-            self.spindle_on = True
+            if self.m_state != "Check":
+                # Set spindle_on flag
+                self.spindle_on = True
 
             if "S" in serialCommand.upper():
                 # Correct the spindle speed command


### PR DESCRIPTION
# Don't set spindle on variable when in check state

[Jira Ticket](https://yetitoolsmartsoftware.atlassian.net/browse/YTSS-3058)

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

Stopped setting spindle on variable when in check state

## Checklist
- [x] I have completed a self review
- [x] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [x] I have updated the jira ticket
- [x] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

## Screenshots

## Dependencies for merge
- [ ] [#<pull_request_number>]

## Testing

### Visual Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [x] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed