### PR TITLE
Purge configs on downgrade

### DIFF
--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -348,6 +348,15 @@ class BetaTestingScreen(Screen):
                 branch_name_formatted = str(self.user_branch.text).translate(None, " ")
                 checkout_call = ("cd /home/pi/easycut-smartbench/ && git fetch origin && git checkout "
                                  + branch_name_formatted)
+
+                if re.match("v\d\.\d\.\d", branch_name_formatted):
+                    current_version_split = [int(i.split("-")[0]) for i in self.set.sw_version.split("v")[1].split(".")]
+                    checkout_version_split = [int(i.split("-")[0]) for i in branch_name_formatted.split("v")[1].split(".")]
+
+                    if current_version_split > checkout_version_split:
+                        os.system("rm -r /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config")
+                        Logger.info("Purged shapes configurations before downgrade")
+
                 checkout_exit_code = os.system(checkout_call)
                 Logger.debug('Checkout call: {} | Returns: {}'.format(checkout_call,checkout_exit_code))
                 # check if branch name is a tag like v2.8.1:
@@ -355,13 +364,6 @@ class BetaTestingScreen(Screen):
                 if not re.match("v\d\.\d\.\d", branch_name_formatted):
                     pull_exit_code = os.system("git pull")
                     Logger.debug('"git pull" returned: {}'.format(pull_exit_code))
-                else:
-                    current_version_split = [int(i.split("-")[0]) for i in self.set.sw_version.split("v")[1].split(".")]
-                    checkout_version_split = [int(i.split("-")[0]) for i in branch_name_formatted.split("v")[1].split(".")]
-
-                    if current_version_split > checkout_version_split:
-                        os.system("rm -r /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config")
-                        Logger.info("Purged shapes configurations before downgrade")
 
                 if checkout_exit_code == 0 and pull_exit_code == 0:
                     self.set.ansible_service_run_without_reboot()

--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -355,6 +355,14 @@ class BetaTestingScreen(Screen):
                 if not re.match("v\d\.\d\.\d", branch_name_formatted):
                     pull_exit_code = os.system("git pull")
                     Logger.debug('"git pull" returned: {}'.format(pull_exit_code))
+                else:
+                    current_version_split = [int(i) for i in self.set.sw_version.split("v")[1].split(".")]
+                    checkout_version_split = [int(i) for i in branch_name_formatted.split("v")[1].split(".")]
+
+                    if current_version_split > checkout_version_split:
+                        os.system("rm -r /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config")
+                        Logger.info("Purged shapes configurations before downgrade")
+
                 if checkout_exit_code == 0 and pull_exit_code == 0:
                     self.set.ansible_service_run_without_reboot()
                     wait_popup.popup.dismiss()

--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -356,8 +356,8 @@ class BetaTestingScreen(Screen):
                     pull_exit_code = os.system("git pull")
                     Logger.debug('"git pull" returned: {}'.format(pull_exit_code))
                 else:
-                    current_version_split = [int(i) for i in self.set.sw_version.split("v")[1].split(".")]
-                    checkout_version_split = [int(i) for i in branch_name_formatted.split("v")[1].split(".")]
+                    current_version_split = [int(i.split("-")[0]) for i in self.set.sw_version.split("v")[1].split(".")]
+                    checkout_version_split = [int(i.split("-")[0]) for i in branch_name_formatted.split("v")[1].split(".")]
 
                     if current_version_split > checkout_version_split:
                         os.system("rm -r /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config")

--- a/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
+++ b/src/asmcnc/apps/systemTools_app/screens/screen_beta_testing.py
@@ -354,7 +354,8 @@ class BetaTestingScreen(Screen):
                     checkout_version_split = [int(i.split("-")[0]) for i in branch_name_formatted.split("v")[1].split(".")]
 
                     if current_version_split > checkout_version_split:
-                        os.system("rm -r /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config")
+                        os.system("rm /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config/configurations/*")
+                        os.system("rm /home/pi/easycut-smartbench/src/asmcnc/apps/drywall_cutter_app/config/temp/*")
                         Logger.info("Purged shapes configurations before downgrade")
 
                 checkout_exit_code = os.system(checkout_call)


### PR DESCRIPTION
On downgrade, the config files will be deleted to not cause a crash on boot. Tested on a rig downgrading to 2.9.0 and checking startup still works, then changing to feature/shapes_lite and checking shapes still works.