### PR TITLE
Watch job streaming variable instead of state for dust shoe alarm

### DIFF
--- a/src/asmcnc/skavaUI/screen_dust_shoe_alarm.py
+++ b/src/asmcnc/skavaUI/screen_dust_shoe_alarm.py
@@ -224,7 +224,7 @@ class DustShoeAlarmScreen(Screen):
             # Check dust shoe detection enabled in maintenance
             if self.usm.get_value('dust_shoe_detection'):
                 # Only check during job or when spindle is enabled
-                if self.m.s.m_state == "Run" or self.m.s.spindle_on:
+                if self.m.s.is_job_streaming or self.m.s.spindle_on:
                     self.m.set_pause(True)
                     if self.sm.current != 'dust_shoe_alarm':
                         Logger.info("Dust shoe unplugged")


### PR DESCRIPTION
# Job running variable

## Changelog ([master doc](https://docs.google.com/document/d/1t3s6lQuUcug1Fj8E_i2gBJNvXN0-funwBArG2hsia6k/edit))
**On merging your PR, please copy the changelog to the master doc.**

Watch job streaming variable instead of m_state for dust shoe alarm

## Checklist
- [ ] I have completed a self review
- [ ] I have set the recent milestone
- [ ] I have tested graphical changes on all languages
- [ ] I have updated the jira ticket
- [ ] I have added the relevant labels to this PR
- [ ] I have updated documentation (if applicable)
- [ ] I have run the unit tests suite and they pass

## Description

## Screenshots

## Dependencies for merge

## Testing

### Visual Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Function Test
- [ ] Not applicable
- [ ] Own computer
- [ ] Console 7"
- [ ] Console 10"

### Unit Tests
- [ ] Not applicable
- [ ] Completed